### PR TITLE
readme feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@
 
 </div>
 
-Claude is now running your GTM, and your lead lists live in CSVs. Not because you love CSVs — because every alternative gets in Claude's way. Spreadsheets fall apart the moment you try to track state across conversations: thirty deals in, you've lost the thread of who said what, what's open, and what's next. Existing CRMs were built for humans clicking through UIs, not agents writing SQL.
+Claude is running your GTM and your leads live in CSVs. Spreadsheets fall apart around 30 deals in: you lose track of who said what, what's open, and what's next. CRMs solve that, but they were built for humans clicking through UIs, not agents writing SQL.
 
-The obvious alternative is plugging Claude into your existing CRM via MCP. That works for a demo. In practice the schema is huge, every action is a network round-trip, and your context window gets torched before Claude has done anything useful.
+Plug Claude into your CRM via MCP and the schema torches your context, every action is a network round-trip, and you blow through your usage limits. Salesforce and HubSpot are shipping their own CLIs, but they end at the deal record — the scrapes, enrichment runs, and half-cleaned lists that fed it live somewhere else. You can't replay how a deal moved through stages, see what your last scrape pulled in and what it didn't clean up, or pick up where last weekend's list-building session left off.
 
-Salesforce and HubSpot are now shipping their own CLIs, but those won't fix the deeper problem: your data still lives on someone else's server. You can't branch it, diff it, fork a copy for an experiment, or hand a snapshot to a teammate. Agents work best on artifacts — files you can version, share, and reason about offline. That's what Agent CRM is.
-
-Agent CRM gives your agent a structured backend it can query, edit, diff and validate, fast. The source of truth is a portable `.acrm` file. UIs, CLIs, scripts, and agents all operate on it and you can send it around like any other file.
+Agents work best on files. Agent CRM is a portable `.acrm` file your agent can query, edit, diff, and version — pipeline, scrapes, and enrichments, all in one place.
 
 ```txt
                     ┌──────────────┐

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A `.acrm` file is a **SQLite database** with a change-history layer ([Lix](https
 
 - **No proprietary format.** Open it with any SQLite client (`sqlite3 pipeline.acrm`) and your data is right there in standard tables.
 - **Every write is a versioned checkpoint.** Like git for your CRM — branch to run an experiment, diff to see what changed, revert if Claude mangles a row.
-- **It's just a file.** Copy it, email it, commit it, sync it through Dropbox. No server, no account, no migration tool needed if you ever walk away.
+- **It's just a file.** Copy it, email it, commit it, sync it through Google Drive. No server, no account, no migration tool needed if you ever walk away.
 
 If you can read SQLite, you can read your CRM. That's the whole guarantee.
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 
 </div>
 
-Claude is now running your GTM. Your lead lists live in CSVs because you want to move fast with claude code, but existing CRMs were built for humans, not agents. Their MCPs slow you down, bloat your context, and kill your usage limits.
+Claude is now running your GTM, and your lead lists live in CSVs. Not because you love CSVs — because every alternative gets in Claude's way. Spreadsheets fall apart the moment you try to track state across conversations: thirty deals in, you've lost the thread of who said what, what's open, and what's next. Existing CRMs were built for humans clicking through UIs, not agents writing SQL.
 
-Agent CRM gives your agent a structured backend it can query, edit, diff and validate, fast.
+The obvious alternative is plugging Claude into your existing CRM via MCP. That works for a demo. In practice the schema is huge, every action is a network round-trip, and your context window gets torched before Claude has done anything useful.
 
-The source of truth is a portable `.acrm` file. UIs, CLIs, scripts, and agents all operate on it and you can send it around like any other file.
+Salesforce and HubSpot are now shipping their own CLIs, but those won't fix the deeper problem: your data still lives on someone else's server. You can't branch it, diff it, fork a copy for an experiment, or hand a snapshot to a teammate. Agents work best on artifacts — files you can version, share, and reason about offline. That's what Agent CRM is.
+
+Agent CRM gives your agent a structured backend it can query, edit, diff and validate, fast. The source of truth is a portable `.acrm` file. UIs, CLIs, scripts, and agents all operate on it and you can send it around like any other file.
 
 ```txt
                     ┌──────────────┐
@@ -19,6 +21,16 @@ The source of truth is a portable `.acrm` file. UIs, CLIs, scripts, and agents a
 │ AI Agents  ├─────►│  .acrm      │◄─────┤ CLI / Scripts │
 └────────────┘      └─────────────┘      └───────────────┘
 ```
+
+## What's in a `.acrm` file?
+
+A `.acrm` file is a **SQLite database** with a change-history layer ([Lix](https://lix.dev)) on top. That means:
+
+- **No proprietary format.** Open it with any SQLite client (`sqlite3 pipeline.acrm`) and your data is right there in standard tables.
+- **Every write is a versioned checkpoint.** Like git for your CRM — branch to run an experiment, diff to see what changed, revert if Claude mangles a row.
+- **It's just a file.** Copy it, email it, commit it, sync it through Dropbox. No server, no account, no migration tool needed if you ever walk away.
+
+If you can read SQLite, you can read your CRM. That's the whole guarantee.
 
 ## Quickstart
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update README to reframe Agent CRM around `.acrm` file format and portability
> Rewrites the intro in [README.md](https://github.com/cluster-software/agent-crm/pull/7/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to replace the MCP/CRM framing with a focus on the limits of spreadsheets and CRMs for agents. Adds a new 'What's in a `.acrm` file?' section explaining that `.acrm` is a SQLite database with a Lix change-history layer, covering no proprietary format, versioned checkpoints, and plain-file portability.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f02cbe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded README with broader narrative on GTM, Claude-assisted workflows, and lead list management; intro now provides more context before the Quickstart.
  * Added a “What’s in a .acrm file?” section explaining the file as a portable SQLite-backed format with change-history, versioned checkpoints, and readable/exportable data characteristics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->