### PR TITLE
Generalize resolve person (email, ln, x) + tests

### DIFF
--- a/.changeset/transcript-multi-identifier-resolution.md
+++ b/.changeset/transcript-multi-identifier-resolution.md
@@ -1,0 +1,17 @@
+---
+"@agent-crm/cli": minor
+---
+
+Resolve transcript participants by any of email / LinkedIn URL / Twitter URL, with backfill of missing identifiers.
+
+`acrm import transcript` used to require an `email` on every participant and resolved them with a single lookup against `people.email_addresses`. A meeting attendee whose `people` record carried only a LinkedIn URL (or whose record had a different email than what the meeting provider supplied) landed in `unresolved` even though the workspace held a unique identifier that unambiguously matched them. The CSV import path already did the right thing — email → linkedin → twitter cascade — but the cascade lived inline and the transcript path never picked it up.
+
+**Shared resolver.** New `src/domain/resolve-person.ts` exposes `resolvePersonByIdentifiers(lookup, ids)` running the canonical email → linkedin → twitter cascade. Both `acrm import csv` and `acrm import transcript` now funnel through this helper. The next identifier added (phone, handle, …) lands in one place.
+
+**Multi-identifier participants.** The canonical transcript JSON now accepts `{ email?, linkedin_url?, twitter_url? }` per participant, with at least one required. Email-only payloads keep working — pure superset. The CLI's `--help` and `docs/transcript-provider-protocol.md` describe the new shape; the `transcript-provider-granola` and `transcript-provider-manual` adapter skills pass identifiers through instead of forcing every attendee into an email-shaped slot.
+
+**Backfill on match.** When a participant resolves by LinkedIn/Twitter and the payload also carried an email (or vice versa) that the matched record didn't have, the CLI writes the missing identifier onto the record so the next import resolves directly. Single-value attributes (`linkedin_url`, `twitter_url`) are only filled when currently empty — curated values are never clobbered. Multi-value `email_addresses` dedupes on the normalized key. The result JSON's `resolved[].backfilled[]` lists which identifiers were written.
+
+**Better `unresolved` shape.** `unresolved[]` now carries `identifiers` (the normalized inputs that were probed), `tried` (which attribute indexes were hit), and `reason` of either `person_not_found` (at least one identifier was tried but missed) or `no_identifier_provided` (every supplied identifier normalized to empty). Self-debugging from the JSON output alone.
+
+**Test suite.** Added `src/domain/resolve-person.test.ts` (pure unit tests on normalization + cascade priority + skipped-when-null branches) and `src/commands/import-transcript.test.ts` (integration tests against an in-memory workspace covering email match, LinkedIn match, Twitter match, email-priority-over-linkedin, backfill of missing email, backfill of missing LinkedIn, no-clobber of curated LinkedIn, unresolved with `tried[]`/`reason`, idempotent re-import, malformed/empty-identifier rejection). 32 tests across the suite, all green.

--- a/docs/transcript-provider-protocol.md
+++ b/docs/transcript-provider-protocol.md
@@ -57,8 +57,11 @@ names into the skills:
    - `source_id` (string, unique per meeting in that provider)
    - `title`, `started_at`, `ended_at`, `duration_seconds` (optional)
    - `content` (raw transcript text)
-   - `participants[]` (array of `{ email }` objects — emails are how the
-     CLI resolves them to existing `people` records)
+   - `participants[]` — array of objects, each carrying at least one of
+     `email`, `linkedin_url`, `twitter_url`. The CLI resolves participants
+     to existing `people` records using priority email → linkedin → twitter,
+     and backfills missing identifiers on the matched record. Pass
+     whichever identifiers the source actually has — don't synthesize.
 
 5. **`## Canonical source slug`** — The string to use as `source` in the
    canonical JSON. Must be one of the values allowed by the `transcripts.source`
@@ -78,8 +81,19 @@ names into the skills:
   "duration_seconds": 1800,
   "summary":    "...",
   "content":    "<raw transcript>",
-  "participants": [{ "email": "..." }]
+  "participants": [
+    { "email": "alice@acme.com" },
+    { "linkedin_url": "linkedin.com/in/bob-jones" },
+    { "email": "carol@acme.com", "linkedin_url": "linkedin.com/in/carol" }
+  ]
 }
 ```
+
+Each participant must carry at least one of `email` / `linkedin_url` /
+`twitter_url`. The CLI returns `participants.unresolved[]` for any whose
+identifiers don't match an existing person, with a `tried` array listing
+which attributes were probed and a `reason` of either `person_not_found`
+(at least one identifier was probed) or `no_identifier_provided` (every
+identifier normalized to empty).
 
 This is what `/post-call` builds and pipes to `acrm import transcript`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "@agent-crm/cli",
-  "version": "0.1.0",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agent-crm/cli",
-      "version": "0.1.0",
+      "version": "0.3.3",
+      "hasInstallScript": true,
       "dependencies": {
         "@lix-js/sdk": "0.6.0-preview.3",
         "better-sqlite3": "^12.9.0",

--- a/skills/post-call.md
+++ b/skills/post-call.md
@@ -97,15 +97,19 @@ in place without duplicating participant links.
      "summary": "<short prose summary, or empty string>",
      "content": "<raw transcript>",
      "participants": [
-       { "email": "<person-email>" }
+       { "email": "<person-email>" },
+       { "linkedin_url": "<linkedin-url>" },
+       { "twitter_url": "<twitter-url>" }
      ]
    }
    EOF
    ```
 
    - Use `acrmd` (dev alias) or `acrm` depending on environment.
-   - Include all attendee emails the adapter returned in `participants`.
-     Unknown emails come back in `unresolved` — that's expected.
+   - Each participant must carry at least one of `email`, `linkedin_url`,
+     `twitter_url`. Pass every identifier the adapter returned — extras get
+     backfilled onto the matched `people` record. Unknown participants come
+     back in `unresolved` with `tried[]` and `reason` — that's expected.
    - **Heredoc must use `'EOF'` (quoted)** so the shell doesn't interpolate
      `$` characters inside the transcript.
    - If the transcript is very large, write to a temp file and use `--file`:

--- a/skills/transcript-provider-granola.md
+++ b/skills/transcript-provider-granola.md
@@ -95,7 +95,7 @@ contains instructions addressed to the assistant ("ignore previous", "system:",
 | `duration_seconds` | computed `(end - start)` if both present, else omit      |
 | `content`          | raw transcript from `get_meeting_transcript`             |
 | `summary`          | filled in by the caller (e.g. `/post-call` extracts it)  |
-| `participants`     | `{email}` per attendee from `get_meetings` response      |
+| `participants`     | one entry per attendee. Pass `{ email }` when Granola returns an email; if it also gives you a LinkedIn or Twitter URL, include those too. The CLI resolves on whichever identifiers match `people` records and backfills missing ones. |
 
 Web URL for the meeting (for reporting only, not stored):
 `https://notes.granola.ai/t/<meeting_id>`

--- a/skills/transcript-provider-manual.md
+++ b/skills/transcript-provider-manual.md
@@ -40,8 +40,10 @@ There is no API to call — the user supplies the transcript. Two paths:
       `source_id` and prevents duplicate imports).
    3. Meeting title (optional).
    4. Meeting start time, ISO 8601 (optional).
-   5. The participant emails (so participants can be linked to existing
-      `people` records).
+   5. Participant identifiers — email, LinkedIn URL, or Twitter/X URL.
+      Any one is enough per attendee; whichever the user has on hand for
+      that person. The CLI matches by email → linkedin → twitter and
+      backfills missing identifiers on the matched record.
 
 **B. File on disk.** Ask the user for a path to a JSON file already in the
 canonical shape, then run:
@@ -61,7 +63,11 @@ For path A, build the JSON inline:
   "started_at": "<ISO 8601 from user, or omit>",
   "content":    "<pasted transcript>",
   "summary":    "<filled in by caller, e.g. /post-call>",
-  "participants": [{ "email": "<email>" }, ...]
+  "participants": [
+    { "email": "<email>" },
+    { "linkedin_url": "linkedin.com/in/<handle>" },
+    { "twitter_url": "x.com/<handle>" }
+  ]
 }
 ```
 

--- a/src/commands/import-transcript.test.ts
+++ b/src/commands/import-transcript.test.ts
@@ -1,0 +1,461 @@
+import { describe, expect, it } from "vitest";
+import type { Lix } from "@lix-js/sdk";
+import { openTestWorkspace } from "../test/open-test-lix.js";
+import { exec } from "../db/execute.js";
+import {
+  addMultiValue,
+  insertRecord,
+  setSingleValue,
+} from "../db/upsert.js";
+import { generateUuid } from "../lib/ids.js";
+import {
+  importTranscript,
+  parsePayload,
+  type ParticipantInput,
+  type TranscriptPayload,
+} from "./import-transcript.js";
+
+type SeedPerson = {
+  email?: string;
+  emails?: string[];
+  linkedin_url?: string;
+  twitter_url?: string;
+  name?: string;
+};
+
+async function seedPerson(lix: Lix, p: SeedPerson): Promise<string> {
+  const id = await generateUuid(lix);
+  await insertRecord(lix, "people", id);
+  const source = "test";
+  const provenance = { test: true };
+  const emails = [...(p.emails ?? []), ...(p.email ? [p.email] : [])];
+  for (const e of emails) {
+    await addMultiValue(lix, {
+      object_slug: "people",
+      record_id: id,
+      attribute_slug: "email_addresses",
+      attribute_type: "email-address",
+      value: e,
+      source,
+      provenance,
+    });
+  }
+  if (p.linkedin_url) {
+    await setSingleValue(lix, {
+      object_slug: "people",
+      record_id: id,
+      attribute_slug: "linkedin_url",
+      attribute_type: "url",
+      value: p.linkedin_url,
+      source,
+      provenance,
+    });
+  }
+  if (p.twitter_url) {
+    await setSingleValue(lix, {
+      object_slug: "people",
+      record_id: id,
+      attribute_slug: "twitter_url",
+      attribute_type: "url",
+      value: p.twitter_url,
+      source,
+      provenance,
+    });
+  }
+  if (p.name) {
+    await setSingleValue(lix, {
+      object_slug: "people",
+      record_id: id,
+      attribute_slug: "name",
+      attribute_type: "personal-name",
+      value: p.name,
+      source,
+      provenance,
+    });
+  }
+  return id;
+}
+
+async function emailsFor(lix: Lix, personId: string): Promise<string[]> {
+  const r = await exec(
+    lix,
+    `SELECT normalized_key FROM acrm_value
+     WHERE object_slug = 'people' AND record_id = $1
+       AND attribute_slug = 'email_addresses' AND active_until IS NULL
+     ORDER BY normalized_key`,
+    [personId],
+  );
+  return r.rows.map((row) => row.normalized_key as string);
+}
+
+async function singleValueFor(
+  lix: Lix,
+  personId: string,
+  attribute_slug: string,
+): Promise<string | null> {
+  const r = await exec(
+    lix,
+    `SELECT normalized_key FROM acrm_value
+     WHERE object_slug = 'people' AND record_id = $1
+       AND attribute_slug = $2 AND active_until IS NULL
+     LIMIT 1`,
+    [personId, attribute_slug],
+  );
+  return (r.rows[0]?.normalized_key as string | undefined) ?? null;
+}
+
+function makePayload(
+  participants: ParticipantInput[],
+  overrides: Partial<TranscriptPayload> = {},
+): TranscriptPayload {
+  return {
+    source: "granola",
+    source_id: "meeting-1",
+    title: "Test meeting",
+    started_at: "2026-05-13T15:00:00Z",
+    ended_at: "2026-05-13T15:30:00Z",
+    duration_seconds: 1800,
+    summary: "summary",
+    content: "transcript body",
+    participants,
+    ...overrides,
+  };
+}
+
+describe("parsePayload", () => {
+  it("accepts a participant with only `linkedin_url`", () => {
+    const out = parsePayload(
+      JSON.stringify({
+        source: "granola",
+        source_id: "x",
+        participants: [{ linkedin_url: "linkedin.com/in/foo" }],
+      }),
+    );
+    expect(out.participants).toEqual([
+      { linkedin_url: "linkedin.com/in/foo" },
+    ]);
+  });
+
+  it("accepts a participant with only `twitter_url`", () => {
+    const out = parsePayload(
+      JSON.stringify({
+        source: "granola",
+        source_id: "x",
+        participants: [{ twitter_url: "@foo" }],
+      }),
+    );
+    expect(out.participants).toEqual([{ twitter_url: "@foo" }]);
+  });
+
+  it("accepts every identifier on one participant", () => {
+    const out = parsePayload(
+      JSON.stringify({
+        source: "granola",
+        source_id: "x",
+        participants: [
+          {
+            email: "a@b.com",
+            linkedin_url: "linkedin.com/in/foo",
+            twitter_url: "x.com/foo",
+          },
+        ],
+      }),
+    );
+    expect(out.participants[0]).toEqual({
+      email: "a@b.com",
+      linkedin_url: "linkedin.com/in/foo",
+      twitter_url: "x.com/foo",
+    });
+  });
+
+  it("rejects a participant with no identifiers", () => {
+    expect(() =>
+      parsePayload(
+        JSON.stringify({
+          source: "granola",
+          source_id: "x",
+          participants: [{}],
+        }),
+      ),
+    ).toThrow(/at least one of/);
+  });
+
+  it("rejects a participant whose only identifier normalizes to empty", () => {
+    expect(() =>
+      parsePayload(
+        JSON.stringify({
+          source: "granola",
+          source_id: "x",
+          participants: [{ linkedin_url: "https://" }],
+        }),
+      ),
+    ).toThrow(/at least one of/);
+  });
+
+  it("rejects malformed email", () => {
+    expect(() =>
+      parsePayload(
+        JSON.stringify({
+          source: "granola",
+          source_id: "x",
+          participants: [{ email: "no-at" }],
+        }),
+      ),
+    ).toThrow(/invalid participant email/);
+  });
+});
+
+describe("importTranscript participant resolution", () => {
+  it("resolves a participant matched by email_addresses", async () => {
+    const lix = await openTestWorkspace();
+    const personId = await seedPerson(lix, {
+      email: "alice@acme.com",
+      name: "Alice",
+    });
+
+    const result = await importTranscript(
+      lix,
+      makePayload([{ email: "alice@acme.com" }]),
+    );
+
+    expect(result.participants.resolved).toHaveLength(1);
+    expect(result.participants.unresolved).toHaveLength(0);
+    expect(result.participants.resolved[0]?.person_record_id).toBe(personId);
+    expect(result.participants.resolved[0]?.matched_by).toBe(
+      "email_addresses",
+    );
+    await lix.close();
+  });
+
+  it("resolves a participant matched by linkedin_url when email is missing on record (the original bug)", async () => {
+    const lix = await openTestWorkspace();
+    const personId = await seedPerson(lix, {
+      linkedin_url: "linkedin.com/in/luis-costa-laveron-834b05177",
+      name: "Luis",
+    });
+
+    const result = await importTranscript(
+      lix,
+      makePayload([
+        {
+          email: "luis@hello-cluster.com",
+          linkedin_url: "linkedin.com/in/luis-costa-laveron-834b05177",
+        },
+      ]),
+    );
+
+    expect(result.participants.resolved).toHaveLength(1);
+    expect(result.participants.unresolved).toHaveLength(0);
+    expect(result.participants.resolved[0]?.person_record_id).toBe(personId);
+    expect(result.participants.resolved[0]?.matched_by).toBe("linkedin_url");
+    await lix.close();
+  });
+
+  it("resolves a participant matched by twitter_url", async () => {
+    const lix = await openTestWorkspace();
+    const personId = await seedPerson(lix, {
+      twitter_url: "x.com/carol",
+      name: "Carol",
+    });
+
+    const result = await importTranscript(
+      lix,
+      makePayload([{ twitter_url: "@carol" }]),
+    );
+
+    expect(result.participants.resolved[0]?.person_record_id).toBe(personId);
+    expect(result.participants.resolved[0]?.matched_by).toBe("twitter_url");
+    await lix.close();
+  });
+
+  it("backfills a missing email onto a person matched by linkedin_url", async () => {
+    const lix = await openTestWorkspace();
+    const personId = await seedPerson(lix, {
+      linkedin_url: "linkedin.com/in/luis",
+    });
+    expect(await emailsFor(lix, personId)).toEqual([]);
+
+    const result = await importTranscript(
+      lix,
+      makePayload([
+        {
+          email: "luis@cluster.com",
+          linkedin_url: "linkedin.com/in/luis",
+        },
+      ]),
+    );
+
+    expect(result.participants.resolved[0]?.backfilled).toContain(
+      "email_addresses",
+    );
+    expect(await emailsFor(lix, personId)).toEqual(["luis@cluster.com"]);
+    await lix.close();
+  });
+
+  it("does not duplicate an email that the person already has", async () => {
+    const lix = await openTestWorkspace();
+    const personId = await seedPerson(lix, {
+      email: "alice@acme.com",
+      linkedin_url: "linkedin.com/in/alice",
+    });
+
+    const result = await importTranscript(
+      lix,
+      makePayload([
+        {
+          email: "alice@acme.com",
+          linkedin_url: "linkedin.com/in/alice",
+        },
+      ]),
+    );
+
+    expect(result.participants.resolved[0]?.backfilled).toEqual([]);
+    expect(await emailsFor(lix, personId)).toEqual(["alice@acme.com"]);
+    await lix.close();
+  });
+
+  it("backfills linkedin_url when matched by email and the person has no linkedin on file", async () => {
+    const lix = await openTestWorkspace();
+    const personId = await seedPerson(lix, { email: "bob@acme.com" });
+    expect(await singleValueFor(lix, personId, "linkedin_url")).toBeNull();
+
+    const result = await importTranscript(
+      lix,
+      makePayload([
+        {
+          email: "bob@acme.com",
+          linkedin_url: "linkedin.com/in/bob",
+        },
+      ]),
+    );
+
+    expect(result.participants.resolved[0]?.backfilled).toContain(
+      "linkedin_url",
+    );
+    expect(await singleValueFor(lix, personId, "linkedin_url")).toBe(
+      "linkedin.com/in/bob",
+    );
+    await lix.close();
+  });
+
+  it("does not clobber an existing linkedin_url that disagrees with the payload", async () => {
+    const lix = await openTestWorkspace();
+    const personId = await seedPerson(lix, {
+      email: "bob@acme.com",
+      linkedin_url: "linkedin.com/in/bob-curated",
+    });
+
+    const result = await importTranscript(
+      lix,
+      makePayload([
+        {
+          email: "bob@acme.com",
+          linkedin_url: "linkedin.com/in/bob-from-meeting",
+        },
+      ]),
+    );
+
+    expect(result.participants.resolved[0]?.backfilled).not.toContain(
+      "linkedin_url",
+    );
+    expect(await singleValueFor(lix, personId, "linkedin_url")).toBe(
+      "linkedin.com/in/bob-curated",
+    );
+    await lix.close();
+  });
+
+  it("marks unknown participants as unresolved with tried[] and reason", async () => {
+    const lix = await openTestWorkspace();
+
+    const result = await importTranscript(
+      lix,
+      makePayload([
+        {
+          email: "ghost@nowhere.com",
+          linkedin_url: "linkedin.com/in/ghost",
+        },
+      ]),
+    );
+
+    expect(result.participants.resolved).toHaveLength(0);
+    expect(result.participants.unresolved).toHaveLength(1);
+    const u = result.participants.unresolved[0]!;
+    expect(u.reason).toBe("person_not_found");
+    expect(u.tried).toEqual(["email_addresses", "linkedin_url"]);
+    expect(u.identifiers.email).toBe("ghost@nowhere.com");
+    expect(u.identifiers.linkedin_url).toBe("linkedin.com/in/ghost");
+    await lix.close();
+  });
+
+  it("upserts the transcript record and is idempotent across re-imports", async () => {
+    const lix = await openTestWorkspace();
+    const personId = await seedPerson(lix, { email: "alice@acme.com" });
+
+    const first = await importTranscript(
+      lix,
+      makePayload([{ email: "alice@acme.com" }]),
+    );
+    expect(first.created).toBe(true);
+
+    const second = await importTranscript(
+      lix,
+      makePayload([{ email: "alice@acme.com" }]),
+    );
+    expect(second.created).toBe(false);
+    expect(second.transcript_record_id).toBe(first.transcript_record_id);
+
+    // Participant link is not duplicated.
+    const links = await exec(
+      lix,
+      `SELECT COUNT(*) AS n FROM acrm_value
+       WHERE object_slug = 'transcripts' AND record_id = $1
+         AND attribute_slug = 'participants'
+         AND ref_object = 'people' AND ref_record_id = $2
+         AND active_until IS NULL`,
+      [first.transcript_record_id, personId],
+    );
+    expect(Number(links.rows[0]?.n)).toBe(1);
+
+    // Reverse link is not duplicated either.
+    const inv = await exec(
+      lix,
+      `SELECT COUNT(*) AS n FROM acrm_value
+       WHERE object_slug = 'people' AND record_id = $1
+         AND attribute_slug = 'associated_transcripts'
+         AND ref_object = 'transcripts' AND ref_record_id = $2
+         AND active_until IS NULL`,
+      [personId, first.transcript_record_id],
+    );
+    expect(Number(inv.rows[0]?.n)).toBe(1);
+    await lix.close();
+  });
+
+  it("email priority wins even when the payload also carries a stale linkedin", async () => {
+    const lix = await openTestWorkspace();
+    const aliceById = await seedPerson(lix, {
+      email: "alice@acme.com",
+      name: "Alice",
+    });
+    // Different person who happens to have the same LinkedIn URL we'll pass.
+    await seedPerson(lix, {
+      linkedin_url: "linkedin.com/in/wrong",
+      name: "Someone else",
+    });
+
+    const result = await importTranscript(
+      lix,
+      makePayload([
+        {
+          email: "alice@acme.com",
+          linkedin_url: "linkedin.com/in/wrong",
+        },
+      ]),
+    );
+
+    expect(result.participants.resolved[0]?.person_record_id).toBe(aliceById);
+    expect(result.participants.resolved[0]?.matched_by).toBe(
+      "email_addresses",
+    );
+    await lix.close();
+  });
+});

--- a/src/commands/import-transcript.ts
+++ b/src/commands/import-transcript.ts
@@ -13,10 +13,20 @@ import {
   insertRecord,
   setSingleValue,
 } from "../db/upsert.js";
+import {
+  normalizeIdentifiers,
+  resolvePersonByIdentifiers,
+  type IdentifierAttribute,
+  type NormalizedIdentifiers,
+} from "../domain/resolve-person.js";
 
-type Participant = { email: string };
+export type ParticipantInput = {
+  email?: string;
+  linkedin_url?: string;
+  twitter_url?: string;
+};
 
-type TranscriptPayload = {
+export type TranscriptPayload = {
   source: string;
   source_id: string;
   title?: string;
@@ -25,7 +35,38 @@ type TranscriptPayload = {
   duration_seconds?: number;
   summary?: string;
   content?: string;
-  participants: Participant[];
+  participants: ParticipantInput[];
+};
+
+export type ResolvedParticipant = {
+  person_record_id: string;
+  matched_by: IdentifierAttribute;
+  matched_key: string;
+  identifiers: ParticipantIdentifiersOut;
+  backfilled: IdentifierAttribute[];
+};
+
+export type UnresolvedParticipant = {
+  identifiers: ParticipantIdentifiersOut;
+  reason: "person_not_found" | "no_identifier_provided";
+  tried: IdentifierAttribute[];
+};
+
+type ParticipantIdentifiersOut = {
+  email?: string;
+  linkedin_url?: string;
+  twitter_url?: string;
+};
+
+export type TranscriptImportResult = {
+  transcript_record_id: string;
+  created: boolean;
+  source: string;
+  source_id: string;
+  participants: {
+    resolved: ResolvedParticipant[];
+    unresolved: UnresolvedParticipant[];
+  };
 };
 
 type Opts = {
@@ -36,7 +77,7 @@ export function attachTranscriptSubcommand(parent: Command): void {
   parent
     .command("transcript")
     .description(
-      "Import a meeting transcript from canonical JSON (stdin or --file). Use after a call to log Granola/Zoom/Meet transcripts into the workspace. Upserts a `transcripts` record (deduped by `source_id`), resolves each participant by email against `people.email_addresses`, and links them via `transcripts.participants` + `people.associated_transcripts`. Participant emails not found in `.acrm` are reported in `unresolved`.",
+      "Import a meeting transcript from canonical JSON (stdin or --file). Use after a call to log Granola/Zoom/Meet transcripts into the workspace. Upserts a `transcripts` record (deduped by `source_id`), resolves each participant by any of email / LinkedIn URL / Twitter URL (in that priority), and links them via `transcripts.participants` + `people.associated_transcripts`. Participants whose identifiers don't match an existing person are reported in `unresolved`.",
     )
     .option("--file <path>", "read JSON from file instead of stdin")
     .addHelpText(
@@ -52,8 +93,17 @@ Input shape (JSON):
     "duration_seconds": 1800,
     "summary": "...",
     "content":  "<raw transcript>",
-    "participants": [{ "email": "alice@acme.com" }, ...]   (required, non-empty)
+    "participants": [
+      { "email": "alice@acme.com" },
+      { "linkedin_url": "linkedin.com/in/bob-jones" },
+      { "email": "carol@acme.com", "linkedin_url": "linkedin.com/in/carol" }
+    ]                                       (required, non-empty)
   }
+
+Each participant must carry at least one of email / linkedin_url / twitter_url.
+Resolution priority: email_addresses → linkedin_url → twitter_url. If a person
+is matched by LinkedIn/Twitter and the payload also carried an email (or other
+identifier) the record doesn't have yet, the missing identifier is backfilled.
 
 Examples:
   cat transcript.json | acrm import transcript
@@ -85,7 +135,7 @@ source_id, scalar fields are updated in place, and participant links dedupe.
 async function runImportTranscript(opts: {
   workspace?: string;
   file?: string;
-}) {
+}): Promise<TranscriptImportResult> {
   const raw = opts.file
     ? await readFile(path.resolve(opts.file), "utf8")
     : await readStdin();
@@ -113,36 +163,148 @@ async function runImportTranscript(opts: {
 
   const lix = await openWorkspace({ workspace: workspaceFile });
   try {
-    const resolved: { email: string; person_record_id: string }[] = [];
-    const unresolved: { email: string; reason: string }[] = [];
-    for (const p of payload.participants) {
-      const normalized = p.email.trim().toLowerCase();
-      const personId = await findRecordByUnique(
-        lix,
-        "people",
-        "email_addresses",
-        normalized,
-      );
-      if (personId) resolved.push({ email: normalized, person_record_id: personId });
-      else unresolved.push({ email: normalized, reason: "person_not_found" });
-    }
-
-    const { transcriptId, created } = await upsertTranscript(lix, payload);
-
-    for (const r of resolved) {
-      await linkParticipant(lix, transcriptId, r.person_record_id, payload.source);
-    }
-
-    return {
-      transcript_record_id: transcriptId,
-      created,
-      source: payload.source,
-      source_id: payload.source_id,
-      participants: { resolved, unresolved },
-    };
+    return await importTranscript(lix, payload);
   } finally {
     await lix.close();
   }
+}
+
+// Exposed for tests and for programmatic callers that already hold a Lix.
+export async function importTranscript(
+  lix: Lix,
+  payload: TranscriptPayload,
+): Promise<TranscriptImportResult> {
+  const resolved: ResolvedParticipant[] = [];
+  const unresolved: UnresolvedParticipant[] = [];
+
+  for (const p of payload.participants) {
+    const result = await resolvePersonByIdentifiers(
+      (attr, key) => findRecordByUnique(lix, "people", attr, key),
+      { email: p.email, linkedin_url: p.linkedin_url, twitter_url: p.twitter_url },
+    );
+
+    const identifiersOut = normalizedToOut(result.normalized);
+
+    if (result.person_record_id && result.matched_by && result.matched_key) {
+      const backfilled = await backfillIdentifiers(
+        lix,
+        result.person_record_id,
+        result.normalized,
+        result.matched_by,
+        payload.source,
+      );
+      resolved.push({
+        person_record_id: result.person_record_id,
+        matched_by: result.matched_by,
+        matched_key: result.matched_key,
+        identifiers: identifiersOut,
+        backfilled,
+      });
+    } else {
+      unresolved.push({
+        identifiers: identifiersOut,
+        reason:
+          result.tried.length === 0
+            ? "no_identifier_provided"
+            : "person_not_found",
+        tried: result.tried,
+      });
+    }
+  }
+
+  const { transcriptId, created } = await upsertTranscript(lix, payload);
+
+  for (const r of resolved) {
+    await linkParticipant(lix, transcriptId, r.person_record_id, payload.source);
+  }
+
+  return {
+    transcript_record_id: transcriptId,
+    created,
+    source: payload.source,
+    source_id: payload.source_id,
+    participants: { resolved, unresolved },
+  };
+}
+
+function normalizedToOut(
+  n: NormalizedIdentifiers,
+): ParticipantIdentifiersOut {
+  const out: ParticipantIdentifiersOut = {};
+  if (n.emails[0]) out.email = n.emails[0];
+  if (n.linkedin_url) out.linkedin_url = n.linkedin_url;
+  if (n.twitter_url) out.twitter_url = n.twitter_url;
+  return out;
+}
+
+// When a transcript carries identifiers that the matched person doesn't yet
+// have on file, fill them in. This closes the loop on the original bug: a
+// person matched by LinkedIn whose email the meeting provider supplied gets
+// that email added to their record. Single-value attributes (linkedin_url,
+// twitter_url) are only set when currently empty — we never clobber a value
+// the user has curated.
+async function backfillIdentifiers(
+  lix: Lix,
+  personId: string,
+  normalized: NormalizedIdentifiers,
+  matchedBy: IdentifierAttribute,
+  importSource: string,
+): Promise<IdentifierAttribute[]> {
+  const backfilled: IdentifierAttribute[] = [];
+  const source = `transcript-import:${importSource}`;
+  const provenance = {
+    backfilled_at: new Date().toISOString(),
+    matched_by: matchedBy,
+  };
+
+  for (const email of normalized.emails) {
+    const existing = await exec(
+      lix,
+      `SELECT 1 FROM acrm_value
+       WHERE object_slug = 'people' AND record_id = $1
+         AND attribute_slug = 'email_addresses'
+         AND normalized_key = $2
+         AND active_until IS NULL LIMIT 1`,
+      [personId, email],
+    );
+    if (existing.rows.length) continue;
+    await addMultiValue(lix, {
+      object_slug: "people",
+      record_id: personId,
+      attribute_slug: "email_addresses",
+      attribute_type: "email-address",
+      value: email,
+      source,
+      provenance,
+    });
+    backfilled.push("email_addresses");
+  }
+
+  for (const attr of ["linkedin_url", "twitter_url"] as const) {
+    const key = normalized[attr];
+    if (!key) continue;
+    const existing = await exec(
+      lix,
+      `SELECT 1 FROM acrm_value
+       WHERE object_slug = 'people' AND record_id = $1
+         AND attribute_slug = $2
+         AND active_until IS NULL LIMIT 1`,
+      [personId, attr],
+    );
+    if (existing.rows.length) continue;
+    await setSingleValue(lix, {
+      object_slug: "people",
+      record_id: personId,
+      attribute_slug: attr,
+      attribute_type: "url",
+      value: key,
+      source,
+      provenance,
+    });
+    backfilled.push(attr);
+  }
+
+  return backfilled;
 }
 
 function parsePayload(raw: string): TranscriptPayload {
@@ -172,20 +334,55 @@ function parsePayload(raw: string): TranscriptPayload {
       ERR.INVALID_INPUT,
     );
   }
-  const participants: Participant[] = [];
+  const participants: ParticipantInput[] = [];
   for (const item of participantsRaw) {
-    if (!item || typeof item !== "object")
+    if (!item || typeof item !== "object") {
       throw new AcrmError(
-        "each participant must be an object with `email`",
+        "each participant must be an object with at least one of `email`, `linkedin_url`, `twitter_url`",
         ERR.INVALID_INPUT,
       );
-    const email = (item as Record<string, unknown>).email;
-    if (typeof email !== "string" || !email.includes("@"))
+    }
+    const rec = item as Record<string, unknown>;
+    const out: ParticipantInput = {};
+
+    if (rec.email !== undefined) {
+      if (typeof rec.email !== "string" || !rec.email.includes("@")) {
+        throw new AcrmError(
+          `invalid participant email: ${JSON.stringify(rec.email)}`,
+          ERR.INVALID_INPUT,
+        );
+      }
+      out.email = rec.email;
+    }
+    if (rec.linkedin_url !== undefined) {
+      if (typeof rec.linkedin_url !== "string" || !rec.linkedin_url.trim()) {
+        throw new AcrmError(
+          `invalid participant linkedin_url: ${JSON.stringify(rec.linkedin_url)}`,
+          ERR.INVALID_INPUT,
+        );
+      }
+      out.linkedin_url = rec.linkedin_url;
+    }
+    if (rec.twitter_url !== undefined) {
+      if (typeof rec.twitter_url !== "string" || !rec.twitter_url.trim()) {
+        throw new AcrmError(
+          `invalid participant twitter_url: ${JSON.stringify(rec.twitter_url)}`,
+          ERR.INVALID_INPUT,
+        );
+      }
+      out.twitter_url = rec.twitter_url;
+    }
+
+    // After normalization, every identifier must produce at least one usable
+    // key — otherwise the participant entry would be pure noise.
+    const probe = normalizeIdentifiers(out);
+    if (!probe.emails.length && !probe.linkedin_url && !probe.twitter_url) {
       throw new AcrmError(
-        `invalid participant email: ${JSON.stringify(email)}`,
+        "each participant must carry at least one of `email`, `linkedin_url`, `twitter_url`",
         ERR.INVALID_INPUT,
       );
-    participants.push({ email });
+    }
+    participants.push(out);
   }
   return {
     source,
@@ -292,7 +489,6 @@ async function linkParticipant(
   const source = `transcript-import:${importSource}`;
   const provenance = { linked_at: new Date().toISOString() };
 
-  // transcripts.participants -> person (skip if already linked)
   const fwd = await exec(
     lix,
     `SELECT 1 FROM acrm_value
@@ -314,7 +510,6 @@ async function linkParticipant(
     });
   }
 
-  // people.associated_transcripts -> transcript (skip if already linked)
   const inv = await exec(
     lix,
     `SELECT 1 FROM acrm_value
@@ -345,3 +540,6 @@ async function readStdin(): Promise<string> {
   }
   return Buffer.concat(chunks).toString("utf8");
 }
+
+// Re-exported for tests that want to exercise parsing alone.
+export { parsePayload };

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -16,11 +16,10 @@ import {
   normalizeUniqueKey,
   normalizeDomain,
   domainFromEmail,
-  normalizeLinkedinUrl,
-  normalizeTwitterUrl,
   type AttributeConfig,
   type AttributeType,
 } from "../domain/values.js";
+import { resolvePersonByIdentifiers } from "../domain/resolve-person.js";
 
 type CsvRow = Record<string, string>;
 
@@ -685,22 +684,21 @@ async function importRow(
     }
   }
 
-  // person — identified by email, then LinkedIn URL, then Twitter/X URL
+  // person — identified by email, then LinkedIn URL, then Twitter/X URL.
+  // Cascade lives in resolvePersonByIdentifiers (shared with transcript import).
   let personId: string | null = null;
-  const linkedinKey = linkedin ? normalizeLinkedinUrl(linkedin) : null;
-  const twitterKey = twitter ? normalizeTwitterUrl(twitter) : null;
+  const personLookup = await resolvePersonByIdentifiers(
+    (attr, key) => findRecordByUnique(lix, cache, "people", attr, key),
+    {
+      emails,
+      linkedin_url: linkedin ?? undefined,
+      twitter_url: twitter ?? undefined,
+    },
+  );
+  const linkedinKey = personLookup.normalized.linkedin_url;
+  const twitterKey = personLookup.normalized.twitter_url;
   if (emails.length || linkedinKey || twitterKey) {
-    for (const e of emails) {
-      const normalized = e.trim().toLowerCase();
-      personId = await findRecordByUnique(lix, cache, "people", "email_addresses", normalized);
-      if (personId) break;
-    }
-    if (!personId && linkedinKey) {
-      personId = await findRecordByUnique(lix, cache, "people", "linkedin_url", linkedinKey);
-    }
-    if (!personId && twitterKey) {
-      personId = await findRecordByUnique(lix, cache, "people", "twitter_url", twitterKey);
-    }
+    personId = personLookup.person_record_id;
     let personIsFresh = false;
     if (!personId) {
       personIsFresh = true;

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -80,7 +80,7 @@ const ATTRIBUTES: AttributeSeed[] = [
   { object_slug: "transcripts", attribute_slug: "participants", title: "Participants", attribute_type: "record-reference", is_multivalued: true, is_unique: false, config: { target_object: "people", inverse: "associated_transcripts" } },
 ];
 
-async function seedObjects(lix: Lix): Promise<void> {
+export async function seedObjects(lix: Lix): Promise<void> {
   for (const o of OBJECTS) {
     const have = await exec(
       lix,
@@ -96,7 +96,7 @@ async function seedObjects(lix: Lix): Promise<void> {
   }
 }
 
-async function seedAttributes(lix: Lix): Promise<void> {
+export async function seedAttributes(lix: Lix): Promise<void> {
   for (const a of ATTRIBUTES) {
     const have = await exec(
       lix,

--- a/src/domain/resolve-person.test.ts
+++ b/src/domain/resolve-person.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  normalizeIdentifiers,
+  resolvePersonByIdentifiers,
+  type IdentifierAttribute,
+  type Lookup,
+} from "./resolve-person.js";
+
+function makeLookup(
+  table: Partial<Record<IdentifierAttribute, Record<string, string>>>,
+): { fn: Lookup; calls: { attr: IdentifierAttribute; key: string }[] } {
+  const calls: { attr: IdentifierAttribute; key: string }[] = [];
+  const fn: Lookup = async (attr, key) => {
+    calls.push({ attr, key });
+    return table[attr]?.[key] ?? null;
+  };
+  return { fn, calls };
+}
+
+describe("normalizeIdentifiers", () => {
+  it("lowercases and trims emails, requires @, dedupes", () => {
+    expect(
+      normalizeIdentifiers({
+        emails: ["  Alice@Example.com ", "alice@example.com", "no-at"],
+      }),
+    ).toEqual({
+      emails: ["alice@example.com"],
+      linkedin_url: null,
+      twitter_url: null,
+    });
+  });
+
+  it("accepts a single `email` field for transcript callers", () => {
+    expect(normalizeIdentifiers({ email: "Bob@Acme.com" })).toEqual({
+      emails: ["bob@acme.com"],
+      linkedin_url: null,
+      twitter_url: null,
+    });
+  });
+
+  it("merges `email` and `emails` without duplicates", () => {
+    expect(
+      normalizeIdentifiers({
+        email: "shared@x.com",
+        emails: ["shared@x.com", "other@x.com"],
+      }),
+    ).toEqual({
+      emails: ["shared@x.com", "other@x.com"],
+      linkedin_url: null,
+      twitter_url: null,
+    });
+  });
+
+  it("normalizes linkedin and twitter URLs", () => {
+    expect(
+      normalizeIdentifiers({
+        linkedin_url: "https://www.LinkedIn.com/in/Foo/?utm=1",
+        twitter_url: "@Bar",
+      }),
+    ).toEqual({
+      emails: [],
+      linkedin_url: "linkedin.com/in/foo",
+      twitter_url: "x.com/bar",
+    });
+  });
+
+  it("returns null for whitespace-only urls", () => {
+    expect(
+      normalizeIdentifiers({ linkedin_url: "   ", twitter_url: "   " }),
+    ).toEqual({ emails: [], linkedin_url: null, twitter_url: null });
+  });
+});
+
+describe("resolvePersonByIdentifiers", () => {
+  it("matches by email and short-circuits before linkedin/twitter", async () => {
+    const { fn, calls } = makeLookup({
+      email_addresses: { "alice@acme.com": "person-1" },
+      linkedin_url: { "linkedin.com/in/alice": "person-2" }, // wrong record
+    });
+    const result = await resolvePersonByIdentifiers(fn, {
+      email: "alice@acme.com",
+      linkedin_url: "linkedin.com/in/alice",
+    });
+    expect(result.person_record_id).toBe("person-1");
+    expect(result.matched_by).toBe("email_addresses");
+    expect(result.tried).toEqual(["email_addresses"]);
+    // Cascade stopped after the email hit — linkedin/twitter never probed.
+    expect(calls).toEqual([
+      { attr: "email_addresses", key: "alice@acme.com" },
+    ]);
+  });
+
+  it("falls through to linkedin when email misses", async () => {
+    const { fn, calls } = makeLookup({
+      linkedin_url: { "linkedin.com/in/bob": "person-2" },
+    });
+    const result = await resolvePersonByIdentifiers(fn, {
+      email: "ghost@nowhere.com",
+      linkedin_url: "linkedin.com/in/bob",
+    });
+    expect(result.person_record_id).toBe("person-2");
+    expect(result.matched_by).toBe("linkedin_url");
+    expect(result.tried).toEqual(["email_addresses", "linkedin_url"]);
+    expect(calls.map((c) => c.attr)).toEqual([
+      "email_addresses",
+      "linkedin_url",
+    ]);
+  });
+
+  it("falls through to twitter when email and linkedin miss", async () => {
+    const { fn } = makeLookup({
+      twitter_url: { "x.com/carol": "person-3" },
+    });
+    const result = await resolvePersonByIdentifiers(fn, {
+      email: "ghost@nowhere.com",
+      linkedin_url: "linkedin.com/in/ghost",
+      twitter_url: "@carol",
+    });
+    expect(result.person_record_id).toBe("person-3");
+    expect(result.matched_by).toBe("twitter_url");
+    expect(result.matched_key).toBe("x.com/carol");
+    expect(result.tried).toEqual([
+      "email_addresses",
+      "linkedin_url",
+      "twitter_url",
+    ]);
+  });
+
+  it("returns null with reason context when nothing matches", async () => {
+    const { fn } = makeLookup({});
+    const result = await resolvePersonByIdentifiers(fn, {
+      email: "ghost@nowhere.com",
+      linkedin_url: "linkedin.com/in/ghost",
+    });
+    expect(result.person_record_id).toBeNull();
+    expect(result.matched_by).toBeNull();
+    expect(result.tried).toEqual(["email_addresses", "linkedin_url"]);
+  });
+
+  it("treats no identifiers as `tried: []` (caller distinguishes reason)", async () => {
+    const lookup = vi.fn();
+    const result = await resolvePersonByIdentifiers(lookup, {});
+    expect(result.person_record_id).toBeNull();
+    expect(result.tried).toEqual([]);
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it("ignores identifiers that normalize to null (only @-bearing emails count)", async () => {
+    const lookup = vi.fn();
+    const result = await resolvePersonByIdentifiers(lookup, {
+      email: "no-at-sign",
+    });
+    expect(result.person_record_id).toBeNull();
+    expect(result.tried).toEqual([]);
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it("tries every email before falling through", async () => {
+    const { fn, calls } = makeLookup({
+      email_addresses: { "second@acme.com": "person-1" },
+    });
+    const result = await resolvePersonByIdentifiers(fn, {
+      emails: ["first@acme.com", "second@acme.com"],
+      linkedin_url: "linkedin.com/in/x",
+    });
+    expect(result.person_record_id).toBe("person-1");
+    expect(result.matched_key).toBe("second@acme.com");
+    expect(calls.map((c) => c.key)).toEqual([
+      "first@acme.com",
+      "second@acme.com",
+    ]);
+  });
+});

--- a/src/domain/resolve-person.ts
+++ b/src/domain/resolve-person.ts
@@ -1,0 +1,125 @@
+import { normalizeLinkedinUrl, normalizeTwitterUrl } from "./values.js";
+
+export type PersonIdentifiers = {
+  emails?: readonly string[];
+  email?: string;
+  linkedin_url?: string;
+  twitter_url?: string;
+};
+
+export type IdentifierAttribute =
+  | "email_addresses"
+  | "linkedin_url"
+  | "twitter_url";
+
+export type NormalizedIdentifiers = {
+  emails: string[];
+  linkedin_url: string | null;
+  twitter_url: string | null;
+};
+
+export type Lookup = (
+  attribute_slug: IdentifierAttribute,
+  normalized_key: string,
+) => Promise<string | null>;
+
+export type ResolveResult = {
+  person_record_id: string | null;
+  matched_by: IdentifierAttribute | null;
+  matched_key: string | null;
+  tried: IdentifierAttribute[];
+  normalized: NormalizedIdentifiers;
+};
+
+// Why this exists: both /post-call (transcript import) and `acrm import csv`
+// resolve people by the same priority — email → linkedin → twitter — but they
+// used to implement the cascade independently. The CSV path had all three; the
+// transcript path was email-only, so a meeting attendee whose record carried
+// only a LinkedIn URL would silently land in `unresolved`. Funnel both through
+// this so the next identifier added (phone, handle, …) lands in one place.
+export function normalizeIdentifiers(
+  ids: PersonIdentifiers,
+): NormalizedIdentifiers {
+  const seen = new Set<string>();
+  const emails: string[] = [];
+  const candidates: string[] = [];
+  if (ids.email != null) candidates.push(ids.email);
+  if (ids.emails) for (const e of ids.emails) candidates.push(e);
+  for (const raw of candidates) {
+    if (typeof raw !== "string") continue;
+    const s = raw.trim().toLowerCase();
+    if (!s || !s.includes("@")) continue;
+    if (seen.has(s)) continue;
+    seen.add(s);
+    emails.push(s);
+  }
+  return {
+    emails,
+    linkedin_url: ids.linkedin_url
+      ? normalizeLinkedinUrl(ids.linkedin_url)
+      : null,
+    twitter_url: ids.twitter_url
+      ? normalizeTwitterUrl(ids.twitter_url)
+      : null,
+  };
+}
+
+export async function resolvePersonByIdentifiers(
+  lookup: Lookup,
+  ids: PersonIdentifiers,
+): Promise<ResolveResult> {
+  const normalized = normalizeIdentifiers(ids);
+  const tried: IdentifierAttribute[] = [];
+
+  if (normalized.emails.length) {
+    for (const email of normalized.emails) {
+      const hit = await lookup("email_addresses", email);
+      if (hit) {
+        return {
+          person_record_id: hit,
+          matched_by: "email_addresses",
+          matched_key: email,
+          tried: ["email_addresses"],
+          normalized,
+        };
+      }
+    }
+    tried.push("email_addresses");
+  }
+
+  if (normalized.linkedin_url) {
+    const hit = await lookup("linkedin_url", normalized.linkedin_url);
+    tried.push("linkedin_url");
+    if (hit) {
+      return {
+        person_record_id: hit,
+        matched_by: "linkedin_url",
+        matched_key: normalized.linkedin_url,
+        tried,
+        normalized,
+      };
+    }
+  }
+
+  if (normalized.twitter_url) {
+    const hit = await lookup("twitter_url", normalized.twitter_url);
+    tried.push("twitter_url");
+    if (hit) {
+      return {
+        person_record_id: hit,
+        matched_by: "twitter_url",
+        matched_key: normalized.twitter_url,
+        tried,
+        normalized,
+      };
+    }
+  }
+
+  return {
+    person_record_id: null,
+    matched_by: null,
+    matched_key: null,
+    tried,
+    normalized,
+  };
+}

--- a/src/test/open-test-lix.ts
+++ b/src/test/open-test-lix.ts
@@ -1,6 +1,7 @@
 import { openLix, type Lix } from "@lix-js/sdk";
 import { createBetterSqlite3Backend } from "@lix-js/sdk/sqlite";
 import { registerAllSchemas } from "../workspace/schemas/index.js";
+import { seedAttributes, seedObjects } from "../commands/init.js";
 
 export async function openTestLix(): Promise<Lix> {
   const lix = await openLix({
@@ -8,5 +9,15 @@ export async function openTestLix(): Promise<Lix> {
   });
 
   await registerAllSchemas(lix);
+  return lix;
+}
+
+// Same lix as openTestLix plus the objects + attributes that `acrm init`
+// seeds. Use this for tests that exercise import paths or any code that
+// reads attribute config (encode/decode, status options, etc.).
+export async function openTestWorkspace(): Promise<Lix> {
+  const lix = await openTestLix();
+  await seedObjects(lix);
+  await seedAttributes(lix);
   return lix;
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add multi-identifier person resolution (email, LinkedIn, Twitter) to transcript import
- Introduces `resolvePersonByIdentifiers` in [`src/domain/resolve-person.ts`](https://github.com/cluster-software/agent-crm/pull/33/files#diff-981878d1871659eeadaea8ce412ecec6c9205da854c84b2787a26699378a1653) to centralize person lookup with an email → LinkedIn → Twitter cascade, replacing ad-hoc inline lookups.
- Transcript import now accepts participants with any combination of `email`, `linkedin_url`, and `twitter_url`; unresolved participants include `tried[]` and `reason` (`person_not_found` or `no_identifier_provided`).
- On a successful match, missing identifiers are backfilled onto the person record without clobbering existing single-value attributes.
- `import-transcript` command and `import` command both now use the shared resolver, ensuring consistent normalization and cascade behavior.
- Adds unit tests for `normalizeIdentifiers`/`resolvePersonByIdentifiers` and integration tests covering resolution, backfill, deduplication, and idempotent re-import.

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized fbfc893. 8 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues

</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->