### PR TITLE
import post command (linkedin/x)

### DIFF
--- a/.changeset/import-post.md
+++ b/.changeset/import-post.md
@@ -1,0 +1,35 @@
+---
+"@agent-crm/cli": minor
+---
+
+Single-profile imports, post imports, and CSV reliability fixes since 0.0.7:
+
+**Import a person from a LinkedIn or X profile URL**
+
+- `acrm import linkedin <url-or-slug>` fetches a LinkedIn profile via Apify and upserts the person (deduped by `linkedin_url`) plus their current employer as a company.
+- `acrm import x <handle-or-url>` fetches an X/Twitter profile and upserts the person (deduped by `twitter_url`, normalized to `x.com/<handle>`). When the bio contains role/company info that's missing from the person record, returns a `needs_enrichment` payload that the new `enrich-x-bio` skill consumes to fill in `job_title` and `company`.
+- Apify responses are cached under `.cache/{linkedin,x}/` with a 14-day TTL. `--refresh` bypasses, `--no-cache` skips writing.
+- Requires `APIFY_API_TOKEN` in a `.env` next to the workspace (or in shell env).
+
+**Import a LinkedIn or X post by URL**
+
+- `acrm import post <url>` auto-detects the platform and imports the post's author as a person, then stores the post itself as a first-class record. Use when a user shares a post link they want to track (e.g. "import this tweet", "save this LinkedIn post").
+- Adds a new top-level `posts` object alongside companies / people / deals, with attributes: `url` (unique, normalized), `platform` (`linkedin` | `x`), `author` (record-reference → people), `posted_at`, `content`. Inverse on people: `associated_posts` (multivalued).
+- Idempotent: re-running the same URL keeps one post record and one author, and skips re-linking. Cached Apify responses make repeat runs free.
+- Actor selection: `apimaestro/linkedin-post-detail` for LinkedIn (single-post-by-URL with author profile URL in the response), `apidojo/twitter-scraper-lite` for X (`startUrls` with single-tweet support, same vendor as the existing X profile actor).
+- New `.claude/skills/import-post.md` skill so agents pick up the command from natural phrasings and bare post URLs in chat.
+
+**`status` / `select` attributes now store `{id, title}`**
+
+- Previously passing a bare string (e.g. `"lead"` for `deal.stage`) stored `{"title":"lead"}`, dropping the id and using the lowercase id as the display title. The `encode()` function now resolves a string input against the attribute's `options` config (case-insensitive match on `id` or `title`) and stores the canonical `{id, title}` pair. This applies to both `acrm import csv` (deal stage) and the new `acrm import post` (platform).
+- Falls back to the old `{title: raw}` behavior when an attribute has no `options` config or the input doesn't match any option, so freeform statuses still work.
+
+**CSV import reliability + UI polish**
+
+- Multiple fixes to `acrm import csv` to handle real-world CSVs more reliably (header normalization, person/company dedup edge cases, batched writes, monotonic UUIDv7 generation to keep insert order stable when rows land within the same millisecond).
+- Deals icon tweak in the local UI.
+
+**Internal**
+
+- Reusable `importLinkedinProfile()` / `importXProfile()` helpers extracted from the CLI wrappers so the new post-import flow can chain into them without re-opening the workspace. Existing CLI behavior for `acrm import linkedin` / `acrm import x` is unchanged.
+- Removed unused skills: `champion-left`, `csv-import`, `new-hire-trigger`, `stale-opportunities`.

--- a/.claude/skills/import-post.md
+++ b/.claude/skills/import-post.md
@@ -1,0 +1,89 @@
+---
+name: import-post
+description: Import a LinkedIn or X post into the .acrm workspace by URL. Triggers when the user shares a LinkedIn post URL (linkedin.com/posts/..., linkedin.com/feed/update/urn:li:activity:...) or an X/Twitter status URL (x.com/<handle>/status/<id>, twitter.com/...) and wants to track the post or its author. Phrasings: "import this post", "save this LinkedIn post", "track this tweet", "add this person from their post", or just a bare post URL in chat.
+---
+
+# import-post
+
+Use when the user pastes a LinkedIn or X **post URL** into chat and wants to capture the post + its author into the `.acrm` workspace.
+
+This is the **post** flow, not the profile flow:
+
+- Post URL → use `acrm import post <url>` (this skill)
+- Profile URL (`linkedin.com/in/<slug>` or `x.com/<handle>` with no `/status/...`) → use `acrm import linkedin <url>` or `acrm import x <handle>`
+
+## Recognize a post URL
+
+| Platform  | Post URL shape                                                  |
+|-----------|------------------------------------------------------------------|
+| LinkedIn  | `https://www.linkedin.com/posts/<slug>_<activity-id>`           |
+| LinkedIn  | `https://www.linkedin.com/feed/update/urn:li:activity:<id>/`    |
+| X         | `https://x.com/<handle>/status/<id>` (query params like `?s=12` are fine) |
+| X         | `https://twitter.com/<handle>/status/<id>`                      |
+
+If the URL has `/status/` (X) or `activity:` / `/posts/` (LinkedIn), it's a post. Anything else is a profile or different surface — pick a different command.
+
+## Run
+
+```sh
+acrm import post '<url>'
+```
+
+That's it. The CLI handles everything:
+
+1. **Sniffs the platform** from the URL host.
+2. **Fetches the post via Apify** (`apimaestro/linkedin-post-detail` for LinkedIn, `apidojo/twitter-scraper-lite` for X). Cached 14 days under `.cache/{linkedin,x}-posts/`.
+3. **Extracts the author profile URL** from the post response and chains into the existing profile import flow, so the author is deduped against any existing person by `linkedin_url` or `twitter_url`.
+4. **Upserts the `posts` record** (deduped by normalized URL) with `url`, `platform`, `author` (→ people), `posted_at`, `content`.
+5. **Links the person → post** via `people.associated_posts` (skips if already linked).
+
+Re-running the same URL is idempotent — `created` will be `false` for everything.
+
+## Prereqs
+
+- Workspace must be initialized (`acrm init <name>.acrm`).
+- `APIFY_API_TOKEN` must be set in `.env` next to the workspace file (or in shell env). Without it the command fails with a clear hint.
+
+## Output
+
+JSON shape (use `--json` or it's auto-emitted when stdout isn't a TTY):
+
+```json
+{
+  "ok": true,
+  "data": {
+    "post_record_id": "...",
+    "person_record_id": "...",
+    "company_record_id": "..." | null,
+    "created": { "post": true|false, "person": true|false, "company": true|false },
+    "platform": "linkedin" | "x",
+    "post_url": "<normalized>",
+    "cache_paths": { "post": "...", "profile": "..." },
+    "cache_hits": { "post": true|false, "profile": true|false },
+    "mapped": { "post_url": "...", "author_profile_url": "...", "posted_at": "YYYY-MM-DD"|null, "content": "..." }
+  }
+}
+```
+
+## After import — what you can do
+
+- **Show the author's full record** to the user:
+  `acrm execute "SELECT attribute_slug, value_json FROM acrm_value WHERE active_until IS NULL AND object_slug = 'people' AND record_id = $1 ORDER BY attribute_slug" '["<person_record_id>"]'`
+- **List all posts you've imported from this author**:
+  `acrm execute "SELECT p.record_id, v.value_json FROM acrm_record p JOIN acrm_value v ON v.object_slug = 'posts' AND v.record_id = p.record_id AND v.attribute_slug = 'url' AND v.active_until IS NULL WHERE p.object_slug = 'posts' AND p.record_id IN (SELECT ref_record_id FROM acrm_value WHERE object_slug = 'people' AND record_id = $1 AND attribute_slug = 'associated_posts' AND active_until IS NULL)" '["<person_record_id>"]'`
+
+## Report
+
+After running, give a short one-liner:
+
+```
+Imported post by <Name> (<platform>) — person <created|matched existing>, post <created|matched existing>. Posted <YYYY-MM-DD>: "<first 80 chars of content>…"
+```
+
+If `needs_enrichment` is set on the chained X profile import (the X bio contained role/company hints but those fields are empty on the person), trigger the `enrich-x-bio` skill on the returned payload.
+
+## Hard rules
+
+- **Never** fabricate a URL. If the user pastes something that isn't a recognizable post URL, ask before running.
+- **Never** pass URLs from untrusted sources without showing the user what's about to be imported.
+- **Don't** delete or overwrite the existing post record on re-import. The CLI already handles dedup — just rerun.

--- a/src/bin/acrm.ts
+++ b/src/bin/acrm.ts
@@ -6,6 +6,7 @@ import { registerExecute } from "../commands/execute.js";
 import { registerImport, getOrCreateImportCommand } from "../commands/import.js";
 import { attachLinkedinSubcommand } from "../commands/import-linkedin.js";
 import { attachXSubcommand } from "../commands/import-x.js";
+import { attachPostSubcommand } from "../commands/import-post.js";
 import { registerUi } from "../commands/ui.js";
 import { fail } from "../output/json.js";
 import { ERR } from "../lib/errors.js";
@@ -19,7 +20,7 @@ const program = new Command();
 program
   .name("acrm")
   .description(
-    "Headless CRM for Claude Code. Stores people (keyed by email, LinkedIn URL, or Twitter/X URL), companies (keyed by domain), and deals in a portable .acrm file.",
+    "Headless CRM for Claude Code. Stores people (keyed by email, LinkedIn URL, or Twitter/X URL), companies (keyed by domain), deals, and posts (LinkedIn/X posts linked to their author) in a portable .acrm file.",
   )
   .version(pkg.version)
   .option("-w, --workspace <path>", "path to .acrm file (default: walk up from cwd)")
@@ -28,13 +29,17 @@ program
     "after",
     `
 Data model:
-  people      contacts, identified by email
+  people      contacts, identified by email / LinkedIn URL / X URL
   companies   organizations, identified by domain
   deals       sales opportunities, created on demand
+  posts       LinkedIn/X posts the user wants to track, linked to author via \`posts.author\` + \`people.associated_posts\`
 
 Typical flow:
   acrm init <name>.acrm           create a workspace
   acrm import csv ./leads.csv     load people + companies (and deals if columns present)
+  acrm import linkedin <url>      add one person from a LinkedIn profile (creates person + company)
+  acrm import x <handle>          add one person from an X/Twitter profile
+  acrm import post <url>          add a LinkedIn or X **post** by URL — upserts the author as a person and stores the post (use when a user shares a post link they want to track)
   acrm ui                         browse the workspace in a local UI
   acrm execute "SELECT ..."       run SQL against the workspace
 
@@ -57,6 +62,7 @@ registerInit(program);
 registerImport(program);
 attachLinkedinSubcommand(getOrCreateImportCommand(program));
 attachXSubcommand(getOrCreateImportCommand(program));
+attachPostSubcommand(getOrCreateImportCommand(program));
 registerExecute(program);
 registerUi(program);
 

--- a/src/commands/import-linkedin.ts
+++ b/src/commands/import-linkedin.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import type { Command } from "commander";
+import type { Lix } from "@lix-js/sdk";
 import { findWorkspace, openWorkspace } from "../workspace/open.js";
 import { fail, ok, setJsonMode } from "../output/json.js";
 import { generateUuid } from "../lib/ids.js";
@@ -16,7 +17,7 @@ import {
   loadFromCacheOrFetch,
   normalizeLinkedinInput,
 } from "../integrations/apify-linkedin.js";
-import { mapProfile } from "../integrations/linkedin-mapping.js";
+import { mapProfile, type MappedProfile } from "../integrations/linkedin-mapping.js";
 
 const SOURCE = "linkedin-import";
 
@@ -25,11 +26,20 @@ type Opts = {
   cache?: boolean; // commander negation: --no-cache → cache=false
 };
 
+export type LinkedinImportResult = {
+  person_record_id: string;
+  company_record_id: string | null;
+  created: { person: boolean; company: boolean };
+  cache_path: string | null;
+  cache_hit: boolean;
+  mapped: MappedProfile;
+};
+
 export function attachLinkedinSubcommand(parent: Command): void {
   parent
     .command("linkedin <url-or-slug>")
     .description(
-      "Fetch a LinkedIn profile via Apify and upsert person + company in the workspace",
+      "Import a person from a LinkedIn profile URL (or `/in/<slug>`). Use when the user shares a LinkedIn **profile** link (e.g. \"add this person\", \"import this LinkedIn\"). For a LinkedIn **post** URL instead, use `acrm import post`. Fetches the profile via Apify, upserts the person (deduped by linkedin_url), and creates/links their current employer as a company. Requires APIFY_API_TOKEN in .env.",
     )
     .option("--refresh", "bypass cache and re-fetch from Apify")
     .option("--no-cache", "do not write the response to cache")
@@ -44,7 +54,13 @@ export function attachLinkedinSubcommand(parent: Command): void {
           refresh: opts.refresh,
           noCache: opts.cache === false,
         });
-        ok(result);
+        const json: LinkedinImportResult = {
+          ...result,
+          cache_path: result.cache_path
+            ? path.relative(process.cwd(), result.cache_path)
+            : null,
+        };
+        ok(json);
       } catch (e) {
         if (e instanceof AcrmError) fail(e.message, e.code, e.hint);
         else fail(e instanceof Error ? e.message : String(e), ERR.UNHANDLED);
@@ -56,9 +72,7 @@ export function attachLinkedinSubcommand(parent: Command): void {
 async function runImportLinkedin(
   urlOrSlug: string,
   opts: { workspace?: string; refresh?: boolean; noCache?: boolean },
-) {
-  const { url, publicId } = normalizeLinkedinInput(urlOrSlug);
-
+): Promise<LinkedinImportResult> {
   const workspaceFile = opts.workspace
     ? path.resolve(
         opts.workspace.endsWith(".acrm")
@@ -88,142 +102,165 @@ async function runImportLinkedin(
 
   const cacheDir = path.join(workspaceDir, ".cache", "linkedin");
 
+  const lix = await openWorkspace({ workspace: workspaceFile });
+  try {
+    return await importLinkedinProfile({
+      lix,
+      urlOrSlug,
+      token,
+      cacheDir,
+      refresh: opts.refresh,
+      noCache: opts.noCache,
+    });
+  } finally {
+    await lix.close();
+  }
+}
+
+export type ImportLinkedinProfileArgs = {
+  lix: Lix;
+  urlOrSlug: string;
+  token: string;
+  cacheDir: string;
+  refresh?: boolean;
+  noCache?: boolean;
+};
+
+export async function importLinkedinProfile(
+  args: ImportLinkedinProfileArgs,
+): Promise<LinkedinImportResult> {
+  const { lix, urlOrSlug, token, cacheDir, refresh, noCache } = args;
+  const { url, publicId } = normalizeLinkedinInput(urlOrSlug);
+
   const { profile, cachePath, cacheHit } = await loadFromCacheOrFetch({
     cacheDir,
     publicId,
     url,
     token,
-    refresh: opts.refresh,
-    noCache: opts.noCache,
+    refresh,
+    noCache,
   });
 
   const mapped = mapProfile(profile);
 
-  const lix = await openWorkspace({ workspace: workspaceFile });
-  try {
-    const provenance = {
-      actor: "harvestapi~linkedin-profile-scraper",
-      public_id: publicId,
-      fetched_at: new Date().toISOString(),
-      cache_hit: cacheHit,
-    };
+  const provenance = {
+    actor: "harvestapi~linkedin-profile-scraper",
+    public_id: publicId,
+    fetched_at: new Date().toISOString(),
+    cache_hit: cacheHit,
+  };
 
-    // Company first so the person can reference it.
-    let companyId: string | null = null;
-    let companyCreated = false;
-    if (mapped.company.name) {
-      companyId = await findCompanyByName(lix, mapped.company.name);
-      if (!companyId) {
-        companyId = await generateUuid(lix);
-        await insertRecord(lix, "companies", companyId);
+  // Company first so the person can reference it.
+  let companyId: string | null = null;
+  let companyCreated = false;
+  if (mapped.company.name) {
+    companyId = await findCompanyByName(lix, mapped.company.name);
+    if (!companyId) {
+      companyId = await generateUuid(lix);
+      await insertRecord(lix, "companies", companyId);
+      await setSingleValue(lix, {
+        object_slug: "companies",
+        record_id: companyId,
+        attribute_slug: "name",
+        attribute_type: "text",
+        value: mapped.company.name,
+        source: SOURCE,
+        provenance,
+      });
+      companyCreated = true;
+    }
+    if (mapped.company.linkedin_url) {
+      const cl = normalizeLinkedinUrl(mapped.company.linkedin_url);
+      if (cl) {
         await setSingleValue(lix, {
           object_slug: "companies",
           record_id: companyId,
-          attribute_slug: "name",
-          attribute_type: "text",
-          value: mapped.company.name,
+          attribute_slug: "linkedin_url",
+          attribute_type: "url",
+          value: cl,
           source: SOURCE,
           provenance,
         });
-        companyCreated = true;
-      }
-      if (mapped.company.linkedin_url) {
-        const cl = normalizeLinkedinUrl(mapped.company.linkedin_url);
-        if (cl) {
-          await setSingleValue(lix, {
-            object_slug: "companies",
-            record_id: companyId,
-            attribute_slug: "linkedin_url",
-            attribute_type: "url",
-            value: cl,
-            source: SOURCE,
-            provenance,
-          });
-        }
       }
     }
+  }
 
-    // Person — dedupe by LinkedIn URL.
-    const linkedinKey = mapped.person.linkedin_url
-      ? normalizeLinkedinUrl(mapped.person.linkedin_url)
-      : normalizeLinkedinUrl(url);
-    if (!linkedinKey) {
-      throw new AcrmError(
-        "could not derive a normalized LinkedIn URL from the profile",
-        ERR.INVALID_INPUT,
-      );
-    }
-
-    let personId = await findRecordByUnique(
-      lix,
-      "people",
-      "linkedin_url",
-      linkedinKey,
+  // Person — dedupe by LinkedIn URL.
+  const linkedinKey = mapped.person.linkedin_url
+    ? normalizeLinkedinUrl(mapped.person.linkedin_url)
+    : normalizeLinkedinUrl(url);
+  if (!linkedinKey) {
+    throw new AcrmError(
+      "could not derive a normalized LinkedIn URL from the profile",
+      ERR.INVALID_INPUT,
     );
-    let personCreated = false;
-    if (!personId) {
-      personId = await generateUuid(lix);
-      await insertRecord(lix, "people", personId);
-      personCreated = true;
-    }
+  }
 
+  let personId = await findRecordByUnique(
+    lix,
+    "people",
+    "linkedin_url",
+    linkedinKey,
+  );
+  let personCreated = false;
+  if (!personId) {
+    personId = await generateUuid(lix);
+    await insertRecord(lix, "people", personId);
+    personCreated = true;
+  }
+
+  await setSingleValue(lix, {
+    object_slug: "people",
+    record_id: personId,
+    attribute_slug: "linkedin_url",
+    attribute_type: "url",
+    value: linkedinKey,
+    source: SOURCE,
+    provenance,
+  });
+
+  if (mapped.person.name) {
     await setSingleValue(lix, {
       object_slug: "people",
       record_id: personId,
-      attribute_slug: "linkedin_url",
-      attribute_type: "url",
-      value: linkedinKey,
+      attribute_slug: "name",
+      attribute_type: "personal-name",
+      value: mapped.person.name,
       source: SOURCE,
       provenance,
     });
-
-    if (mapped.person.name) {
-      await setSingleValue(lix, {
-        object_slug: "people",
-        record_id: personId,
-        attribute_slug: "name",
-        attribute_type: "personal-name",
-        value: mapped.person.name,
-        source: SOURCE,
-        provenance,
-      });
-    }
-
-    if (mapped.person.job_title) {
-      await setSingleValue(lix, {
-        object_slug: "people",
-        record_id: personId,
-        attribute_slug: "job_title",
-        attribute_type: "text",
-        value: mapped.person.job_title,
-        source: SOURCE,
-        provenance,
-      });
-    }
-
-    if (companyId) {
-      await setSingleValue(lix, {
-        object_slug: "people",
-        record_id: personId,
-        attribute_slug: "company",
-        attribute_type: "record-reference",
-        value: { target_object: "companies", target_record_id: companyId },
-        source: SOURCE,
-        provenance,
-      });
-    }
-
-    return {
-      person_record_id: personId,
-      company_record_id: companyId,
-      created: { person: personCreated, company: companyCreated },
-      cache_path: cachePath
-        ? path.relative(process.cwd(), cachePath)
-        : null,
-      cache_hit: cacheHit,
-      mapped,
-    };
-  } finally {
-    await lix.close();
   }
+
+  if (mapped.person.job_title) {
+    await setSingleValue(lix, {
+      object_slug: "people",
+      record_id: personId,
+      attribute_slug: "job_title",
+      attribute_type: "text",
+      value: mapped.person.job_title,
+      source: SOURCE,
+      provenance,
+    });
+  }
+
+  if (companyId) {
+    await setSingleValue(lix, {
+      object_slug: "people",
+      record_id: personId,
+      attribute_slug: "company",
+      attribute_type: "record-reference",
+      value: { target_object: "companies", target_record_id: companyId },
+      source: SOURCE,
+      provenance,
+    });
+  }
+
+  return {
+    person_record_id: personId,
+    company_record_id: companyId,
+    created: { person: personCreated, company: companyCreated },
+    cache_path: cachePath,
+    cache_hit: cacheHit,
+    mapped,
+  };
 }

--- a/src/commands/import-post.ts
+++ b/src/commands/import-post.ts
@@ -1,0 +1,378 @@
+import path from "node:path";
+import type { Command } from "commander";
+import type { Lix } from "@lix-js/sdk";
+import { findWorkspace, openWorkspace } from "../workspace/open.js";
+import { fail, ok, setJsonMode } from "../output/json.js";
+import { generateUuid } from "../lib/ids.js";
+import { AcrmError, ERR } from "../lib/errors.js";
+import { loadDotenv } from "../lib/dotenv.js";
+import { normalizePostUrl, type PostPlatform } from "../domain/values.js";
+import { exec } from "../db/execute.js";
+import {
+  addMultiValue,
+  findRecordByUnique,
+  insertRecord,
+  setSingleValue,
+} from "../db/upsert.js";
+import {
+  extractLinkedinPostId,
+  extractXPostId,
+  loadLinkedinPost,
+  loadXPost,
+} from "../integrations/apify-post.js";
+import { mapLinkedinPost, mapXPost, type MappedPost } from "../integrations/post-mapping.js";
+import { importLinkedinProfile } from "./import-linkedin.js";
+import { importXProfile } from "./import-x.js";
+
+type Opts = {
+  refresh?: boolean;
+  cache?: boolean;
+};
+
+export function attachPostSubcommand(parent: Command): void {
+  parent
+    .command("post <url>")
+    .description(
+      "Import a LinkedIn or X post by URL. Use when the user shares a post link they want to track (e.g. \"import this post\", \"save this tweet\", \"add this person from their post\"). Auto-detects platform from the URL. Upserts the post author as a person (deduped by LinkedIn URL or X handle), creates a `posts` record (deduped by URL), and links them via `posts.author` + `people.associated_posts`. Requires APIFY_API_TOKEN in .env.",
+    )
+    .option("--refresh", "bypass cache and re-fetch from Apify")
+    .option("--no-cache", "do not write the response to cache")
+    .addHelpText(
+      "after",
+      `
+Accepted URL formats:
+  LinkedIn   https://www.linkedin.com/posts/<slug>_<activity-id>
+             https://www.linkedin.com/feed/update/urn:li:activity:<id>/
+  X / Twitter  https://x.com/<handle>/status/<id>
+               https://twitter.com/<handle>/status/<id>
+
+Examples:
+  acrm import post https://x.com/jack/status/20
+  acrm import post 'https://www.linkedin.com/feed/update/urn:li:activity:7458176780059897856/'
+
+What gets written:
+  people     author upserted (deduped by linkedin_url or twitter_url)
+  companies  for LinkedIn posts only — author's current employer (deduped by name)
+  posts      one record per unique post URL with: url, platform, author, posted_at, content
+
+Re-running the same URL is safe — dedup keeps one post record and one author
+record; cached Apify responses (14-day TTL in .cache/{linkedin,x}-posts/) make
+repeat runs free.
+`,
+    )
+    .action(async (url: string, opts: Opts) => {
+      const root = parent.parent?.opts() as
+        | { workspace?: string; json?: boolean }
+        | undefined;
+      setJsonMode(root?.json);
+      try {
+        const result = await runImportPost(url, {
+          workspace: root?.workspace,
+          refresh: opts.refresh,
+          noCache: opts.cache === false,
+        });
+        ok(result);
+      } catch (e) {
+        if (e instanceof AcrmError) fail(e.message, e.code, e.hint);
+        else fail(e instanceof Error ? e.message : String(e), ERR.UNHANDLED);
+        process.exit(1);
+      }
+    });
+}
+
+async function runImportPost(
+  rawUrl: string,
+  opts: { workspace?: string; refresh?: boolean; noCache?: boolean },
+) {
+  const sniffed = normalizePostUrl(rawUrl);
+  if (!sniffed) {
+    throw new AcrmError(
+      `unrecognized post URL: ${rawUrl} (expected linkedin.com, x.com, or twitter.com)`,
+      ERR.INVALID_INPUT,
+    );
+  }
+  const { platform, url: normalizedUrl } = sniffed;
+
+  const workspaceFile = opts.workspace
+    ? path.resolve(
+        opts.workspace.endsWith(".acrm")
+          ? opts.workspace
+          : opts.workspace + ".acrm",
+      )
+    : findWorkspace();
+  if (!workspaceFile) {
+    throw new AcrmError(
+      "no .acrm file found (run `acrm init <name>.acrm` to create one)",
+      ERR.NO_WORKSPACE,
+    );
+  }
+  const workspaceDir = path.dirname(workspaceFile);
+  loadDotenv(workspaceDir);
+  loadDotenv(process.cwd());
+
+  const token = process.env.APIFY_API_TOKEN;
+  if (!token) {
+    const envFile = path.join(workspaceDir, ".env");
+    throw new AcrmError(
+      "APIFY_API_TOKEN is not set",
+      ERR.INVALID_INPUT,
+      `create a .env file at ${envFile} containing:\n  APIFY_API_TOKEN=<your-apify-token>\n(or export APIFY_API_TOKEN in your shell)`,
+    );
+  }
+
+  const postCacheDir = path.join(
+    workspaceDir,
+    ".cache",
+    platform === "linkedin" ? "linkedin-posts" : "x-posts",
+  );
+  const profileCacheDir = path.join(
+    workspaceDir,
+    ".cache",
+    platform === "linkedin" ? "linkedin" : "x",
+  );
+
+  // 1. Fetch the post (with cache).
+  const postId =
+    platform === "linkedin"
+      ? extractLinkedinPostId(rawUrl)
+      : extractXPostId(rawUrl);
+  const postLoad =
+    platform === "linkedin"
+      ? await loadLinkedinPost({
+          cacheDir: postCacheDir,
+          postId,
+          url: rawUrl,
+          token,
+          refresh: opts.refresh,
+          noCache: opts.noCache,
+        })
+      : await loadXPost({
+          cacheDir: postCacheDir,
+          postId,
+          url: rawUrl,
+          token,
+          refresh: opts.refresh,
+          noCache: opts.noCache,
+        });
+
+  // 2. Map post + extract author profile URL.
+  const mapped: MappedPost =
+    platform === "linkedin"
+      ? mapLinkedinPost(postLoad.post)
+      : mapXPost(postLoad.post);
+
+  if (!mapped.author_profile_url) {
+    throw new AcrmError(
+      "could not extract author profile URL from the post",
+      ERR.UNHANDLED,
+    );
+  }
+
+  const lix = await openWorkspace({ workspace: workspaceFile });
+  try {
+    // 3. Import the author via the existing profile flow.
+    let personId: string;
+    let companyId: string | null = null;
+    let personCreated = false;
+    let companyCreated = false;
+    let profileCachePath: string | null = null;
+    let profileCacheHit = false;
+
+    if (platform === "linkedin") {
+      const r = await importLinkedinProfile({
+        lix,
+        urlOrSlug: mapped.author_profile_url,
+        token,
+        cacheDir: profileCacheDir,
+        refresh: opts.refresh,
+        noCache: opts.noCache,
+      });
+      personId = r.person_record_id;
+      companyId = r.company_record_id;
+      personCreated = r.created.person;
+      companyCreated = r.created.company;
+      profileCachePath = r.cache_path;
+      profileCacheHit = r.cache_hit;
+    } else {
+      const r = await importXProfile({
+        lix,
+        handleOrUrl: mapped.author_profile_url,
+        token,
+        cacheDir: profileCacheDir,
+        refresh: opts.refresh,
+        noCache: opts.noCache,
+      });
+      personId = r.person_record_id;
+      personCreated = r.created.person;
+      profileCachePath = r.cache_path;
+      profileCacheHit = r.cache_hit;
+    }
+
+    // 4. Upsert the post record (dedup by normalized URL).
+    const postRecord = await upsertPost({
+      lix,
+      platform,
+      normalizedUrl,
+      rawUrl,
+      mapped,
+      personId,
+      postCacheHit: postLoad.cacheHit,
+      apifyActor:
+        platform === "linkedin"
+          ? "apimaestro~linkedin-post-detail"
+          : "apidojo~twitter-scraper-lite",
+    });
+
+    // 5. Link person → post (skip if already linked).
+    await linkPersonToPost(lix, personId, postRecord.postRecordId, platform);
+
+    return {
+      post_record_id: postRecord.postRecordId,
+      person_record_id: personId,
+      company_record_id: companyId,
+      created: {
+        post: postRecord.created,
+        person: personCreated,
+        company: companyCreated,
+      },
+      platform,
+      post_url: normalizedUrl,
+      cache_paths: {
+        post: postLoad.cachePath
+          ? path.relative(process.cwd(), postLoad.cachePath)
+          : null,
+        profile: profileCachePath
+          ? path.relative(process.cwd(), profileCachePath)
+          : null,
+      },
+      cache_hits: {
+        post: postLoad.cacheHit,
+        profile: profileCacheHit,
+      },
+      mapped,
+    };
+  } finally {
+    await lix.close();
+  }
+}
+
+async function upsertPost(args: {
+  lix: Lix;
+  platform: PostPlatform;
+  normalizedUrl: string;
+  rawUrl: string;
+  mapped: MappedPost;
+  personId: string;
+  postCacheHit: boolean;
+  apifyActor: string;
+}): Promise<{ postRecordId: string; created: boolean }> {
+  const { lix, platform, normalizedUrl, rawUrl, mapped, personId, apifyActor } =
+    args;
+  const source =
+    platform === "linkedin" ? "linkedin-post-import" : "x-post-import";
+  const provenance = {
+    actor: apifyActor,
+    post_url: rawUrl,
+    fetched_at: new Date().toISOString(),
+    cache_hit: args.postCacheHit,
+  };
+
+  let postRecordId = await findRecordByUnique(
+    lix,
+    "posts",
+    "url",
+    normalizedUrl,
+  );
+  let created = false;
+  if (!postRecordId) {
+    postRecordId = await generateUuid(lix);
+    await insertRecord(lix, "posts", postRecordId);
+    created = true;
+  }
+
+  await setSingleValue(lix, {
+    object_slug: "posts",
+    record_id: postRecordId,
+    attribute_slug: "url",
+    attribute_type: "url",
+    value: normalizedUrl,
+    source,
+    provenance,
+  });
+
+  await setSingleValue(lix, {
+    object_slug: "posts",
+    record_id: postRecordId,
+    attribute_slug: "platform",
+    attribute_type: "status",
+    value: platform,
+    source,
+    provenance,
+  });
+
+  await setSingleValue(lix, {
+    object_slug: "posts",
+    record_id: postRecordId,
+    attribute_slug: "author",
+    attribute_type: "record-reference",
+    value: { target_object: "people", target_record_id: personId },
+    source,
+    provenance,
+  });
+
+  if (mapped.posted_at) {
+    await setSingleValue(lix, {
+      object_slug: "posts",
+      record_id: postRecordId,
+      attribute_slug: "posted_at",
+      attribute_type: "date",
+      value: mapped.posted_at,
+      source,
+      provenance,
+    });
+  }
+
+  if (mapped.content) {
+    await setSingleValue(lix, {
+      object_slug: "posts",
+      record_id: postRecordId,
+      attribute_slug: "content",
+      attribute_type: "text",
+      value: mapped.content,
+      source,
+      provenance,
+    });
+  }
+
+  return { postRecordId, created };
+}
+
+async function linkPersonToPost(
+  lix: Lix,
+  personId: string,
+  postRecordId: string,
+  platform: PostPlatform,
+): Promise<void> {
+  const existing = await exec(
+    lix,
+    `SELECT 1 FROM acrm_value
+     WHERE object_slug = 'people' AND record_id = $1
+       AND attribute_slug = 'associated_posts'
+       AND ref_object = 'posts' AND ref_record_id = $2
+       AND active_until IS NULL LIMIT 1`,
+    [personId, postRecordId],
+  );
+  if (existing.rows.length) return;
+
+  const source =
+    platform === "linkedin" ? "linkedin-post-import" : "x-post-import";
+  await addMultiValue(lix, {
+    object_slug: "people",
+    record_id: personId,
+    attribute_slug: "associated_posts",
+    attribute_type: "record-reference",
+    value: { target_object: "posts", target_record_id: postRecordId },
+    source,
+    provenance: { linked_at: new Date().toISOString() },
+  });
+}

--- a/src/commands/import-x.ts
+++ b/src/commands/import-x.ts
@@ -13,8 +13,12 @@ import {
   insertRecord,
   setSingleValue,
 } from "../db/upsert.js";
-import { loadFromCacheOrFetch, normalizeXInput } from "../integrations/apify-x.js";
-import { mapProfile } from "../integrations/x-mapping.js";
+import {
+  loadFromCacheOrFetch,
+  normalizeXInput,
+  type XProfile,
+} from "../integrations/apify-x.js";
+import { mapProfile, type MappedXProfile } from "../integrations/x-mapping.js";
 
 const SOURCE = "x-import";
 const ENRICHABLE = ["job_title", "company"] as const;
@@ -24,11 +28,26 @@ type Opts = {
   cache?: boolean;
 };
 
+export type XImportResult = {
+  person_record_id: string;
+  created: { person: boolean };
+  cache_path: string | null;
+  cache_hit: boolean;
+  mapped: MappedXProfile;
+  bio: string | null;
+  needs_enrichment: {
+    person_record_id: string;
+    bio: string;
+    missing: string[];
+    instructions: string;
+  } | null;
+};
+
 export function attachXSubcommand(parent: Command): void {
   parent
     .command("x <handle-or-url>")
     .description(
-      "Fetch an X (Twitter) profile via Apify and upsert the person in the workspace",
+      "Import a person from an X/Twitter profile (`@handle`, `handle`, or `https://x.com/handle`). Use when the user shares an X **profile** (e.g. \"add @jack\", \"import this X profile\"). For an X **post/tweet** URL instead, use `acrm import post`. Fetches the profile via Apify, upserts the person (deduped by twitter_url normalized to x.com/<handle>). If the bio contains role/company info, returns a `needs_enrichment` payload — trigger the `enrich-x-bio` skill on it. Requires APIFY_API_TOKEN in .env.",
     )
     .option("--refresh", "bypass cache and re-fetch from Apify")
     .option("--no-cache", "do not write the response to cache")
@@ -43,7 +62,12 @@ export function attachXSubcommand(parent: Command): void {
           refresh: opts.refresh,
           noCache: opts.cache === false,
         });
-        ok(result);
+        ok({
+          ...result,
+          cache_path: result.cache_path
+            ? path.relative(process.cwd(), result.cache_path)
+            : null,
+        });
       } catch (e) {
         if (e instanceof AcrmError) fail(e.message, e.code, e.hint);
         else fail(e instanceof Error ? e.message : String(e), ERR.UNHANDLED);
@@ -55,9 +79,7 @@ export function attachXSubcommand(parent: Command): void {
 async function runImportX(
   handleOrUrl: string,
   opts: { workspace?: string; refresh?: boolean; noCache?: boolean },
-) {
-  const { handle } = normalizeXInput(handleOrUrl);
-
+): Promise<XImportResult> {
   const workspaceFile = opts.workspace
     ? path.resolve(
         opts.workspace.endsWith(".acrm")
@@ -87,105 +109,130 @@ async function runImportX(
 
   const cacheDir = path.join(workspaceDir, ".cache", "x");
 
-  const { profile, cachePath, cacheHit } = await loadFromCacheOrFetch({
-    cacheDir,
-    handle,
-    token,
-    refresh: opts.refresh,
-    noCache: opts.noCache,
-  });
-
-  const mapped = mapProfile(profile, handle);
-
   const lix = await openWorkspace({ workspace: workspaceFile });
   try {
-    const provenance = {
-      actor: "apidojo~twitter-user-scraper",
-      handle: mapped.person.handle,
-      fetched_at: new Date().toISOString(),
-      cache_hit: cacheHit,
-    };
-
-    const twitterKey = normalizeTwitterUrl(mapped.person.twitter_url);
-    if (!twitterKey) {
-      throw new AcrmError(
-        "could not derive a normalized X URL from the profile",
-        ERR.INVALID_INPUT,
-      );
-    }
-
-    let personId = await findRecordByUnique(
+    return await importXProfile({
       lix,
-      "people",
-      "twitter_url",
-      twitterKey,
-    );
-    let personCreated = false;
-    if (!personId) {
-      personId = await generateUuid(lix);
-      await insertRecord(lix, "people", personId);
-      personCreated = true;
-    }
-
-    await setSingleValue(lix, {
-      object_slug: "people",
-      record_id: personId,
-      attribute_slug: "twitter_url",
-      attribute_type: "url",
-      value: twitterKey,
-      source: SOURCE,
-      provenance,
+      handleOrUrl,
+      token,
+      cacheDir,
+      refresh: opts.refresh,
+      noCache: opts.noCache,
     });
-
-    if (mapped.person.name) {
-      await setSingleValue(lix, {
-        object_slug: "people",
-        record_id: personId,
-        attribute_slug: "name",
-        attribute_type: "personal-name",
-        value: mapped.person.name,
-        source: SOURCE,
-        provenance,
-      });
-    }
-
-    const bio = pickBio(profile);
-    const missing: string[] = [];
-    for (const attr of ENRICHABLE) {
-      if (!(await hasActiveValue(lix, "people", personId, attr))) {
-        missing.push(attr);
-      }
-    }
-
-    const needsEnrichment =
-      bio && missing.length > 0
-        ? {
-            person_record_id: personId,
-            bio,
-            missing,
-            instructions:
-              "Extract role/company from `bio`. For each slug in `missing`, write a value via `acrm execute` UPDATE/INSERT on acrm_value. Only write what's clearly stated; skip if uncertain. Source: 'x-bio-enrichment'.",
-          }
-        : null;
-
-    return {
-      person_record_id: personId,
-      created: { person: personCreated },
-      cache_path: cachePath ? path.relative(process.cwd(), cachePath) : null,
-      cache_hit: cacheHit,
-      mapped,
-      bio,
-      needs_enrichment: needsEnrichment,
-    };
   } finally {
     await lix.close();
   }
 }
 
-function pickBio(profile: Record<string, unknown>): string | null {
+export type ImportXProfileArgs = {
+  lix: Lix;
+  handleOrUrl: string;
+  token: string;
+  cacheDir: string;
+  refresh?: boolean;
+  noCache?: boolean;
+};
+
+export async function importXProfile(
+  args: ImportXProfileArgs,
+): Promise<XImportResult> {
+  const { lix, handleOrUrl, token, cacheDir, refresh, noCache } = args;
+  const { handle } = normalizeXInput(handleOrUrl);
+
+  const { profile, cachePath, cacheHit } = await loadFromCacheOrFetch({
+    cacheDir,
+    handle,
+    token,
+    refresh,
+    noCache,
+  });
+
+  const mapped = mapProfile(profile, handle);
+
+  const provenance = {
+    actor: "apidojo~twitter-user-scraper",
+    handle: mapped.person.handle,
+    fetched_at: new Date().toISOString(),
+    cache_hit: cacheHit,
+  };
+
+  const twitterKey = normalizeTwitterUrl(mapped.person.twitter_url);
+  if (!twitterKey) {
+    throw new AcrmError(
+      "could not derive a normalized X URL from the profile",
+      ERR.INVALID_INPUT,
+    );
+  }
+
+  let personId = await findRecordByUnique(
+    lix,
+    "people",
+    "twitter_url",
+    twitterKey,
+  );
+  let personCreated = false;
+  if (!personId) {
+    personId = await generateUuid(lix);
+    await insertRecord(lix, "people", personId);
+    personCreated = true;
+  }
+
+  await setSingleValue(lix, {
+    object_slug: "people",
+    record_id: personId,
+    attribute_slug: "twitter_url",
+    attribute_type: "url",
+    value: twitterKey,
+    source: SOURCE,
+    provenance,
+  });
+
+  if (mapped.person.name) {
+    await setSingleValue(lix, {
+      object_slug: "people",
+      record_id: personId,
+      attribute_slug: "name",
+      attribute_type: "personal-name",
+      value: mapped.person.name,
+      source: SOURCE,
+      provenance,
+    });
+  }
+
+  const bio = pickBio(profile);
+  const missing: string[] = [];
+  for (const attr of ENRICHABLE) {
+    if (!(await hasActiveValue(lix, "people", personId, attr))) {
+      missing.push(attr);
+    }
+  }
+
+  const needsEnrichment =
+    bio && missing.length > 0
+      ? {
+          person_record_id: personId,
+          bio,
+          missing,
+          instructions:
+            "Extract role/company from `bio`. For each slug in `missing`, write a value via `acrm execute` UPDATE/INSERT on acrm_value. Only write what's clearly stated; skip if uncertain. Source: 'x-bio-enrichment'.",
+        }
+      : null;
+
+  return {
+    person_record_id: personId,
+    created: { person: personCreated },
+    cache_path: cachePath,
+    cache_hit: cacheHit,
+    mapped,
+    bio,
+    needs_enrichment: needsEnrichment,
+  };
+}
+
+function pickBio(profile: XProfile): string | null {
   let raw: string | null = null;
   for (const k of ["description", "bio", "about"]) {
-    const v = profile[k];
+    const v = (profile as Record<string, unknown>)[k];
     if (typeof v === "string" && v.trim().length) {
       raw = v.trim();
       break;
@@ -195,11 +242,8 @@ function pickBio(profile: Record<string, unknown>): string | null {
   return expandTcoUrls(raw, profile);
 }
 
-function expandTcoUrls(
-  bio: string,
-  profile: Record<string, unknown>,
-): string {
-  const entities = profile.entities as
+function expandTcoUrls(bio: string, profile: XProfile): string {
+  const entities = (profile as Record<string, unknown>).entities as
     | { description?: { urls?: Array<Record<string, unknown>> } }
     | undefined;
   const urls = entities?.description?.urls;

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -18,6 +18,7 @@ import {
   domainFromEmail,
   normalizeLinkedinUrl,
   normalizeTwitterUrl,
+  type AttributeConfig,
   type AttributeType,
 } from "../domain/values.js";
 
@@ -346,15 +347,24 @@ async function getAttribute(
   lix: Lix,
   object_slug: string,
   attribute_slug: string,
-): Promise<{ attribute_type: AttributeType } | null> {
+): Promise<{ attribute_type: AttributeType; config?: AttributeConfig } | null> {
   const r = await exec(
     lix,
-    "SELECT attribute_type FROM acrm_attribute WHERE object_slug = $1 AND attribute_slug = $2",
+    "SELECT attribute_type, config_json FROM acrm_attribute WHERE object_slug = $1 AND attribute_slug = $2",
     [object_slug, attribute_slug],
   );
   const row = r.rows[0];
   if (!row) return null;
-  return { attribute_type: row.attribute_type as AttributeType };
+  let config: AttributeConfig | undefined;
+  const raw = row.config_json as string | null | undefined;
+  if (raw) {
+    try {
+      config = JSON.parse(raw) as AttributeConfig;
+    } catch {
+      config = undefined;
+    }
+  }
+  return { attribute_type: row.attribute_type as AttributeType, config };
 }
 
 async function setSingleValue(
@@ -368,13 +378,14 @@ async function setSingleValue(
     value: unknown;
     source: string;
     provenance: Record<string, unknown>;
+    attribute_config?: AttributeConfig;
     // When true, the record was created in this import and cannot have
     // pre-existing active values — skip the closing UPDATE round-trip and
     // enqueue the INSERT into the batch.
     isFresh?: boolean;
   },
 ): Promise<void> {
-  const value_json = encode(args.attribute_type, args.value);
+  const value_json = encode(args.attribute_type, args.value, args.attribute_config);
   if (!args.isFresh) {
     // The record may have pre-existing values that need to be closed before
     // we insert the replacement. Flush pending INSERTs first so the UPDATE
@@ -402,12 +413,13 @@ async function addMultiValue(
     value: unknown;
     source: string;
     provenance: Record<string, unknown>;
+    attribute_config?: AttributeConfig;
     // When true, the record was created in this import — skip the dedupe
     // SELECT (it cannot have pre-existing values).
     isFresh?: boolean;
   },
 ): Promise<void> {
-  const value_json = encode(args.attribute_type, args.value);
+  const value_json = encode(args.attribute_type, args.value, args.attribute_config);
   const normalized = normalizeUniqueKey(args.attribute_type, value_json);
   if (!args.isFresh && normalized) {
     // Existing record — flush so the SELECT sees in-flight inserts (the same
@@ -800,6 +812,7 @@ async function importRow(
           record_id: dealId,
           attribute_slug: "stage",
           attribute_type: attr.attribute_type,
+          attribute_config: attr.config,
           value: stage,
           source,
           provenance,

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -28,6 +28,7 @@ const OBJECTS: ObjectSeed[] = [
   { object_slug: "people", singular_name: "Person", plural_name: "People" },
   { object_slug: "companies", singular_name: "Company", plural_name: "Companies" },
   { object_slug: "deals", singular_name: "Deal", plural_name: "Deals" },
+  { object_slug: "posts", singular_name: "Post", plural_name: "Posts" },
 ];
 
 const ATTRIBUTES: AttributeSeed[] = [
@@ -47,6 +48,7 @@ const ATTRIBUTES: AttributeSeed[] = [
   { object_slug: "people", attribute_slug: "twitter_url", title: "Twitter / X", attribute_type: "url", is_multivalued: false, is_unique: false },
   { object_slug: "people", attribute_slug: "company", title: "Company", attribute_type: "record-reference", is_multivalued: false, is_unique: false, config: { target_object: "companies", inverse: "team" } },
   { object_slug: "people", attribute_slug: "associated_deals", title: "Associated deals", attribute_type: "record-reference", is_multivalued: true, is_unique: false, config: { target_object: "deals", inverse: "associated_people" } },
+  { object_slug: "people", attribute_slug: "associated_posts", title: "Associated posts", attribute_type: "record-reference", is_multivalued: true, is_unique: false, config: { target_object: "posts", inverse: "author" } },
 
   // deals
   { object_slug: "deals", attribute_slug: "name", title: "Name", attribute_type: "text", is_multivalued: false, is_unique: false },
@@ -56,6 +58,13 @@ const ATTRIBUTES: AttributeSeed[] = [
   { object_slug: "deals", attribute_slug: "associated_people", title: "Associated people", attribute_type: "record-reference", is_multivalued: true, is_unique: false, config: { target_object: "people", inverse: "associated_deals" } },
   { object_slug: "deals", attribute_slug: "close_date", title: "Close date", attribute_type: "date", is_multivalued: false, is_unique: false },
   { object_slug: "deals", attribute_slug: "next_step", title: "Next step", attribute_type: "text", is_multivalued: false, is_unique: false },
+
+  // posts
+  { object_slug: "posts", attribute_slug: "url", title: "URL", attribute_type: "url", is_multivalued: false, is_unique: true },
+  { object_slug: "posts", attribute_slug: "platform", title: "Platform", attribute_type: "status", is_multivalued: false, is_unique: false, config: { options: [{ id: "linkedin", title: "LinkedIn" }, { id: "x", title: "X" }] } },
+  { object_slug: "posts", attribute_slug: "author", title: "Author", attribute_type: "record-reference", is_multivalued: false, is_unique: false, config: { target_object: "people", inverse: "associated_posts" } },
+  { object_slug: "posts", attribute_slug: "posted_at", title: "Posted at", attribute_type: "date", is_multivalued: false, is_unique: false },
+  { object_slug: "posts", attribute_slug: "content", title: "Content", attribute_type: "text", is_multivalued: false, is_unique: false },
 ];
 
 async function seedObjects(lix: Lix): Promise<void> {

--- a/src/db/upsert.ts
+++ b/src/db/upsert.ts
@@ -5,8 +5,32 @@ import { nowIso } from "../lib/time.js";
 import {
   encode,
   normalizeUniqueKey,
+  type AttributeConfig,
   type AttributeType,
 } from "../domain/values.js";
+
+async function loadAttributeConfig(
+  lix: Lix,
+  object_slug: string,
+  attribute_slug: string,
+): Promise<AttributeConfig | undefined> {
+  const r = await exec(
+    lix,
+    "SELECT config_json FROM acrm_attribute WHERE object_slug = $1 AND attribute_slug = $2",
+    [object_slug, attribute_slug],
+  );
+  const raw = r.rows[0]?.config_json as string | null | undefined;
+  if (!raw) return undefined;
+  try {
+    return JSON.parse(raw) as AttributeConfig;
+  } catch {
+    return undefined;
+  }
+}
+
+function needsConfig(type: AttributeType): boolean {
+  return type === "status" || type === "select";
+}
 
 export async function findRecordByUnique(
   lix: Lix,
@@ -109,7 +133,10 @@ export async function setSingleValue(
     provenance: Record<string, unknown>;
   },
 ): Promise<void> {
-  const value_json = encode(args.attribute_type, args.value);
+  const config = needsConfig(args.attribute_type)
+    ? await loadAttributeConfig(lix, args.object_slug, args.attribute_slug)
+    : undefined;
+  const value_json = encode(args.attribute_type, args.value, config);
   await exec(
     lix,
     `UPDATE acrm_value SET active_until = $1
@@ -131,7 +158,10 @@ export async function addMultiValue(
     provenance: Record<string, unknown>;
   },
 ): Promise<void> {
-  const value_json = encode(args.attribute_type, args.value);
+  const config = needsConfig(args.attribute_type)
+    ? await loadAttributeConfig(lix, args.object_slug, args.attribute_slug)
+    : undefined;
+  const value_json = encode(args.attribute_type, args.value, config);
   const normalized = normalizeUniqueKey(args.attribute_type, value_json);
   if (normalized) {
     const exists = await exec(

--- a/src/domain/values.ts
+++ b/src/domain/values.ts
@@ -14,7 +14,34 @@ export type AttributeType =
 
 export type ValueJson = Record<string, unknown>;
 
-export function encode(type: AttributeType, input: unknown): ValueJson {
+export type StatusOption = { id: string; title: string };
+
+export type AttributeConfig = {
+  options?: StatusOption[];
+  // Other config keys (target_object, inverse, currency_code, ...) are
+  // intentionally not typed here — they're consumed elsewhere.
+  [key: string]: unknown;
+};
+
+export function resolveStatusOption(
+  raw: string,
+  options: StatusOption[] | undefined,
+): StatusOption | null {
+  if (!options || options.length === 0) return null;
+  const needle = raw.trim().toLowerCase();
+  for (const o of options) {
+    if (o.id.toLowerCase() === needle || o.title.toLowerCase() === needle) {
+      return { id: o.id, title: o.title };
+    }
+  }
+  return null;
+}
+
+export function encode(
+  type: AttributeType,
+  input: unknown,
+  config?: AttributeConfig,
+): ValueJson {
   if (input === null || input === undefined) {
     throw new Error(`cannot encode null/undefined for ${type}`);
   }
@@ -61,8 +88,11 @@ export function encode(type: AttributeType, input: unknown): ValueJson {
       return { timestamp: String(input).trim() };
     case "select":
     case "status": {
-      if (typeof input === "object") return input as ValueJson;
-      return { title: String(input).trim() };
+      if (typeof input === "object" && input !== null) return input as ValueJson;
+      const raw = String(input).trim();
+      const match = resolveStatusOption(raw, config?.options);
+      if (match) return { id: match.id, title: match.title };
+      return { title: raw };
     }
     case "record-reference": {
       const v = input as { target_object?: string; target_record_id?: string };
@@ -149,4 +179,53 @@ export function normalizeTwitterUrl(input: string): string | null {
   s = s.replace(/\/+$/, "");
   s = s.toLowerCase();
   return s.length ? s : null;
+}
+
+export type PostPlatform = "linkedin" | "x";
+
+export function sniffPostPlatform(input: string): PostPlatform | null {
+  const s = input.trim().toLowerCase();
+  if (!s) return null;
+  if (/(?:^|\/\/|\.)linkedin\.com\b/.test(s)) return "linkedin";
+  if (/(?:^|\/\/|\.)(?:x\.com|twitter\.com)\b/.test(s)) return "x";
+  return null;
+}
+
+export function normalizeLinkedinPostUrl(input: string): string | null {
+  let s = input.trim();
+  if (!s) return null;
+  s = s.replace(/^https?:\/\//i, "");
+  s = s.replace(/^www\./i, "");
+  const q = s.search(/[?#]/);
+  if (q >= 0) s = s.slice(0, q);
+  s = s.replace(/\/+$/, "");
+  s = s.toLowerCase();
+  return s.length ? s : null;
+}
+
+export function normalizeXPostUrl(input: string): string | null {
+  let s = input.trim();
+  if (!s) return null;
+  s = s.replace(/^https?:\/\//i, "");
+  s = s.replace(/^www\./i, "");
+  s = s.replace(/^twitter\.com\b/i, "x.com");
+  const q = s.search(/[?#]/);
+  if (q >= 0) s = s.slice(0, q);
+  s = s.replace(/\/+$/, "");
+  s = s.toLowerCase();
+  return s.length ? s : null;
+}
+
+export function normalizePostUrl(input: string): {
+  platform: PostPlatform;
+  url: string;
+} | null {
+  const platform = sniffPostPlatform(input);
+  if (!platform) return null;
+  const url =
+    platform === "linkedin"
+      ? normalizeLinkedinPostUrl(input)
+      : normalizeXPostUrl(input);
+  if (!url) return null;
+  return { platform, url };
 }

--- a/src/integrations/apify-post.ts
+++ b/src/integrations/apify-post.ts
@@ -1,0 +1,151 @@
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { createHash } from "node:crypto";
+import { AcrmError, ERR } from "../lib/errors.js";
+
+const LINKEDIN_ACTOR = "apimaestro~linkedin-post-detail";
+const X_ACTOR = "apidojo~twitter-scraper-lite";
+const TTL_MS = 14 * 24 * 60 * 60 * 1000;
+
+export type RawPost = Record<string, unknown>;
+
+export function extractLinkedinPostId(url: string): string {
+  const activity = url.match(/activity[-:](\d{10,})/i);
+  if (activity) return activity[1]!;
+  const urn = url.match(/urn:li:activity:(\d{10,})/i);
+  if (urn) return urn[1]!;
+  return createHash("sha1").update(url).digest("hex").slice(0, 16);
+}
+
+export function extractXPostId(url: string): string {
+  const m = url.match(/\/status(?:es)?\/(\d{6,})/i);
+  if (m) return m[1]!;
+  return createHash("sha1").update(url).digest("hex").slice(0, 16);
+}
+
+async function callApify(
+  actor: string,
+  token: string,
+  body: Record<string, unknown>,
+  timeoutMs = 180_000,
+): Promise<RawPost> {
+  const params = new URLSearchParams({ token, maxTotalChargeUsd: "1.00" });
+  const endpoint = `https://api.apify.com/v2/acts/${actor}/run-sync-get-dataset-items`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  let resp: Response;
+  try {
+    resp = await fetch(`${endpoint}?${params.toString()}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new AcrmError(`apify network error: ${msg}`, ERR.UNHANDLED);
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (!resp.ok) {
+    const text = (await resp.text()).slice(0, 500);
+    throw new AcrmError(`apify http ${resp.status}: ${text}`, ERR.UNHANDLED);
+  }
+  const data = (await resp.json()) as RawPost[];
+  if (!Array.isArray(data) || data.length === 0) {
+    throw new AcrmError(
+      "apify returned no post data (private, deleted, or invalid URL?)",
+      ERR.NOT_FOUND,
+    );
+  }
+  return data[0]!;
+}
+
+export async function fetchLinkedinPost(
+  url: string,
+  token: string,
+  opts: { timeoutMs?: number } = {},
+): Promise<RawPost> {
+  return callApify(
+    LINKEDIN_ACTOR,
+    token,
+    { post_urls: [url] },
+    opts.timeoutMs,
+  );
+}
+
+export async function fetchXPost(
+  url: string,
+  token: string,
+  opts: { timeoutMs?: number } = {},
+): Promise<RawPost> {
+  return callApify(X_ACTOR, token, { startUrls: [url] }, opts.timeoutMs);
+}
+
+export type PostCacheOptions = {
+  cacheDir: string;
+  postId: string;
+  url: string;
+  token: string;
+  refresh?: boolean;
+  noCache?: boolean;
+  timeoutMs?: number;
+};
+
+export type PostCacheResult = {
+  post: RawPost;
+  cachePath: string | null;
+  cacheHit: boolean;
+};
+
+export async function loadLinkedinPost(
+  opts: PostCacheOptions,
+): Promise<PostCacheResult> {
+  return loadOrFetch(opts, fetchLinkedinPost);
+}
+
+export async function loadXPost(
+  opts: PostCacheOptions,
+): Promise<PostCacheResult> {
+  return loadOrFetch(opts, fetchXPost);
+}
+
+async function loadOrFetch(
+  opts: PostCacheOptions,
+  fetcher: (
+    url: string,
+    token: string,
+    o?: { timeoutMs?: number },
+  ) => Promise<RawPost>,
+): Promise<PostCacheResult> {
+  const cachePath = path.join(opts.cacheDir, `${opts.postId}.json`);
+
+  if (!opts.refresh && !opts.noCache) {
+    const cached = await readFreshCache(cachePath);
+    if (cached) return { post: cached, cachePath, cacheHit: true };
+  }
+
+  const post = await fetcher(opts.url, opts.token, {
+    timeoutMs: opts.timeoutMs,
+  });
+
+  if (!opts.noCache) {
+    await mkdir(opts.cacheDir, { recursive: true });
+    await writeFile(cachePath, JSON.stringify(post, null, 2), "utf8");
+    return { post, cachePath, cacheHit: false };
+  }
+  return { post, cachePath: null, cacheHit: false };
+}
+
+async function readFreshCache(cachePath: string): Promise<RawPost | null> {
+  let s;
+  try {
+    s = await stat(cachePath);
+  } catch {
+    return null;
+  }
+  if (Date.now() - s.mtimeMs > TTL_MS) return null;
+  const raw = await readFile(cachePath, "utf8");
+  return JSON.parse(raw) as RawPost;
+}

--- a/src/integrations/post-mapping.ts
+++ b/src/integrations/post-mapping.ts
@@ -1,0 +1,126 @@
+import type { RawPost } from "./apify-post.js";
+
+export type MappedPost = {
+  post_url: string;
+  author_profile_url: string;
+  posted_at: string | null; // YYYY-MM-DD
+  content: string | null;
+};
+
+function pickString(...vals: unknown[]): string | null {
+  for (const v of vals) {
+    if (typeof v === "string" && v.trim().length) return v.trim();
+  }
+  return null;
+}
+
+function toDateOnly(raw: string | null): string | null {
+  if (!raw) return null;
+  const d = new Date(raw);
+  if (isNaN(d.getTime())) {
+    const m = raw.match(/^(\d{4}-\d{2}-\d{2})/);
+    return m ? m[1]! : null;
+  }
+  return d.toISOString().slice(0, 10);
+}
+
+export function mapLinkedinPost(raw: RawPost): MappedPost {
+  // apimaestro/linkedin-post-detail wraps fields under `post` + `author`.
+  // Fall back to top-level keys for resilience against schema drift.
+  const post = ((raw.post ?? raw) as Record<string, unknown>) ?? {};
+  const author = ((raw.author ?? {}) as Record<string, unknown>) ?? {};
+
+  const postUrl =
+    pickString(
+      post.url,
+      post.postUrl,
+      post.post_url,
+      post.linkedinUrl,
+      post.permalink,
+    ) ?? "";
+
+  const authorProfileUrl =
+    pickString(
+      author.profile_url,
+      author.profileUrl,
+      author.url,
+      author.linkedinUrl,
+      author.linkedin_url,
+    ) ?? "";
+
+  const createdAt = post.created_at as
+    | { timestamp?: number; date?: string }
+    | string
+    | undefined;
+  let postedAtRaw: string | null = null;
+  if (createdAt && typeof createdAt === "object") {
+    if (typeof createdAt.timestamp === "number") {
+      postedAtRaw = new Date(createdAt.timestamp).toISOString();
+    } else if (typeof createdAt.date === "string") {
+      postedAtRaw = createdAt.date;
+    }
+  } else if (typeof createdAt === "string") {
+    postedAtRaw = createdAt;
+  }
+  if (!postedAtRaw) {
+    postedAtRaw = pickString(
+      post.postedAt,
+      post.posted_at,
+      post.createdAt,
+      post.date,
+      post.publishedAt,
+      post.published_at,
+    );
+  }
+
+  const content = pickString(
+    post.text,
+    post.content,
+    post.commentary,
+    post.postText,
+    post.post_text,
+    post.body,
+  );
+
+  return {
+    post_url: postUrl,
+    author_profile_url: authorProfileUrl,
+    posted_at: toDateOnly(postedAtRaw),
+    content,
+  };
+}
+
+export function mapXPost(post: RawPost): MappedPost {
+  const author = (post.author ?? post.user ?? {}) as Record<string, unknown>;
+
+  const postUrl =
+    pickString(post.url, post.tweetUrl, post.permalink) ?? "";
+
+  const authorHandle = pickString(
+    author.userName,
+    author.username,
+    author.screen_name,
+    author.handle,
+  );
+
+  const authorProfileUrl =
+    pickString(author.url, author.profileUrl, author.profile_url) ??
+    (authorHandle ? `https://x.com/${authorHandle}` : "");
+
+  const postedAtRaw = pickString(
+    post.createdAt,
+    post.created_at,
+    post.date,
+    post.postedAt,
+    post.posted_at,
+  );
+
+  const content = pickString(post.text, post.fullText, post.full_text);
+
+  return {
+    post_url: postUrl,
+    author_profile_url: authorProfileUrl,
+    posted_at: toDateOnly(postedAtRaw),
+    content,
+  };
+}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `acrm import post <url>` command to import LinkedIn and X posts
- Adds a new `import post` subcommand in [`src/commands/import-post.ts`](https://github.com/cluster-software/agent-crm/pull/15/files#diff-c6e4b28fe9557cc194ff029ae6044a4c18d2a13634efeb103da1a6c7cb20a630) that accepts a LinkedIn or X post URL, fetches post data via Apify (with 14-day cache), imports the author profile, and upserts a `posts` record linked to the person.
- Adds a new `posts` object (seeded in [`src/commands/init.ts`](https://github.com/cluster-software/agent-crm/pull/15/files#diff-ec8485d3117f43c2d2d8e3ec7b2830f2d6b5df3f20626a62b04f61ccd70ec93f)) with attributes: `url`, `platform` (status: linkedin/x), `author`, `posted_at`, and `content`; also adds `people.associated_posts` as a reverse link.
- Refactors `import-linkedin` and `import-x` commands to extract reusable `importLinkedinProfile` and `importXProfile` helpers that operate on an existing open workspace, enabling chaining from `import post`.
- Fixes status/select attribute encoding in [`src/domain/values.ts`](https://github.com/cluster-software/agent-crm/pull/15/files#diff-f7330ed1df77dc9e606b8d1056332c517091612d0344e05d130b46615252642a) and [`src/db/upsert.ts`](https://github.com/cluster-software/agent-crm/pull/15/files#diff-1f332ffff964298eef808c64739968968065a011f32318f1da0c613fbfc175bb) so string inputs are resolved to canonical `{id, title}` against configured options before storage.
- Behavioral Change: existing CSV imports of deal stage and any status/select fields now store `{id, title}` objects instead of raw strings when the input matches a configured option.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47c2733.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->