### PR TITLE
merge command

### DIFF
--- a/.changeset/merge-records-and-eav-surfacing.md
+++ b/.changeset/merge-records-and-eav-surfacing.md
@@ -1,0 +1,21 @@
+---
+"@agent-crm/cli": minor
+---
+
+Add `acrm merge` and surface the EAV schema in the CLI itself.
+
+Background: merging two duplicate `people` records (created by an `acrm import linkedin` pass and an `acrm import transcript` pass with disjoint identifier sets) used to require hand-written SQL surgery against `acrm_record` + `acrm_value` — several introspection queries, two `UPDATE acrm_value` statements, one `DELETE FROM acrm_record`, and a `SELECT * FROM people` that errored because the EAV shape isn't a per-object table. RCA recommended a merge primitive + putting the EAV model in front of every code path an agent could reach for.
+
+**`acrm merge <object> --keep <record_id> --discard <record_id>`** (new). First-class merge command. Reassigns every `acrm_value` row from the discard to the keeper, dedupes multivalued attributes by `normalized_key` (or `ref_record_id` for record-references), resolves single-valued conflicts via `--prefer keep | discard | interactive` (default `keep`), rewrites every inbound reference (both `ref_record_id` and the embedded `value_json.target_record_id`), and deletes the discarded `acrm_record` row. Supports `--dry-run` to print the plan without applying and `--json` (inherited) for machine output. Lix doesn't expose `BEGIN`/`COMMIT`, so the command is not a single SQL transaction — it validates the full plan before any mutation and is idempotent on re-run; documented in `--help`.
+
+**`acrm execute --schema`** (new flag). Dumps the workspace's full EAV layout — objects, attributes per object, type, multivalued, unique, config_json — as JSON. Cheaper than four introspection queries for an agent loading the schema once at session start.
+
+**EAV warnings in CLI help text and error hints.**
+
+- `acrm --help` top-level description now opens with a one-paragraph warning that there is no `people` / `companies` / `transcripts` table — those are `object_slug` values on `acrm_record`, with fields stored as rows in `acrm_value`. Right next to the existing "Data model:" conceptual block.
+- `acrm execute --help` gains an EAV-first section before the dialect notes: ❌/✅ examples (`SELECT * FROM people` vs `SELECT record_id FROM acrm_record WHERE object_slug='people'`), the three tables agents need to know (`acrm_record`, `acrm_value`, `acrm_attribute`), the pivot pattern for reading one record's fields, and the `active_until IS NULL` rule.
+- `LIX_TABLE_NOT_FOUND` hint upgrade. When the missing table name matches a known `object_slug` (`people`, `companies`, `deals`, `posts`, `transcripts`), the hint becomes a copy-pasteable fix that names the exact mistake: ``` `people` is an object_slug, not a table. Try: `SELECT record_id FROM acrm_record WHERE object_slug='people'`. To read fields, pivot from acrm_value (filter active_until IS NULL). ``` This catches the exact mistake at the moment it happens, with the exact fix inline.
+
+**`skills/acrm-query.md`** (new). EAV cheat-sheet for the postinstall skill bundle — auto-installed into Claude Code / Codex / Cursor via the existing `acrm skills` installer. Covers tables, common pivots (read all fields for one record, find a person by email, list a person's transcripts, read a transcript's participants), the DataFusion dialect rules, and points at `acrm merge` for the duplicate-record workflow.
+
+Tests: 11 new unit tests cover merge planning (multivalued dedupe, single-valued conflict policies, inbound ref redirect with `value_json` rewrite, dry-run, validation) and the table-not-found hint upgrade.

--- a/skills/acrm-query.md
+++ b/skills/acrm-query.md
@@ -1,0 +1,125 @@
+---
+description: Cheat-sheet for querying the .acrm workspace with `acrm execute`. Read this before writing any SQL against acrm. acrm uses an EAV schema — there is no `people` / `companies` / `transcripts` table.
+---
+
+The .acrm file does **not** have per-object SQL tables. Every record lives in
+`acrm_record`; every attribute value lives in `acrm_value`. The object names
+you see in the docs (`people`, `companies`, `deals`, `posts`, `transcripts`)
+are values in the `object_slug` column — not tables.
+
+```
+❌ SELECT * FROM people                                  -- fails: no such table
+✅ SELECT record_id FROM acrm_record WHERE object_slug='people'
+```
+
+## Tables
+
+| table            | purpose                                                                       |
+|------------------|-------------------------------------------------------------------------------|
+| `acrm_record`    | one row per record. Columns: `object_slug`, `record_id`.                      |
+| `acrm_value`     | one row per attribute value (current OR historical, see `active_until`).      |
+| `acrm_attribute` | schema: which attributes exist on which object, type, multivalued, unique.    |
+| `acrm_object`    | the list of registered objects (`people`, `companies`, …).                    |
+
+### `acrm_value` columns worth knowing
+
+- `id` — value-row PK. Use this for surgical updates (`UPDATE … WHERE id=$1`).
+- `object_slug`, `record_id`, `attribute_slug` — the entity this value belongs to.
+- `value_json` — the typed payload (e.g. `{"value":"Cluster"}` or `{"target_record_id":"…"}`).
+- `normalized_key` — denormalized key for unique-keyed attrs (email_address, domain, url, text).
+- `ref_object`, `ref_record_id` — for record-reference attrs, the indexed link target.
+- `active_from`, `active_until` — versioning. **Always filter `active_until IS NULL` for current values.**
+- `source`, `provenance_json` — where this value came from.
+
+## SQL dialect: DataFusion
+
+- Placeholders are `$1`, `$2`, … (`?` is rejected).
+- Single statement per `acrm execute` call.
+- No `sqlite_master` — use `information_schema.tables`, `information_schema.columns`.
+- No `json_extract` — use lix UDFs:
+  - `lix_json_get(value_json, 'key')` returns a JSON value.
+  - `lix_json_get_text(value_json, 'key')` returns text.
+
+## Common queries
+
+Dump the EAV layout for the current workspace once at session start:
+
+```sh
+acrm execute --schema
+```
+
+Count records by object:
+
+```sh
+acrm execute "SELECT object_slug, COUNT(*) AS n FROM acrm_record GROUP BY object_slug"
+```
+
+Read every active field for one person:
+
+```sh
+acrm execute "
+  SELECT attribute_slug, value_json, normalized_key, ref_record_id
+  FROM   acrm_value
+  WHERE  object_slug = 'people' AND record_id = \$1
+         AND active_until IS NULL" '["<record_id>"]'
+```
+
+Find a person by email:
+
+```sh
+acrm execute "
+  SELECT record_id
+  FROM   acrm_value
+  WHERE  object_slug = 'people' AND attribute_slug = 'email_addresses'
+         AND normalized_key = \$1 AND active_until IS NULL
+  LIMIT 1" '["alice@example.com"]'
+```
+
+List a person's transcripts (forward link from `people.associated_transcripts`):
+
+```sh
+acrm execute "
+  SELECT ref_record_id AS transcript_id
+  FROM   acrm_value
+  WHERE  object_slug = 'people' AND record_id = \$1
+         AND attribute_slug = 'associated_transcripts'
+         AND active_until IS NULL" '["<person_record_id>"]'
+```
+
+Read a transcript's participants (and only those rows):
+
+```sh
+acrm execute "
+  SELECT ref_record_id AS person_id
+  FROM   acrm_value
+  WHERE  object_slug = 'transcripts' AND record_id = \$1
+         AND attribute_slug = 'participants'
+         AND active_until IS NULL" '["<transcript_record_id>"]'
+```
+
+> Don't `SELECT *` from `acrm_value` without filtering by `attribute_slug` —
+> a transcript row's `content` field alone can be tens of kilobytes.
+
+## Merging duplicates
+
+Two records describing the same entity? Don't hand-write merge SQL — use the
+first-class command:
+
+```sh
+acrm merge people --keep <record_id> --discard <record_id> --dry-run
+acrm merge people --keep <record_id> --discard <record_id>
+```
+
+It reassigns the discard's `acrm_value` rows to the keeper, rewrites every
+inbound reference (including the embedded `target_record_id` in `value_json`),
+dedupes multivalued attributes, applies a conflict policy on single-valued
+attributes (`--prefer keep|discard|interactive`, default `keep`), and finally
+removes the discarded `acrm_record` row.
+
+## Mutating directly (rare)
+
+Prefer the CLI's `acrm import …` and `acrm merge …` commands — they handle
+soft-delete (`active_until`), provenance, and EAV invariants. Hand-rolled
+`INSERT`/`UPDATE` on `acrm_value` should be the last resort, and you should
+read [the upsert helpers](https://github.com/cluster-software/agent-crm) once
+before doing it.

--- a/src/bin/acrm.ts
+++ b/src/bin/acrm.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import { Command } from "commander";
 import { registerInit } from "../commands/init.js";
 import { registerExecute } from "../commands/execute.js";
+import { registerMerge } from "../commands/merge.js";
 import { registerImport, getOrCreateImportCommand } from "../commands/import.js";
 import { attachLinkedinSubcommand } from "../commands/import-linkedin.js";
 import { attachXSubcommand } from "../commands/import-x.js";
@@ -32,6 +33,12 @@ program
   .addHelpText(
     "after",
     `
+Storage model: EAV. There is no \`people\` / \`companies\` / \`transcripts\` SQL
+table — those are \`object_slug\` values on \`acrm_record\`, and each field lives
+as a row in \`acrm_value\` keyed by (object_slug, record_id, attribute_slug).
+\`SELECT * FROM people\` will fail. See \`acrm execute --help\` for the EAV
+query patterns.
+
 Data model:
   people      contacts, identified by email / LinkedIn URL / X URL
   companies   organizations, identified by domain
@@ -48,6 +55,7 @@ Typical flow:
   acrm import transcript          import a meeting transcript — use \`--from <provider>\` for the fast path, or pipe JSON via stdin / \`--file\`
   acrm ui                         browse the workspace in a local UI
   acrm execute "SELECT ..."       run SQL against the workspace
+  acrm merge people --keep <id> --discard <id>   merge two duplicate records
 
 Provider auth (one-time, for \`acrm import transcript --from <provider>\`):
 ${PROVIDERS.filter((p) => p.oauth)
@@ -79,6 +87,7 @@ attachXSubcommand(getOrCreateImportCommand(program));
 attachPostSubcommand(getOrCreateImportCommand(program));
 attachTranscriptSubcommand(getOrCreateImportCommand(program));
 registerExecute(program);
+registerMerge(program);
 registerUi(program);
 registerSkills(program);
 registerAuth(program);

--- a/src/commands/execute.ts
+++ b/src/commands/execute.ts
@@ -7,13 +7,46 @@ import { AcrmError, ERR } from "../lib/errors.js";
 
 export function registerExecute(program: Command): void {
   program
-    .command("execute <sql> [params]")
+    .command("execute [sql] [params]")
     .description(
-      "run a SQL query or mutation against the .acrm file; params is a JSON array. SQL dialect is DataFusion (NOT SQLite/Postgres) — see `acrm execute --help`.",
+      "run a SQL query or mutation against the .acrm file; params is a JSON array. Pass `--schema` instead of SQL to dump the EAV layout (objects, attributes, types). SQL dialect is DataFusion (NOT SQLite/Postgres) — see `acrm execute --help`.",
+    )
+    .option(
+      "--schema",
+      "dump the workspace's EAV layout (objects + attributes) instead of running SQL. Use this once at session start to see what's queryable.",
     )
     .addHelpText(
       "after",
       `
+Storage model: EAV. Records are not stored in per-object SQL tables.
+
+  Tables (the only three you query directly):
+    acrm_record     (record_id, object_slug)              one row per record
+    acrm_value      (id, record_id, object_slug,          one row per attribute
+                     attribute_slug, value_json,           value (current OR
+                     normalized_key, ref_object,           historical)
+                     ref_record_id, active_from, active_until, source, …)
+    acrm_attribute  (object_slug, attribute_slug,         schema: what fields
+                     attribute_type, is_multivalued,       exist on each object
+                     is_unique, config_json)
+
+  There is NO per-object table:
+    ❌ SELECT * FROM people
+    ✅ SELECT record_id FROM acrm_record WHERE object_slug = 'people'
+
+  Read all fields for one record (pivot from acrm_value):
+    SELECT attribute_slug, value_json, normalized_key, ref_record_id
+    FROM   acrm_value
+    WHERE  object_slug = 'people' AND record_id = $1
+           AND active_until IS NULL;
+
+  Always filter \`active_until IS NULL\` for current values — historical rows
+  are kept in the same table with a non-null active_until.
+
+  For record-reference attributes, prefer the indexed columns:
+    ref_object, ref_record_id        (use these for joins/filters)
+  rather than digging into value_json.target_record_id.
+
 SQL dialect: DataFusion (NOT SQLite, NOT Postgres)
   - Placeholders are $1, $2, ...   The '?' placeholder is rejected.
   - No sqlite_master — use information_schema.tables / .columns.
@@ -34,6 +67,7 @@ JSON columns to be aware of:
   acrm_attribute.config_json   per-attribute config (status options, ref target, ...)
 
 Introspection (use these instead of sqlite_master):
+  acrm execute --schema                                          # full EAV layout for this workspace
   acrm execute "SELECT table_name FROM information_schema.tables WHERE table_schema='public'"
   acrm execute "SELECT column_name, data_type FROM information_schema.columns WHERE table_name='acrm_value'"
   acrm execute "SELECT * FROM acrm_object"                      # registered objects
@@ -44,37 +78,137 @@ Errors carry the lix engine code + hint when applicable
 (e.g. LIX_SQL_PARSE_ERROR with hint: "Use $1 instead of ?").
 `,
     )
-    .action(async (sql: string, paramsJson: string | undefined) => {
-      const root = program.opts() as { json?: boolean; workspace?: string };
-      setJsonMode(root.json);
-      try {
-        let params: LixRuntimeValue[] = [];
-        if (paramsJson) {
-          let parsed: unknown;
-          try {
-            parsed = JSON.parse(paramsJson);
-          } catch {
+    .action(
+      async (
+        sql: string | undefined,
+        paramsJson: string | undefined,
+        opts: { schema?: boolean },
+      ) => {
+        const root = program.opts() as { json?: boolean; workspace?: string };
+        setJsonMode(root.json);
+        try {
+          if (opts.schema) {
+            if (sql) {
+              throw new AcrmError(
+                "--schema does not take a SQL argument",
+                ERR.INVALID_INPUT,
+              );
+            }
+            const lix = await openWorkspace({ workspace: root.workspace });
+            try {
+              const schema = await dumpSchema(lix);
+              ok(schema);
+            } finally {
+              await lix.close();
+            }
+            return;
+          }
+
+          if (!sql) {
             throw new AcrmError(
-              `params must be a JSON array, got: ${paramsJson}`,
+              "missing SQL argument (run `acrm execute --help` for the dialect; pass `--schema` to dump the EAV layout)",
               ERR.INVALID_INPUT,
             );
           }
-          if (!Array.isArray(parsed)) {
-            throw new AcrmError("params must be a JSON array", ERR.INVALID_INPUT);
+
+          let params: LixRuntimeValue[] = [];
+          if (paramsJson) {
+            let parsed: unknown;
+            try {
+              parsed = JSON.parse(paramsJson);
+            } catch {
+              throw new AcrmError(
+                `params must be a JSON array, got: ${paramsJson}`,
+                ERR.INVALID_INPUT,
+              );
+            }
+            if (!Array.isArray(parsed)) {
+              throw new AcrmError(
+                "params must be a JSON array",
+                ERR.INVALID_INPUT,
+              );
+            }
+            params = parsed as LixRuntimeValue[];
           }
-          params = parsed as LixRuntimeValue[];
+          const lix = await openWorkspace({ workspace: root.workspace });
+          try {
+            const result = await exec(lix, sql, params);
+            ok({ rows: result.rows, rows_affected: result.rowsAffected });
+          } finally {
+            await lix.close();
+          }
+        } catch (e) {
+          if (e instanceof AcrmError) fail(e.message, e.code, e.hint);
+          else fail(e instanceof Error ? e.message : String(e), ERR.EXECUTE);
+          process.exit(1);
         }
-        const lix = await openWorkspace({ workspace: root.workspace });
-        try {
-          const result = await exec(lix, sql, params);
-          ok({ rows: result.rows, rows_affected: result.rowsAffected });
-        } finally {
-          await lix.close();
-        }
-      } catch (e) {
-        if (e instanceof AcrmError) fail(e.message, e.code, e.hint);
-        else fail(e instanceof Error ? e.message : String(e), ERR.EXECUTE);
-        process.exit(1);
+      },
+    );
+}
+
+type SchemaAttribute = {
+  attribute_slug: string;
+  title: string;
+  attribute_type: string;
+  is_multivalued: boolean;
+  is_unique: boolean;
+  config?: unknown;
+};
+
+type SchemaObject = {
+  object_slug: string;
+  singular_name: string;
+  plural_name: string;
+  attributes: SchemaAttribute[];
+};
+
+async function dumpSchema(
+  lix: import("@lix-js/sdk").Lix,
+): Promise<{ objects: SchemaObject[] }> {
+  const objects = await exec(
+    lix,
+    `SELECT object_slug, singular_name, plural_name
+     FROM acrm_object
+     ORDER BY object_slug`,
+  );
+  const attrs = await exec(
+    lix,
+    `SELECT object_slug, attribute_slug, title, attribute_type,
+            is_multivalued, is_unique, config_json
+     FROM acrm_attribute
+     ORDER BY object_slug, attribute_slug`,
+  );
+
+  const byObject = new Map<string, SchemaAttribute[]>();
+  for (const row of attrs.rows) {
+    const slug = row.object_slug as string;
+    const list = byObject.get(slug) ?? [];
+    const raw = row.config_json as string | null | undefined;
+    let config: unknown;
+    if (raw) {
+      try {
+        config = JSON.parse(raw);
+      } catch {
+        config = raw;
       }
+    }
+    list.push({
+      attribute_slug: row.attribute_slug as string,
+      title: row.title as string,
+      attribute_type: row.attribute_type as string,
+      is_multivalued: Boolean(row.is_multivalued),
+      is_unique: Boolean(row.is_unique),
+      ...(config !== undefined ? { config } : {}),
     });
+    byObject.set(slug, list);
+  }
+
+  return {
+    objects: objects.rows.map((row) => ({
+      object_slug: row.object_slug as string,
+      singular_name: row.singular_name as string,
+      plural_name: row.plural_name as string,
+      attributes: byObject.get(row.object_slug as string) ?? [],
+    })),
+  };
 }

--- a/src/commands/merge.test.ts
+++ b/src/commands/merge.test.ts
@@ -1,0 +1,398 @@
+import { describe, expect, it } from "vitest";
+import type { Lix } from "@lix-js/sdk";
+import { openTestWorkspace } from "../test/open-test-lix.js";
+import { exec } from "../db/execute.js";
+import {
+  addMultiValue,
+  insertRecord,
+  setSingleValue,
+} from "../db/upsert.js";
+import { generateUuid } from "../lib/ids.js";
+import { mergeRecords } from "./merge.js";
+import { importTranscript } from "./import-transcript.js";
+
+async function seedPerson(
+  lix: Lix,
+  spec: {
+    email?: string;
+    emails?: string[];
+    linkedin_url?: string;
+    twitter_url?: string;
+    name?: string;
+    job_title?: string;
+  },
+): Promise<string> {
+  const id = await generateUuid(lix);
+  await insertRecord(lix, "people", id);
+  const source = "test";
+  const provenance = { test: true };
+  const emails = [...(spec.emails ?? []), ...(spec.email ? [spec.email] : [])];
+  for (const e of emails) {
+    await addMultiValue(lix, {
+      object_slug: "people",
+      record_id: id,
+      attribute_slug: "email_addresses",
+      attribute_type: "email-address",
+      value: e,
+      source,
+      provenance,
+    });
+  }
+  if (spec.linkedin_url) {
+    await setSingleValue(lix, {
+      object_slug: "people",
+      record_id: id,
+      attribute_slug: "linkedin_url",
+      attribute_type: "url",
+      value: spec.linkedin_url,
+      source,
+      provenance,
+    });
+  }
+  if (spec.twitter_url) {
+    await setSingleValue(lix, {
+      object_slug: "people",
+      record_id: id,
+      attribute_slug: "twitter_url",
+      attribute_type: "url",
+      value: spec.twitter_url,
+      source,
+      provenance,
+    });
+  }
+  if (spec.name) {
+    await setSingleValue(lix, {
+      object_slug: "people",
+      record_id: id,
+      attribute_slug: "name",
+      attribute_type: "personal-name",
+      value: spec.name,
+      source,
+      provenance,
+    });
+  }
+  if (spec.job_title) {
+    await setSingleValue(lix, {
+      object_slug: "people",
+      record_id: id,
+      attribute_slug: "job_title",
+      attribute_type: "text",
+      value: spec.job_title,
+      source,
+      provenance,
+    });
+  }
+  return id;
+}
+
+async function emailsFor(lix: Lix, personId: string): Promise<string[]> {
+  const r = await exec(
+    lix,
+    `SELECT normalized_key FROM acrm_value
+     WHERE object_slug = 'people' AND record_id = $1
+       AND attribute_slug = 'email_addresses' AND active_until IS NULL
+     ORDER BY normalized_key`,
+    [personId],
+  );
+  return r.rows.map((row) => row.normalized_key as string);
+}
+
+async function singleValueFor(
+  lix: Lix,
+  personId: string,
+  attribute_slug: string,
+): Promise<string | null> {
+  const r = await exec(
+    lix,
+    `SELECT normalized_key, value_json FROM acrm_value
+     WHERE object_slug = 'people' AND record_id = $1
+       AND attribute_slug = $2 AND active_until IS NULL
+     LIMIT 1`,
+    [personId, attribute_slug],
+  );
+  return (
+    (r.rows[0]?.normalized_key as string | undefined) ??
+    (r.rows[0]?.value_json as string | undefined) ??
+    null
+  );
+}
+
+async function recordExists(
+  lix: Lix,
+  object_slug: string,
+  record_id: string,
+): Promise<boolean> {
+  const r = await exec(
+    lix,
+    `SELECT 1 FROM acrm_record WHERE object_slug = $1 AND record_id = $2`,
+    [object_slug, record_id],
+  );
+  return r.rows.length > 0;
+}
+
+describe("mergeRecords", () => {
+  it("reassigns multivalued values and dedupes by normalized_key", async () => {
+    const lix = await openTestWorkspace();
+    const keep = await seedPerson(lix, {
+      emails: ["alice@acme.com"],
+      name: "Alice",
+    });
+    const discard = await seedPerson(lix, {
+      emails: ["alice@acme.com", "alice.b@acme.com"],
+    });
+
+    const result = await mergeRecords(lix, {
+      object_slug: "people",
+      keep_record_id: keep,
+      discard_record_id: discard,
+      prefer: "keep",
+      dryRun: false,
+    });
+
+    expect(result.applied).toBe(true);
+    expect(result.discard_record_deleted).toBe(true);
+    expect(await recordExists(lix, "people", discard)).toBe(false);
+
+    // Keeper has both emails, deduped.
+    expect(await emailsFor(lix, keep)).toEqual([
+      "alice.b@acme.com",
+      "alice@acme.com",
+    ]);
+    await lix.close();
+  });
+
+  it("moves single-valued attributes when keeper is empty", async () => {
+    const lix = await openTestWorkspace();
+    const keep = await seedPerson(lix, { email: "luis@cluster.com" });
+    const discard = await seedPerson(lix, {
+      linkedin_url: "linkedin.com/in/luis",
+      job_title: "Founder",
+    });
+
+    await mergeRecords(lix, {
+      object_slug: "people",
+      keep_record_id: keep,
+      discard_record_id: discard,
+      prefer: "keep",
+      dryRun: false,
+    });
+
+    expect(await singleValueFor(lix, keep, "linkedin_url")).toBe(
+      "linkedin.com/in/luis",
+    );
+    const titleRow = await exec(
+      lix,
+      `SELECT value_json FROM acrm_value
+       WHERE object_slug='people' AND record_id=$1
+         AND attribute_slug='job_title' AND active_until IS NULL`,
+      [keep],
+    );
+    expect(titleRow.rows[0]?.value_json).toContain("Founder");
+    await lix.close();
+  });
+
+  it("--prefer keep drops discard's single-value on conflict", async () => {
+    const lix = await openTestWorkspace();
+    const keep = await seedPerson(lix, {
+      linkedin_url: "linkedin.com/in/keep",
+    });
+    const discard = await seedPerson(lix, {
+      linkedin_url: "linkedin.com/in/discard",
+    });
+
+    const result = await mergeRecords(lix, {
+      object_slug: "people",
+      keep_record_id: keep,
+      discard_record_id: discard,
+      prefer: "keep",
+      dryRun: false,
+    });
+
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0]?.attribute_slug).toBe("linkedin_url");
+    expect(result.conflicts[0]?.resolution).toBe("keep");
+    expect(await singleValueFor(lix, keep, "linkedin_url")).toBe(
+      "linkedin.com/in/keep",
+    );
+    await lix.close();
+  });
+
+  it("--prefer discard replaces keeper's single-value", async () => {
+    const lix = await openTestWorkspace();
+    const keep = await seedPerson(lix, {
+      linkedin_url: "linkedin.com/in/keep",
+    });
+    const discard = await seedPerson(lix, {
+      linkedin_url: "linkedin.com/in/discard",
+    });
+
+    await mergeRecords(lix, {
+      object_slug: "people",
+      keep_record_id: keep,
+      discard_record_id: discard,
+      prefer: "discard",
+      dryRun: false,
+    });
+
+    expect(await singleValueFor(lix, keep, "linkedin_url")).toBe(
+      "linkedin.com/in/discard",
+    );
+    await lix.close();
+  });
+
+  it("redirects inbound record-references (transcripts.participants) to the keeper", async () => {
+    const lix = await openTestWorkspace();
+    const keep = await seedPerson(lix, {
+      linkedin_url: "linkedin.com/in/luis",
+    });
+    const discard = await seedPerson(lix, { email: "luis@cluster.com" });
+
+    // Import a transcript that points at the discard via email.
+    await importTranscript(lix, {
+      source: "granola",
+      source_id: "meeting-1",
+      title: "T",
+      participants: [{ email: "luis@cluster.com" }],
+    });
+
+    // Sanity: the transcript references the discard, not the keeper.
+    const before = await exec(
+      lix,
+      `SELECT ref_record_id FROM acrm_value
+       WHERE object_slug='transcripts' AND attribute_slug='participants'
+         AND active_until IS NULL`,
+    );
+    expect(before.rows[0]?.ref_record_id).toBe(discard);
+
+    await mergeRecords(lix, {
+      object_slug: "people",
+      keep_record_id: keep,
+      discard_record_id: discard,
+      prefer: "keep",
+      dryRun: false,
+    });
+
+    // Forward link now points at the keeper.
+    const after = await exec(
+      lix,
+      `SELECT ref_record_id, value_json FROM acrm_value
+       WHERE object_slug='transcripts' AND attribute_slug='participants'
+         AND active_until IS NULL`,
+    );
+    expect(after.rows[0]?.ref_record_id).toBe(keep);
+    expect(after.rows[0]?.value_json).toContain(keep);
+
+    // Inverse link (people.associated_transcripts) was on the discard;
+    // gets moved to the keeper as one of its own multivalued rows.
+    const inv = await exec(
+      lix,
+      `SELECT record_id FROM acrm_value
+       WHERE object_slug='people' AND attribute_slug='associated_transcripts'
+         AND active_until IS NULL`,
+    );
+    expect(inv.rows[0]?.record_id).toBe(keep);
+
+    // The discard record is gone.
+    expect(await recordExists(lix, "people", discard)).toBe(false);
+    await lix.close();
+  });
+
+  it("--dry-run reports the plan without mutating", async () => {
+    const lix = await openTestWorkspace();
+    const keep = await seedPerson(lix, {
+      linkedin_url: "linkedin.com/in/luis",
+    });
+    const discard = await seedPerson(lix, { email: "luis@cluster.com" });
+
+    const plan = await mergeRecords(lix, {
+      object_slug: "people",
+      keep_record_id: keep,
+      discard_record_id: discard,
+      prefer: "keep",
+      dryRun: true,
+    });
+
+    expect(plan.applied).toBe(false);
+    expect(plan.discard_record_deleted).toBe(false);
+    expect(plan.items.length).toBeGreaterThan(0);
+    expect(await recordExists(lix, "people", discard)).toBe(true);
+    expect(await emailsFor(lix, keep)).toEqual([]);
+    await lix.close();
+  });
+
+  it("rejects merging a record with itself", async () => {
+    const lix = await openTestWorkspace();
+    const id = await seedPerson(lix, { email: "a@b.com" });
+    await expect(
+      mergeRecords(lix, {
+        object_slug: "people",
+        keep_record_id: id,
+        discard_record_id: id,
+        prefer: "keep",
+        dryRun: false,
+      }),
+    ).rejects.toThrow(/same record_id/);
+    await lix.close();
+  });
+
+  it("rejects unknown keep / discard record_ids", async () => {
+    const lix = await openTestWorkspace();
+    const id = await seedPerson(lix, { email: "a@b.com" });
+    await expect(
+      mergeRecords(lix, {
+        object_slug: "people",
+        keep_record_id: id,
+        discard_record_id: "does-not-exist",
+        prefer: "keep",
+        dryRun: false,
+      }),
+    ).rejects.toThrow(/discard record_id not found/);
+    await lix.close();
+  });
+
+  it("end-to-end: reproduces the Luis duplicate scenario from the RCA", async () => {
+    const lix = await openTestWorkspace();
+    // Luis #1: created by `acrm import linkedin` — has LinkedIn, no email.
+    const luis1 = await seedPerson(lix, {
+      linkedin_url: "linkedin.com/in/luis-costa-laveron-834b05177",
+      name: "Luis Costa Laveron",
+      job_title: "Founder",
+    });
+    // Luis #2: created by `acrm import transcript` from an email-only
+    // participant before the resolver could bridge identifier sets.
+    const luis2 = await seedPerson(lix, { email: "luis@hello-cluster.com" });
+
+    // Transcript was imported pointing at luis2.
+    await importTranscript(lix, {
+      source: "granola",
+      source_id: "meeting-luis",
+      title: "Discovery — Luis",
+      participants: [{ email: "luis@hello-cluster.com" }],
+    });
+
+    const result = await mergeRecords(lix, {
+      object_slug: "people",
+      keep_record_id: luis1,
+      discard_record_id: luis2,
+      prefer: "keep",
+      dryRun: false,
+    });
+
+    expect(result.applied).toBe(true);
+    expect(await recordExists(lix, "people", luis2)).toBe(false);
+    expect(await emailsFor(lix, luis1)).toEqual(["luis@hello-cluster.com"]);
+    expect(await singleValueFor(lix, luis1, "linkedin_url")).toBe(
+      "linkedin.com/in/luis-costa-laveron-834b05177",
+    );
+
+    // Transcript now references the kept Luis.
+    const refs = await exec(
+      lix,
+      `SELECT ref_record_id FROM acrm_value
+       WHERE object_slug='transcripts' AND attribute_slug='participants'
+         AND active_until IS NULL`,
+    );
+    expect(refs.rows[0]?.ref_record_id).toBe(luis1);
+    await lix.close();
+  });
+});

--- a/src/commands/merge.ts
+++ b/src/commands/merge.ts
@@ -1,0 +1,662 @@
+import { createInterface } from "node:readline";
+import type { Command } from "commander";
+import type { Lix } from "@lix-js/sdk";
+import { openWorkspace } from "../workspace/open.js";
+import { exec } from "../db/execute.js";
+import { fail, isJson, ok, setJsonMode } from "../output/json.js";
+import { AcrmError, ERR } from "../lib/errors.js";
+import { nowIso } from "../lib/time.js";
+
+type Prefer = "keep" | "discard" | "interactive";
+
+type Opts = {
+  keep: string;
+  discard: string;
+  dryRun?: boolean;
+  prefer?: string;
+  json?: boolean;
+};
+
+type ValueRow = {
+  id: string;
+  attribute_slug: string;
+  attribute_type: string;
+  value_json: string;
+  normalized_key: string | null;
+  ref_object: string | null;
+  ref_record_id: string | null;
+};
+
+type InboundRow = ValueRow & {
+  object_slug: string;
+  record_id: string;
+};
+
+type AttributeMeta = {
+  attribute_type: string;
+  is_multivalued: boolean;
+};
+
+export type MergePlanItem =
+  | {
+      kind: "move_multi";
+      attribute_slug: string;
+      from_value_id: string;
+      normalized_key: string | null;
+      ref_record_id: string | null;
+    }
+  | {
+      kind: "drop_multi_duplicate";
+      attribute_slug: string;
+      from_value_id: string;
+      normalized_key: string | null;
+      ref_record_id: string | null;
+    }
+  | {
+      kind: "move_single_empty_keeper";
+      attribute_slug: string;
+      from_value_id: string;
+    }
+  | {
+      kind: "single_conflict_keep_wins";
+      attribute_slug: string;
+      kept_value_id: string;
+      dropped_value_id: string;
+    }
+  | {
+      kind: "single_conflict_discard_wins";
+      attribute_slug: string;
+      kept_value_id: string;
+      dropped_value_id: string;
+    }
+  | {
+      kind: "inbound_redirect";
+      object_slug: string;
+      record_id: string;
+      attribute_slug: string;
+      value_id: string;
+    }
+  | {
+      kind: "inbound_drop_duplicate";
+      object_slug: string;
+      record_id: string;
+      attribute_slug: string;
+      value_id: string;
+    };
+
+export type MergePlan = {
+  object_slug: string;
+  keep_record_id: string;
+  discard_record_id: string;
+  prefer: Prefer;
+  items: MergePlanItem[];
+  conflicts: Array<{
+    attribute_slug: string;
+    keeper_value_json: unknown;
+    discard_value_json: unknown;
+    resolution: "keep" | "discard";
+  }>;
+};
+
+export type MergeResult = MergePlan & {
+  applied: boolean;
+  values_moved: number;
+  values_dropped: number;
+  inbound_redirected: number;
+  inbound_dropped: number;
+  discard_record_deleted: boolean;
+};
+
+export function registerMerge(program: Command): void {
+  program
+    .command("merge <object>")
+    .description(
+      "merge two records of the same object: reassign attribute values + inbound references from `--discard` to `--keep`, then delete the discarded record. Use when two `people`/`companies`/etc. records describe the same entity (e.g. one created from a LinkedIn import and a duplicate created from a transcript email).",
+    )
+    .requiredOption("--keep <record_id>", "the record to keep (winner)")
+    .requiredOption("--discard <record_id>", "the record to delete (loser)")
+    .option(
+      "--prefer <policy>",
+      "conflict policy for single-valued attributes: keep | discard | interactive (default: keep)",
+      "keep",
+    )
+    .option(
+      "--dry-run",
+      "print the plan (rows moved, rows redirected, conflicts) without applying",
+    )
+    .addHelpText(
+      "after",
+      `
+Examples:
+  acrm merge people --keep <luis-1> --discard <luis-2>
+  acrm merge people --keep <luis-1> --discard <luis-2> --dry-run
+  acrm merge people --keep <luis-1> --discard <luis-2> --prefer discard
+
+What it does:
+  1. Reassigns every \`acrm_value\` row from the discard to the keeper.
+     - Multivalued attrs: dedupe by normalized_key (or ref_record_id for refs).
+     - Single-valued attrs: keeper wins by default; \`--prefer discard\` flips it;
+       \`--prefer interactive\` prompts on each conflict.
+  2. Rewrites every inbound reference (acrm_value rows where
+     ref_record_id = discard) to point at the keeper. Dedupes if the source
+     record already had an active ref to the keeper.
+  3. Deletes the discarded record from \`acrm_record\`.
+
+Note: lix does not currently expose BEGIN/COMMIT, so this command is not a
+single SQL transaction. It validates the full plan before any mutation
+(use \`--dry-run\` to inspect). If a step fails midway, re-run the command —
+the operation is idempotent once the duplicate row has been redirected.
+`,
+    )
+    .action(async (object: string, opts: Opts) => {
+      const root = program.opts() as { json?: boolean; workspace?: string };
+      setJsonMode(root.json);
+      try {
+        const prefer = parsePrefer(opts.prefer);
+        const lix = await openWorkspace({ workspace: root.workspace });
+        try {
+          const result = await mergeRecords(lix, {
+            object_slug: object,
+            keep_record_id: opts.keep,
+            discard_record_id: opts.discard,
+            prefer,
+            dryRun: Boolean(opts.dryRun),
+          });
+          ok(result);
+          if (!isJson() && opts.dryRun) {
+            process.stderr.write(`(dry-run — no changes applied)\n`);
+          }
+        } finally {
+          await lix.close();
+        }
+      } catch (e) {
+        if (e instanceof AcrmError) fail(e.message, e.code, e.hint);
+        else fail(e instanceof Error ? e.message : String(e), ERR.UNHANDLED);
+        process.exit(1);
+      }
+    });
+}
+
+function parsePrefer(input: string | undefined): Prefer {
+  if (!input) return "keep";
+  const s = input.trim().toLowerCase();
+  if (s === "keep" || s === "discard" || s === "interactive") return s;
+  throw new AcrmError(
+    `invalid --prefer value: ${input} (expected keep | discard | interactive)`,
+    ERR.INVALID_INPUT,
+  );
+}
+
+export async function mergeRecords(
+  lix: Lix,
+  args: {
+    object_slug: string;
+    keep_record_id: string;
+    discard_record_id: string;
+    prefer: Prefer;
+    dryRun: boolean;
+  },
+): Promise<MergeResult> {
+  const { object_slug, keep_record_id, discard_record_id, prefer, dryRun } =
+    args;
+
+  if (keep_record_id === discard_record_id) {
+    throw new AcrmError(
+      "--keep and --discard are the same record_id",
+      ERR.INVALID_INPUT,
+    );
+  }
+
+  await assertRecordExists(lix, object_slug, keep_record_id, "keep");
+  await assertRecordExists(lix, object_slug, discard_record_id, "discard");
+
+  const attrs = await loadAttributeMeta(lix, object_slug);
+
+  const discardValues = await loadActiveValues(
+    lix,
+    object_slug,
+    discard_record_id,
+  );
+  const keeperValues = await loadActiveValues(
+    lix,
+    object_slug,
+    keep_record_id,
+  );
+
+  const items: MergePlanItem[] = [];
+  const conflicts: MergeResult["conflicts"] = [];
+
+  // Index keeper values by attribute for O(1) lookups during planning.
+  const keeperByAttr = new Map<string, ValueRow[]>();
+  for (const v of keeperValues) {
+    const list = keeperByAttr.get(v.attribute_slug) ?? [];
+    list.push(v);
+    keeperByAttr.set(v.attribute_slug, list);
+  }
+
+  for (const v of discardValues) {
+    const meta = attrs.get(v.attribute_slug);
+    // Unknown attribute (orphan attribute_slug) — preserve by moving; safer
+    // than dropping data we don't have schema for.
+    const multivalued = meta?.is_multivalued ?? false;
+    const keeperRows = keeperByAttr.get(v.attribute_slug) ?? [];
+
+    if (multivalued) {
+      const dupeKey = duplicateKey(v);
+      const isDupe =
+        dupeKey !== null &&
+        keeperRows.some((k) => duplicateKey(k) === dupeKey);
+      if (isDupe) {
+        items.push({
+          kind: "drop_multi_duplicate",
+          attribute_slug: v.attribute_slug,
+          from_value_id: v.id,
+          normalized_key: v.normalized_key,
+          ref_record_id: v.ref_record_id,
+        });
+      } else {
+        items.push({
+          kind: "move_multi",
+          attribute_slug: v.attribute_slug,
+          from_value_id: v.id,
+          normalized_key: v.normalized_key,
+          ref_record_id: v.ref_record_id,
+        });
+        // So that subsequent discard rows in the same attribute see the new
+        // keeper-side value during dedup.
+        keeperRows.push(v);
+        keeperByAttr.set(v.attribute_slug, keeperRows);
+      }
+    } else {
+      // Single-valued: at most one active row per side.
+      const keeperRow = keeperRows[0];
+      if (!keeperRow) {
+        items.push({
+          kind: "move_single_empty_keeper",
+          attribute_slug: v.attribute_slug,
+          from_value_id: v.id,
+        });
+        keeperByAttr.set(v.attribute_slug, [v]);
+      } else if (sameValue(keeperRow, v)) {
+        // Same value on both sides — just drop the discard's row.
+        items.push({
+          kind: "drop_multi_duplicate",
+          attribute_slug: v.attribute_slug,
+          from_value_id: v.id,
+          normalized_key: v.normalized_key,
+          ref_record_id: v.ref_record_id,
+        });
+      } else {
+        const resolution = await resolveConflict(
+          v.attribute_slug,
+          keeperRow,
+          v,
+          prefer,
+        );
+        if (resolution === "keep") {
+          items.push({
+            kind: "single_conflict_keep_wins",
+            attribute_slug: v.attribute_slug,
+            kept_value_id: keeperRow.id,
+            dropped_value_id: v.id,
+          });
+        } else {
+          items.push({
+            kind: "single_conflict_discard_wins",
+            attribute_slug: v.attribute_slug,
+            kept_value_id: v.id,
+            dropped_value_id: keeperRow.id,
+          });
+        }
+        conflicts.push({
+          attribute_slug: v.attribute_slug,
+          keeper_value_json: safeJson(keeperRow.value_json),
+          discard_value_json: safeJson(v.value_json),
+          resolution,
+        });
+      }
+    }
+  }
+
+  const inbound = await loadInboundRefs(lix, object_slug, discard_record_id);
+
+  // Group inbound by (record_id, attribute_slug) so we can dedupe duplicates
+  // that would otherwise point a single source record at the keeper twice.
+  const keeperInboundKeys = new Set<string>();
+  const keeperInbound = await loadKeeperInbound(lix, object_slug, keep_record_id);
+  for (const k of keeperInbound) {
+    keeperInboundKeys.add(`${k.object_slug}|${k.record_id}|${k.attribute_slug}`);
+  }
+
+  for (const i of inbound) {
+    const key = `${i.object_slug}|${i.record_id}|${i.attribute_slug}`;
+    if (keeperInboundKeys.has(key)) {
+      items.push({
+        kind: "inbound_drop_duplicate",
+        object_slug: i.object_slug,
+        record_id: i.record_id,
+        attribute_slug: i.attribute_slug,
+        value_id: i.id,
+      });
+    } else {
+      items.push({
+        kind: "inbound_redirect",
+        object_slug: i.object_slug,
+        record_id: i.record_id,
+        attribute_slug: i.attribute_slug,
+        value_id: i.id,
+      });
+      keeperInboundKeys.add(key);
+    }
+  }
+
+  const plan: MergePlan = {
+    object_slug,
+    keep_record_id,
+    discard_record_id,
+    prefer,
+    items,
+    conflicts,
+  };
+
+  if (dryRun) {
+    return {
+      ...plan,
+      applied: false,
+      values_moved: items.filter(
+        (i) => i.kind === "move_multi" || i.kind === "move_single_empty_keeper",
+      ).length,
+      values_dropped: items.filter(
+        (i) =>
+          i.kind === "drop_multi_duplicate" ||
+          i.kind === "single_conflict_keep_wins" ||
+          i.kind === "single_conflict_discard_wins",
+      ).length,
+      inbound_redirected: items.filter((i) => i.kind === "inbound_redirect")
+        .length,
+      inbound_dropped: items.filter((i) => i.kind === "inbound_drop_duplicate")
+        .length,
+      discard_record_deleted: false,
+    };
+  }
+
+  let movedCount = 0;
+  let droppedCount = 0;
+  let redirectedCount = 0;
+  let inboundDroppedCount = 0;
+
+  const ts = nowIso();
+  for (const item of items) {
+    switch (item.kind) {
+      case "move_multi":
+      case "move_single_empty_keeper": {
+        await exec(
+          lix,
+          `UPDATE acrm_value SET record_id = $1 WHERE id = $2`,
+          [keep_record_id, item.from_value_id],
+        );
+        movedCount++;
+        break;
+      }
+      case "drop_multi_duplicate": {
+        await exec(
+          lix,
+          `UPDATE acrm_value SET active_until = $1 WHERE id = $2`,
+          [ts, item.from_value_id],
+        );
+        droppedCount++;
+        break;
+      }
+      case "single_conflict_keep_wins": {
+        await exec(
+          lix,
+          `UPDATE acrm_value SET active_until = $1 WHERE id = $2`,
+          [ts, item.dropped_value_id],
+        );
+        droppedCount++;
+        break;
+      }
+      case "single_conflict_discard_wins": {
+        // Soft-delete the keeper's existing value, then move the discard's
+        // value over to the keeper record.
+        await exec(
+          lix,
+          `UPDATE acrm_value SET active_until = $1 WHERE id = $2`,
+          [ts, item.dropped_value_id],
+        );
+        await exec(
+          lix,
+          `UPDATE acrm_value SET record_id = $1 WHERE id = $2`,
+          [keep_record_id, item.kept_value_id],
+        );
+        droppedCount++;
+        movedCount++;
+        break;
+      }
+      case "inbound_redirect": {
+        // Rewrite both columns: the indexed `ref_record_id` column and the
+        // embedded `target_record_id` field inside value_json. Lix's
+        // DataFusion dialect doesn't expose JSON UPDATE, so we round-trip
+        // through JS.
+        const cur = await exec(
+          lix,
+          `SELECT value_json FROM acrm_value WHERE id = $1`,
+          [item.value_id],
+        );
+        const raw = cur.rows[0]?.value_json as string | undefined;
+        let nextJson = raw;
+        if (raw) {
+          try {
+            const obj = JSON.parse(raw) as Record<string, unknown>;
+            if (typeof obj.target_record_id === "string") {
+              obj.target_record_id = keep_record_id;
+              nextJson = JSON.stringify(obj);
+            }
+          } catch {
+            // Leave value_json untouched if it's not the expected shape —
+            // the ref_record_id column is the index of record, value_json
+            // is denormalized cache.
+          }
+        }
+        await exec(
+          lix,
+          `UPDATE acrm_value
+           SET ref_record_id = $1, value_json = $2
+           WHERE id = $3`,
+          [keep_record_id, nextJson ?? null, item.value_id],
+        );
+        redirectedCount++;
+        break;
+      }
+      case "inbound_drop_duplicate": {
+        await exec(
+          lix,
+          `UPDATE acrm_value SET active_until = $1 WHERE id = $2`,
+          [ts, item.value_id],
+        );
+        inboundDroppedCount++;
+        break;
+      }
+    }
+  }
+
+  // Discard the empty record. acrm_value rows still tagged with the discard's
+  // record_id (e.g. soft-deleted ones) are intentionally left in place as a
+  // history trail.
+  await exec(
+    lix,
+    `DELETE FROM acrm_record WHERE object_slug = $1 AND record_id = $2`,
+    [object_slug, discard_record_id],
+  );
+
+  return {
+    ...plan,
+    applied: true,
+    values_moved: movedCount,
+    values_dropped: droppedCount,
+    inbound_redirected: redirectedCount,
+    inbound_dropped: inboundDroppedCount,
+    discard_record_deleted: true,
+  };
+}
+
+async function assertRecordExists(
+  lix: Lix,
+  object_slug: string,
+  record_id: string,
+  side: "keep" | "discard",
+): Promise<void> {
+  const r = await exec(
+    lix,
+    `SELECT 1 FROM acrm_record WHERE object_slug = $1 AND record_id = $2`,
+    [object_slug, record_id],
+  );
+  if (!r.rows.length) {
+    throw new AcrmError(
+      `--${side} record_id not found: ${record_id} (object_slug=${object_slug})`,
+      ERR.NOT_FOUND,
+    );
+  }
+}
+
+async function loadAttributeMeta(
+  lix: Lix,
+  object_slug: string,
+): Promise<Map<string, AttributeMeta>> {
+  const r = await exec(
+    lix,
+    `SELECT attribute_slug, attribute_type, is_multivalued
+     FROM acrm_attribute WHERE object_slug = $1`,
+    [object_slug],
+  );
+  const out = new Map<string, AttributeMeta>();
+  for (const row of r.rows) {
+    out.set(row.attribute_slug as string, {
+      attribute_type: row.attribute_type as string,
+      is_multivalued: Boolean(row.is_multivalued),
+    });
+  }
+  return out;
+}
+
+async function loadActiveValues(
+  lix: Lix,
+  object_slug: string,
+  record_id: string,
+): Promise<ValueRow[]> {
+  const r = await exec(
+    lix,
+    `SELECT id, attribute_slug, attribute_type, value_json, normalized_key,
+            ref_object, ref_record_id
+     FROM acrm_value
+     WHERE object_slug = $1 AND record_id = $2 AND active_until IS NULL`,
+    [object_slug, record_id],
+  );
+  return r.rows.map((row) => ({
+    id: row.id as string,
+    attribute_slug: row.attribute_slug as string,
+    attribute_type: row.attribute_type as string,
+    value_json: (row.value_json as string | null) ?? "",
+    normalized_key: (row.normalized_key as string | null) ?? null,
+    ref_object: (row.ref_object as string | null) ?? null,
+    ref_record_id: (row.ref_record_id as string | null) ?? null,
+  }));
+}
+
+async function loadInboundRefs(
+  lix: Lix,
+  ref_object: string,
+  ref_record_id: string,
+): Promise<InboundRow[]> {
+  const r = await exec(
+    lix,
+    `SELECT id, object_slug, record_id, attribute_slug, attribute_type,
+            value_json, normalized_key, ref_object, ref_record_id
+     FROM acrm_value
+     WHERE ref_object = $1 AND ref_record_id = $2 AND active_until IS NULL`,
+    [ref_object, ref_record_id],
+  );
+  return r.rows.map((row) => ({
+    id: row.id as string,
+    object_slug: row.object_slug as string,
+    record_id: row.record_id as string,
+    attribute_slug: row.attribute_slug as string,
+    attribute_type: row.attribute_type as string,
+    value_json: (row.value_json as string | null) ?? "",
+    normalized_key: (row.normalized_key as string | null) ?? null,
+    ref_object: (row.ref_object as string | null) ?? null,
+    ref_record_id: (row.ref_record_id as string | null) ?? null,
+  }));
+}
+
+async function loadKeeperInbound(
+  lix: Lix,
+  ref_object: string,
+  ref_record_id: string,
+): Promise<InboundRow[]> {
+  return loadInboundRefs(lix, ref_object, ref_record_id);
+}
+
+function duplicateKey(v: ValueRow): string | null {
+  // Prefer ref_record_id for record-references; normalized_key for everything
+  // else. If neither exists (e.g. free-text multivalued without normalization),
+  // the row cannot be deduped and is always moved.
+  if (v.ref_record_id) return `ref:${v.ref_record_id}`;
+  if (v.normalized_key) return `key:${v.normalized_key}`;
+  return null;
+}
+
+function sameValue(a: ValueRow, b: ValueRow): boolean {
+  // Cheap structural equality. value_json is small JSON; if the same fields
+  // appear in different order it still compares unequal, which is fine — the
+  // worst case is treating two structurally identical rows as a conflict and
+  // letting the conflict policy resolve it (defaulting to keep, so no data
+  // loss).
+  if (a.ref_record_id && b.ref_record_id) {
+    return a.ref_record_id === b.ref_record_id;
+  }
+  if (a.normalized_key && b.normalized_key) {
+    return a.normalized_key === b.normalized_key;
+  }
+  return a.value_json === b.value_json;
+}
+
+function safeJson(raw: string): unknown {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+async function resolveConflict(
+  attribute_slug: string,
+  keeperRow: ValueRow,
+  discardRow: ValueRow,
+  prefer: Prefer,
+): Promise<"keep" | "discard"> {
+  if (prefer === "keep") return "keep";
+  if (prefer === "discard") return "discard";
+  // interactive
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    process.stderr.write(
+      `\nconflict on ${attribute_slug}:\n` +
+        `  keep    → ${truncate(keeperRow.value_json)}\n` +
+        `  discard → ${truncate(discardRow.value_json)}\n`,
+    );
+    const answer = await new Promise<string>((resolve) =>
+      rl.question("which to keep? [k=keep / d=discard] ", resolve),
+    );
+    const s = answer.trim().toLowerCase();
+    return s.startsWith("d") ? "discard" : "keep";
+  } finally {
+    rl.close();
+  }
+}
+
+function truncate(s: string, n = 80): string {
+  if (s.length <= n) return s;
+  return s.slice(0, n) + "…";
+}

--- a/src/db/execute.test.ts
+++ b/src/db/execute.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { openTestWorkspace } from "../test/open-test-lix.js";
+import { exec } from "./execute.js";
+import { AcrmError } from "../lib/errors.js";
+
+describe("exec error mapping", () => {
+  it("upgrades LIX_TABLE_NOT_FOUND hint when the missing table is a known object_slug", async () => {
+    const lix = await openTestWorkspace();
+    try {
+      await exec(lix, "SELECT * FROM people");
+      throw new Error("expected throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(AcrmError);
+      const err = e as AcrmError;
+      expect(err.code).toBe("LIX_TABLE_NOT_FOUND");
+      expect(err.hint).toMatch(/object_slug/);
+      expect(err.hint).toMatch(/acrm_record/);
+      expect(err.hint).toMatch(/people/);
+    } finally {
+      await lix.close();
+    }
+  });
+
+  it("falls back to generic EAV hint for unknown tables", async () => {
+    const lix = await openTestWorkspace();
+    try {
+      await exec(lix, "SELECT * FROM foozle");
+      throw new Error("expected throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(AcrmError);
+      const err = e as AcrmError;
+      expect(err.code).toBe("LIX_TABLE_NOT_FOUND");
+      expect(err.hint).toMatch(/EAV/);
+    } finally {
+      await lix.close();
+    }
+  });
+});

--- a/src/db/execute.ts
+++ b/src/db/execute.ts
@@ -4,6 +4,31 @@ import { AcrmError } from "../lib/errors.js";
 
 export type Row = Record<string, unknown>;
 
+// Object slugs seeded by `acrm init`. When a user/agent reaches for one of
+// these as a SQL table, the LIX_TABLE_NOT_FOUND hint is upgraded to call out
+// the EAV shape with a copy-paste fix.
+const KNOWN_OBJECT_SLUGS = new Set([
+  "people",
+  "companies",
+  "deals",
+  "posts",
+  "transcripts",
+]);
+
+function extractMissingTableName(message: string): string | null {
+  // Lix surfaces messages like:
+  //   "Error during planning: table 'datafusion.public.people' not found"
+  // We want just the tail identifier ("people"). Accept dot-qualified names
+  // inside the quoted segment, then peel off the schema prefix.
+  const quoted = /['"`]([A-Za-z_][\w.]*)['"`]/.exec(message);
+  const bare = quoted ? null : /\btable\s+([A-Za-z_][\w.]*)/i.exec(message);
+  const m = quoted ?? bare;
+  if (!m) return null;
+  const raw = m[1] ?? "";
+  const tail = raw.includes(".") ? raw.split(".").pop()! : raw;
+  return tail.toLowerCase();
+}
+
 export async function exec(
   lix: Lix,
   sql: string,
@@ -20,10 +45,19 @@ export async function exec(
       // `message` says what's wrong, `hint` (when present) says how to fix it.
       let hint = e.hint;
       if (e.code === "LIX_TABLE_NOT_FOUND") {
-        // Lix's hint points at information_schema, but users hitting this are
-        // typically reaching for `select * from people` — the data is EAV in
-        // acrm_record + acrm_value, keyed by object_slug.
-        hint = `Records are EAV: try \`acrm execute "SELECT object_slug, COUNT(*) FROM acrm_record GROUP BY object_slug"\` to see what's loaded, then query acrm_value for attribute values.`;
+        const slug = extractMissingTableName(e.message);
+        if (slug && KNOWN_OBJECT_SLUGS.has(slug)) {
+          // Catch the exact mistake at the moment it happens, with the exact
+          // fix inline. Agents reaching for `select * from people` learn the
+          // EAV shape from the error rather than from the docs after the fact.
+          hint =
+            `\`${slug}\` is an object_slug, not a table. Try: ` +
+            `\`SELECT record_id FROM acrm_record WHERE object_slug='${slug}'\`. ` +
+            `To read fields, pivot from acrm_value (filter active_until IS NULL). ` +
+            `Run \`acrm execute --help\` for the full EAV cheat-sheet.`;
+        } else {
+          hint = `Records are EAV: try \`acrm execute "SELECT object_slug, COUNT(*) FROM acrm_record GROUP BY object_slug"\` to see what's loaded, then query acrm_value for attribute values.`;
+        }
       }
       throw new AcrmError(e.message, e.code, hint, e.details);
     }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `acrm merge` command to merge two CRM records with conflict resolution
- Adds [`src/commands/merge.ts`](https://github.com/cluster-software/agent-crm/pull/41/files#diff-9c402817fb764166eaae14c943dfb1f6bad3d718a74aee40c8b77c476451a45d) implementing `acrm merge <object> --keep <id> --discard <id>` with `--prefer` (keep/discard/interactive) and `--dry-run` options.
- The merge engine reassigns `acrm_value` rows, dedupes multivalued attributes, resolves single-valued conflicts per policy, redirects inbound record references (including rewriting embedded `value_json`), and deletes the discarded record.
- Adds `acrm execute --schema` in [`src/commands/execute.ts`](https://github.com/cluster-software/agent-crm/pull/41/files#diff-d2c74a7a9f5b41a53adf5dfd52c40781f1740c748d34f96154e5048e9ec4f9e3) to dump the workspace's EAV object/attribute layout as JSON.
- Improves `LIX_TABLE_NOT_FOUND` error hints in [`src/db/execute.ts`](https://github.com/cluster-software/agent-crm/pull/41/files#diff-5ced13b1df94a781e2eaa44ededcbc84aa33db4426928254fcac1519c3110e09) to explain the EAV model and suggest a corrected query when the missing table matches a known object slug.
- Risk: the merge is destructive — it soft-deletes `acrm_value` rows and hard-deletes the discarded `acrm_record` row; use `--dry-run` to preview before applying.

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c94ac78. 5 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues

</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->