### PR TITLE
fix: correct postinstall.cjs path so skills actually install on `npm …

### DIFF
--- a/.changeset/fix-postinstall-path.md
+++ b/.changeset/fix-postinstall-path.md
@@ -1,0 +1,5 @@
+---
+"@agent-crm/cli": patch
+---
+
+Fix `npm install -g @agent-crm/cli` not actually installing skills on a fresh install. The postinstall bootstrap (`postinstall.cjs`) was resolving the installer at `<pkg>/../dist/scripts/install-skills.js` — one level too high — so the `existsSync` guard always returned false and the script silently no-op'd. Result: skills weren't written to `~/.claude/skills/`, `~/.codex/skills/`, or `~/.cursor/skills/`, and `~/.acrm/skills.lock.json` was never created. Manual recovery via `acrm skills install` worked as a workaround. Fixed by correcting the path; the `acrm skills install` CLI command was unaffected because it resolves the source from `dist/commands/skills.js`, which has the right relative depth.

--- a/postinstall.cjs
+++ b/postinstall.cjs
@@ -8,9 +8,13 @@
 const fs = require("node:fs");
 const path = require("node:path");
 
+// postinstall.cjs lives at the package root (same dir as package.json),
+// so dist/ is a direct child — NOT one level up. An earlier draft had this
+// at scripts/postinstall.cjs where "../dist" was correct; relocating without
+// updating the path made the existsSync check below silently fail in
+// production, skipping the install entirely. Keep this path simple.
 const target = path.join(
   __dirname,
-  "..",
   "dist",
   "scripts",
   "install-skills.js",


### PR DESCRIPTION
…install -g`

postinstall.cjs lives at the package root, but the bootstrap was walking up one extra level (`..`) before descending into `dist/scripts/install-skills.js`. The resulting path never existed in the installed package, so the existsSync guard silently exited 0 on every install — skills weren't written and no lockfile was created. The `acrm skills install` CLI command was unaffected (it resolves from dist/commands/, which had the correct depth).

Verified end-to-end by packing the tarball, extracting it, and running the bootstrap with ACRM_SKIP_SKILLS=1 — the env-var message from install-skills.ts now appears, proving the chain executes to completion.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `postinstall.cjs` path so skills install correctly on `npm install`
> The [postinstall.cjs](https://github.com/cluster-software/agent-crm/pull/26/files#diff-1ea848f0244312332a442f7540bc459ab9c61653463bd21fcc04ff00a3d76eab) script was resolving the installer one directory above the package root due to an extra `..` segment. Removes that segment so the path resolves to `dist/scripts/install-skills.js` under the package root.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1dd0c3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->