### PR TITLE
README: drop csv-import skill blurb

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,6 @@ Need something custom? Just ask:
 
 > _"Write me a skill that reads my call transcripts, updates deal stages, and posts a summary to Slack."_
 
-The [`csv-import`](.claude/skills/csv-import.md) skill reads your headers, maps them to `.acrm`'s schema (people, companies, deals), dedupes on email + domain, and lands the import on a branch you review before merging.
-
 ## Roadmap
 - [x] `.acrm` file format
 - [ ] CLI


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Remove csv-import skill reference from README
Deletes the paragraph describing the csv-import skill, including its link, from [README.md](https://github.com/cluster-software/agent-crm/pull/4/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0dcee37.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README by removing outdated content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->