### PR TITLE
ci: drop registry-url from setup-node so NPM_TOKEN auth works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
setup-node's registry-url writes a project-level .npmrc that expects NODE_AUTH_TOKEN, which overrides the ~/.npmrc that changesets/action writes from NPM_TOKEN. Result: publishes went out unauthenticated and npm returned 404 (its mask for unauthorized writes). Removing registry-url lets changesets/action own auth, matching the upstream example in the changesets docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions release workflow configuration by removing an npm registry override setting while maintaining Node.js version configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop `registry-url` from `setup-node` so `NPM_TOKEN` auth works in release CI
> Removes the `registry-url: https://registry.npmjs.org` input from the `actions/setup-node@v4` step in [release.yml](.github/workflows/release.yml). Setting an explicit registry URL causes `setup-node` to write an `.npmrc` that overrides `NPM_TOKEN`-based auth; removing it lets the action use its default registry handling so the token is picked up correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db4530b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->