### PR TITLE
fixing acrm auth granola fix

### DIFF
--- a/.changeset/granola-auth-dcr-and-browser-open.md
+++ b/.changeset/granola-auth-dcr-and-browser-open.md
@@ -1,0 +1,17 @@
+---
+"@agent-crm/cli": patch
+---
+
+Fix `acrm auth granola` — Dynamic Client Registration + auto-open browser.
+
+Two bugs were stacking on top of each other.
+
+**Bug 1: hardcoded `client_id` was never registered with Granola.** The provider config hardcoded `client_id=acrm-cli`, but Granola's MCP OAuth server requires RFC 7591 Dynamic Client Registration (advertised via `registration_endpoint` in the discovery doc). The authorize URL returned `application_not_found` and the flow died before the user could even consent.
+
+The auth flow now POSTs to the discovery doc's `registration_endpoint` (with the actual loopback `redirect_uri` for this run) whenever the provider didn't supply a static `clientId`, gets back a fresh `client_id`, and uses it for the authorize + token-exchange steps. The registered `client_id` (and `client_secret`, if any) is persisted alongside the token in `~/.config/acrm/<provider>.json` so future refresh-token exchanges reuse the same client identity.
+
+The provider config now treats `clientId` as optional. `ACRM_GRANOLA_CLIENT_ID` still overrides DCR if you have a pre-registered public client. For every other provider, leaving `clientId` unset opts into DCR automatically — adapters with no `registration_endpoint` get a clear error pointing at the env var or `--token` escape hatch.
+
+**Bug 2: `! acrm auth granola` from inside Claude Code never showed the URL.** Claude Code's bash tool buffers stdout/stderr until the command exits. The auth command blocks indefinitely on the OAuth callback, so the URL never reached the screen and the user was stuck. Fixed by auto-opening the system browser (`open` / `xdg-open` / `start`) right after building the authorize URL. The URL is still printed (to stderr) as a fallback for headless environments.
+
+**Touched files.** `src/commands/auth.ts` (DCR call site, `registerClient()` helper, browser auto-open), `src/integrations/provider.ts` (`clientId` made optional, comment updated), `src/integrations/granola.ts` (drop the bogus `acrm-cli` default), `src/lib/token-cache.ts` (`CachedToken` carries `client_id` / `client_secret` / `registration_endpoint`).

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -1,5 +1,6 @@
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
+import { spawn } from "node:child_process";
 import type { Command } from "commander";
 import { fail, ok, setJsonMode, isJson } from "../output/json.js";
 import { AcrmError, ERR } from "../lib/errors.js";
@@ -19,6 +20,12 @@ import type { TranscriptProvider } from "../integrations/provider.js";
 type AuthMetadata = {
   authorization_endpoint?: string;
   token_endpoint?: string;
+  registration_endpoint?: string;
+};
+
+type RegistrationResponse = {
+  client_id: string;
+  client_secret?: string;
 };
 
 type AuthOpts = {
@@ -110,9 +117,30 @@ async function runProviderOAuth(
 
   const { port, captured } = await startCallbackServer(state);
   const redirect_uri = `http://127.0.0.1:${port}/callback`;
+
+  let client_id = oauth.clientId;
+  let client_secret: string | undefined;
+  if (!client_id) {
+    if (!discovery.registration_endpoint) {
+      throw new AcrmError(
+        `${provider.label} requires a client_id but its discovery doc has no registration_endpoint`,
+        ERR.IMPORT,
+        `set ACRM_${provider.name.toUpperCase()}_CLIENT_ID with a pre-registered client, or pass --token <token>`,
+      );
+    }
+    const reg = await registerClient({
+      registration_endpoint: discovery.registration_endpoint,
+      redirect_uri,
+      scope: oauth.scope,
+      provider_label: provider.label,
+    });
+    client_id = reg.client_id;
+    client_secret = reg.client_secret;
+  }
+
   const url = buildAuthorizationUrl({
     authorization_endpoint: discovery.authorization_endpoint,
-    client_id: oauth.clientId,
+    client_id,
     redirect_uri,
     scope: oauth.scope || undefined,
     state,
@@ -121,9 +149,10 @@ async function runProviderOAuth(
 
   if (!isJson()) {
     process.stderr.write(
-      `\nOpen this URL in your browser to authorize:\n\n  ${url}\n\nWaiting for the callback…\n`,
+      `\nOpening browser to authorize. If it doesn't open, paste this URL:\n\n  ${url}\n\nWaiting for the callback…\n`,
     );
   }
+  openInBrowser(url);
 
   const code = await captured;
   const tokenResp = await exchangeCodeForToken({
@@ -131,7 +160,8 @@ async function runProviderOAuth(
     code,
     redirect_uri,
     code_verifier: pkce.code_verifier,
-    client_id: oauth.clientId,
+    client_id,
+    client_secret,
   });
 
   const expires_at =
@@ -148,6 +178,9 @@ async function runProviderOAuth(
     expires_at,
     authorization_endpoint: discovery.authorization_endpoint,
     token_endpoint: discovery.token_endpoint,
+    client_id,
+    client_secret,
+    registration_endpoint: discovery.registration_endpoint,
   };
   const file = await writeToken(cached);
   return { provider: provider.name, cached_at: new Date().toISOString(), file };
@@ -174,6 +207,63 @@ async function fetchDiscovery(url: string): Promise<AuthMetadata> {
   return (await res.json()) as AuthMetadata;
 }
 
+async function registerClient(input: {
+  registration_endpoint: string;
+  redirect_uri: string;
+  scope?: string;
+  provider_label: string;
+}): Promise<RegistrationResponse> {
+  const body: Record<string, unknown> = {
+    client_name: "acrm",
+    redirect_uris: [input.redirect_uri],
+    grant_types: ["authorization_code", "refresh_token"],
+    response_types: ["code"],
+    token_endpoint_auth_method: "none",
+    application_type: "native",
+  };
+  if (input.scope) body.scope = input.scope;
+
+  let res: Response;
+  try {
+    res = await fetch(input.registration_endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (e) {
+    throw new AcrmError(
+      `failed to reach ${input.provider_label} registration endpoint: ${e instanceof Error ? e.message : String(e)}`,
+      ERR.IMPORT,
+    );
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    throw new AcrmError(
+      `${input.provider_label} dynamic client registration failed: HTTP ${res.status} ${text.slice(0, 200)}`,
+      ERR.IMPORT,
+    );
+  }
+  let parsed: RegistrationResponse;
+  try {
+    parsed = JSON.parse(text) as RegistrationResponse;
+  } catch (e) {
+    throw new AcrmError(
+      `${input.provider_label} registration returned invalid JSON: ${e instanceof Error ? e.message : String(e)}`,
+      ERR.IMPORT,
+    );
+  }
+  if (!parsed.client_id) {
+    throw new AcrmError(
+      `${input.provider_label} registration response missing client_id`,
+      ERR.IMPORT,
+    );
+  }
+  return parsed;
+}
+
 type TokenResponse = {
   access_token: string;
   token_type?: string;
@@ -188,6 +278,7 @@ async function exchangeCodeForToken(input: {
   redirect_uri: string;
   code_verifier: string;
   client_id: string;
+  client_secret?: string;
 }): Promise<TokenResponse> {
   const body = new URLSearchParams({
     grant_type: "authorization_code",
@@ -196,6 +287,7 @@ async function exchangeCodeForToken(input: {
     client_id: input.client_id,
     code_verifier: input.code_verifier,
   });
+  if (input.client_secret) body.set("client_secret", input.client_secret);
   const res = await fetch(input.token_endpoint, {
     method: "POST",
     headers: {
@@ -287,6 +379,20 @@ function startCallbackServer(
       resolveOuter({ port, captured });
     });
   });
+}
+
+function openInBrowser(url: string): void {
+  const cmd =
+    process.platform === "darwin"
+      ? "open"
+      : process.platform === "win32"
+        ? "start"
+        : "xdg-open";
+  try {
+    spawn(cmd, [url], { detached: true, stdio: "ignore" }).unref();
+  } catch {
+    // fine — user can paste the URL manually
+  }
 }
 
 // Re-export for tests.

--- a/src/integrations/granola.ts
+++ b/src/integrations/granola.ts
@@ -27,7 +27,11 @@ export const granolaProvider: TranscriptProvider = {
   fetchTranscript: (meetingId) => fetchGranolaTranscript(meetingId),
   oauth: {
     discoveryUrl: GRANOLA_DISCOVERY_URL,
-    clientId: process.env.ACRM_GRANOLA_CLIENT_ID?.trim() || "acrm-cli",
+    // Granola's MCP server requires RFC 7591 Dynamic Client Registration —
+    // there is no static public `client_id`. Leaving this undefined makes
+    // `acrm auth granola` register a fresh client per auth. Set
+    // ACRM_GRANOLA_CLIENT_ID to override with a pre-registered client.
+    clientId: process.env.ACRM_GRANOLA_CLIENT_ID?.trim() || undefined,
     scope: process.env.ACRM_GRANOLA_SCOPE?.trim() || undefined,
   },
 };

--- a/src/integrations/provider.ts
+++ b/src/integrations/provider.ts
@@ -25,9 +25,14 @@ export type TranscriptProvider = {
   // Optional OAuth 2.0 + PKCE config. Providers without OAuth (API key,
   // webhook export, manual paste) leave this unset; the `acrm auth <name>`
   // subcommand is only registered when this is present.
+  //
+  // `clientId` is optional: if absent and the discovery doc advertises a
+  // `registration_endpoint`, the auth flow performs RFC 7591 Dynamic Client
+  // Registration to obtain one. Set it explicitly to use a pre-registered
+  // public client.
   oauth?: {
     discoveryUrl: string;
-    clientId: string;
+    clientId?: string;
     scope?: string;
   };
 };

--- a/src/lib/token-cache.ts
+++ b/src/lib/token-cache.ts
@@ -11,6 +11,11 @@ export type CachedToken = {
   scope?: string;
   authorization_endpoint?: string;
   token_endpoint?: string;
+  // Populated when the auth flow obtained the client via RFC 7591 Dynamic
+  // Client Registration. Reused on refresh so we don't have to re-register.
+  client_id?: string;
+  client_secret?: string;
+  registration_endpoint?: string;
 };
 
 export function tokenCacheDir(): string {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add Dynamic Client Registration and auto-browser-open to Granola OAuth flow
- Removes the hardcoded `clientId` from the Granola provider in [granola.ts](https://github.com/cluster-software/agent-crm/pull/37/files#diff-af3a6ba97bb13cda7a2fef7e974dc5b62294af9c9de2da7b72d2b2715d28cb02); the auth flow now performs RFC 7591 Dynamic Client Registration when no `clientId` is configured.
- Adds `registerClient()` in [auth.ts](https://github.com/cluster-software/agent-crm/pull/37/files#diff-e7f669a16cb4ecffee825c7752a80d11b708e5e471aefb2f95b6f1187f8da78e) to POST to the provider's `registration_endpoint` and obtain `client_id`/`client_secret` at runtime.
- The resolved `client_id` and optional `client_secret` are passed through the authorization URL construction and token exchange, then persisted in the token cache.
- Adds `openInBrowser()` to automatically open the authorization URL in the system browser (macOS, Windows, Linux) instead of only printing it.
- Behavioral Change: Granola auth now requires network access to the registration endpoint on first use; `ACRM_GRANOLA_CLIENT_ID` env var still overrides DCR.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized d1460c3.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->