### PR TITLE
rename merge to records dedupe

### DIFF
--- a/.changeset/rename-merge-to-records-dedupe.md
+++ b/.changeset/rename-merge-to-records-dedupe.md
@@ -1,0 +1,31 @@
+---
+"@agent-crm/cli": minor
+---
+
+Rename `acrm merge <object>` → `acrm records dedupe <object>`.
+
+Two reasons for the rename:
+
+- **Avoid collision with lix's "merge" terminology.** lix's `mergeVersion` / `mergeVersionPreview` already mean "merge two branches / versions of the workspace" — a different operation from collapsing two duplicate rows. Having both verbs alive on the same surface was going to confuse docs and chat ("merge the records on this branch and then merge the branch").
+- **Open a namespace for record-level operations.** Putting `records` at the front leaves room for the obvious siblings (`acrm records archive`, `acrm records restore`, `acrm records show <id>`, `acrm records list <object>`) without re-litigating the top-level command surface each time. Mirrors how `acrm import <source>` and `acrm auth <provider>` already group by capability.
+
+Old:
+
+```sh
+acrm merge people --keep <id> --discard <id>
+acrm merge people --keep <id> --discard <id> --dry-run --prefer discard
+```
+
+New:
+
+```sh
+acrm records dedupe people --keep <id> --discard <id>
+acrm records dedupe people --keep <id> --discard <id> --dry-run --prefer discard
+acrm records dedupe companies --keep <id> --discard <id>
+```
+
+Behavior is unchanged — all flags (`--keep`, `--discard`, `--prefer`, `--dry-run`) and the JSON result shape are identical. The implementation file moved to `src/commands/records.ts`; the programmatic export renamed `mergeRecords` → `dedupeRecords` (relevant only if you import it from outside the CLI).
+
+`skills/acrm-query.md` updated to use the new command and to call out the verb choice explicitly so agents don't try to use `acrm merge` and then guess at SQL surgery.
+
+**This is a breaking change for the CLI surface** — there is no shim under the old name. The merge command shipped in the previous release; anything wired against it (skills, scripts, CI) needs to switch to `acrm records dedupe`.

--- a/skills/acrm-query.md
+++ b/skills/acrm-query.md
@@ -100,26 +100,29 @@ acrm execute "
 > Don't `SELECT *` from `acrm_value` without filtering by `attribute_slug` —
 > a transcript row's `content` field alone can be tens of kilobytes.
 
-## Merging duplicates
+## Deduping records (collapsing two rows that describe the same entity)
 
-Two records describing the same entity? Don't hand-write merge SQL — use the
-first-class command:
+Don't hand-write merge SQL — use the first-class command:
 
 ```sh
-acrm merge people --keep <record_id> --discard <record_id> --dry-run
-acrm merge people --keep <record_id> --discard <record_id>
+acrm records dedupe people --keep <record_id> --discard <record_id> --dry-run
+acrm records dedupe people --keep <record_id> --discard <record_id>
 ```
 
-It reassigns the discard's `acrm_value` rows to the keeper, rewrites every
-inbound reference (including the embedded `target_record_id` in `value_json`),
-dedupes multivalued attributes, applies a conflict policy on single-valued
-attributes (`--prefer keep|discard|interactive`, default `keep`), and finally
-removes the discarded `acrm_record` row.
+Works on any object (`people`, `companies`, `deals`, `posts`, `transcripts`).
+Reassigns the discard's `acrm_value` rows to the keeper, rewrites every inbound
+reference (including the embedded `target_record_id` in `value_json`), dedupes
+multivalued attributes, applies a conflict policy on single-valued attributes
+(`--prefer keep|discard|interactive`, default `keep`), and removes the discarded
+`acrm_record` row.
+
+> The verb is `dedupe`, not `merge` — `merge` in lix-land means version/branch
+> merging (`mergeVersion`), which is a different operation.
 
 ## Mutating directly (rare)
 
-Prefer the CLI's `acrm import …` and `acrm merge …` commands — they handle
-soft-delete (`active_until`), provenance, and EAV invariants. Hand-rolled
+Prefer the CLI's `acrm import …` and `acrm records dedupe …` commands — they
+handle soft-delete (`active_until`), provenance, and EAV invariants. Hand-rolled
 `INSERT`/`UPDATE` on `acrm_value` should be the last resort, and you should
 read [the upsert helpers](https://github.com/cluster-software/agent-crm) once
 before doing it.

--- a/src/bin/acrm.ts
+++ b/src/bin/acrm.ts
@@ -3,7 +3,7 @@ import { createRequire } from "node:module";
 import { Command } from "commander";
 import { registerInit } from "../commands/init.js";
 import { registerExecute } from "../commands/execute.js";
-import { registerMerge } from "../commands/merge.js";
+import { registerRecords } from "../commands/records.js";
 import { registerImport, getOrCreateImportCommand } from "../commands/import.js";
 import { attachLinkedinSubcommand } from "../commands/import-linkedin.js";
 import { attachXSubcommand } from "../commands/import-x.js";
@@ -55,7 +55,7 @@ Typical flow:
   acrm import transcript          import a meeting transcript — use \`--from <provider>\` for the fast path, or pipe JSON via stdin / \`--file\`
   acrm ui                         browse the workspace in a local UI
   acrm execute "SELECT ..."       run SQL against the workspace
-  acrm merge people --keep <id> --discard <id>   merge two duplicate records
+  acrm records dedupe people --keep <id> --discard <id>   collapse two duplicate records into one
 
 Provider auth (one-time, for \`acrm import transcript --from <provider>\`):
 ${PROVIDERS.filter((p) => p.oauth)
@@ -87,7 +87,7 @@ attachXSubcommand(getOrCreateImportCommand(program));
 attachPostSubcommand(getOrCreateImportCommand(program));
 attachTranscriptSubcommand(getOrCreateImportCommand(program));
 registerExecute(program);
-registerMerge(program);
+registerRecords(program);
 registerUi(program);
 registerSkills(program);
 registerAuth(program);

--- a/src/commands/records.test.ts
+++ b/src/commands/records.test.ts
@@ -8,7 +8,7 @@ import {
   setSingleValue,
 } from "../db/upsert.js";
 import { generateUuid } from "../lib/ids.js";
-import { mergeRecords } from "./merge.js";
+import { dedupeRecords } from "./records.js";
 import { importTranscript } from "./import-transcript.js";
 
 async function seedPerson(
@@ -130,7 +130,7 @@ async function recordExists(
   return r.rows.length > 0;
 }
 
-describe("mergeRecords", () => {
+describe("dedupeRecords", () => {
   it("reassigns multivalued values and dedupes by normalized_key", async () => {
     const lix = await openTestWorkspace();
     const keep = await seedPerson(lix, {
@@ -141,7 +141,7 @@ describe("mergeRecords", () => {
       emails: ["alice@acme.com", "alice.b@acme.com"],
     });
 
-    const result = await mergeRecords(lix, {
+    const result = await dedupeRecords(lix, {
       object_slug: "people",
       keep_record_id: keep,
       discard_record_id: discard,
@@ -169,7 +169,7 @@ describe("mergeRecords", () => {
       job_title: "Founder",
     });
 
-    await mergeRecords(lix, {
+    await dedupeRecords(lix, {
       object_slug: "people",
       keep_record_id: keep,
       discard_record_id: discard,
@@ -200,7 +200,7 @@ describe("mergeRecords", () => {
       linkedin_url: "linkedin.com/in/discard",
     });
 
-    const result = await mergeRecords(lix, {
+    const result = await dedupeRecords(lix, {
       object_slug: "people",
       keep_record_id: keep,
       discard_record_id: discard,
@@ -226,7 +226,7 @@ describe("mergeRecords", () => {
       linkedin_url: "linkedin.com/in/discard",
     });
 
-    await mergeRecords(lix, {
+    await dedupeRecords(lix, {
       object_slug: "people",
       keep_record_id: keep,
       discard_record_id: discard,
@@ -264,7 +264,7 @@ describe("mergeRecords", () => {
     );
     expect(before.rows[0]?.ref_record_id).toBe(discard);
 
-    await mergeRecords(lix, {
+    await dedupeRecords(lix, {
       object_slug: "people",
       keep_record_id: keep,
       discard_record_id: discard,
@@ -304,7 +304,7 @@ describe("mergeRecords", () => {
     });
     const discard = await seedPerson(lix, { email: "luis@cluster.com" });
 
-    const plan = await mergeRecords(lix, {
+    const plan = await dedupeRecords(lix, {
       object_slug: "people",
       keep_record_id: keep,
       discard_record_id: discard,
@@ -324,7 +324,7 @@ describe("mergeRecords", () => {
     const lix = await openTestWorkspace();
     const id = await seedPerson(lix, { email: "a@b.com" });
     await expect(
-      mergeRecords(lix, {
+      dedupeRecords(lix, {
         object_slug: "people",
         keep_record_id: id,
         discard_record_id: id,
@@ -339,7 +339,7 @@ describe("mergeRecords", () => {
     const lix = await openTestWorkspace();
     const id = await seedPerson(lix, { email: "a@b.com" });
     await expect(
-      mergeRecords(lix, {
+      dedupeRecords(lix, {
         object_slug: "people",
         keep_record_id: id,
         discard_record_id: "does-not-exist",
@@ -370,7 +370,7 @@ describe("mergeRecords", () => {
       participants: [{ email: "luis@hello-cluster.com" }],
     });
 
-    const result = await mergeRecords(lix, {
+    const result = await dedupeRecords(lix, {
       object_slug: "people",
       keep_record_id: luis1,
       discard_record_id: luis2,

--- a/src/commands/records.ts
+++ b/src/commands/records.ts
@@ -37,7 +37,7 @@ type AttributeMeta = {
   is_multivalued: boolean;
 };
 
-export type MergePlanItem =
+export type DedupePlanItem =
   | {
       kind: "move_multi";
       attribute_slug: string;
@@ -84,12 +84,12 @@ export type MergePlanItem =
       value_id: string;
     };
 
-export type MergePlan = {
+export type DedupePlan = {
   object_slug: string;
   keep_record_id: string;
   discard_record_id: string;
   prefer: Prefer;
-  items: MergePlanItem[];
+  items: DedupePlanItem[];
   conflicts: Array<{
     attribute_slug: string;
     keeper_value_json: unknown;
@@ -98,7 +98,7 @@ export type MergePlan = {
   }>;
 };
 
-export type MergeResult = MergePlan & {
+export type DedupeResult = DedupePlan & {
   applied: boolean;
   values_moved: number;
   values_dropped: number;
@@ -107,11 +107,22 @@ export type MergeResult = MergePlan & {
   discard_record_deleted: boolean;
 };
 
-export function registerMerge(program: Command): void {
-  program
-    .command("merge <object>")
+export function registerRecords(program: Command): void {
+  // Namespace `records` carves out room for future per-record operations
+  // (archive, restore, show, list) without crowding the top-level surface.
+  // `dedupe` is the verb agents and humans reach for when two rows describe
+  // the same entity — chosen over `merge` to keep clear of lix's branch /
+  // version merge terminology.
+  const records = program
+    .command("records")
     .description(
-      "merge two records of the same object: reassign attribute values + inbound references from `--discard` to `--keep`, then delete the discarded record. Use when two `people`/`companies`/etc. records describe the same entity (e.g. one created from a LinkedIn import and a duplicate created from a transcript email).",
+      "operations on records as a group (dedupe duplicates, etc.). Subcommands act on any object — `people`, `companies`, `deals`, `posts`, `transcripts`.",
+    );
+
+  records
+    .command("dedupe <object>")
+    .description(
+      "collapse two duplicate records of the same object into one: reassign attribute values + inbound references from `--discard` to `--keep`, then delete the discarded record. Use when two `people`/`companies`/etc. records describe the same entity (e.g. one created from a LinkedIn import and a duplicate created from a transcript email).",
     )
     .requiredOption("--keep <record_id>", "the record to keep (winner)")
     .requiredOption("--discard <record_id>", "the record to delete (loser)")
@@ -128,9 +139,10 @@ export function registerMerge(program: Command): void {
       "after",
       `
 Examples:
-  acrm merge people --keep <luis-1> --discard <luis-2>
-  acrm merge people --keep <luis-1> --discard <luis-2> --dry-run
-  acrm merge people --keep <luis-1> --discard <luis-2> --prefer discard
+  acrm records dedupe people --keep <luis-1> --discard <luis-2>
+  acrm records dedupe people --keep <luis-1> --discard <luis-2> --dry-run
+  acrm records dedupe people --keep <luis-1> --discard <luis-2> --prefer discard
+  acrm records dedupe companies --keep <co-1> --discard <co-2>
 
 What it does:
   1. Reassigns every \`acrm_value\` row from the discard to the keeper.
@@ -155,7 +167,7 @@ the operation is idempotent once the duplicate row has been redirected.
         const prefer = parsePrefer(opts.prefer);
         const lix = await openWorkspace({ workspace: root.workspace });
         try {
-          const result = await mergeRecords(lix, {
+          const result = await dedupeRecords(lix, {
             object_slug: object,
             keep_record_id: opts.keep,
             discard_record_id: opts.discard,
@@ -187,7 +199,7 @@ function parsePrefer(input: string | undefined): Prefer {
   );
 }
 
-export async function mergeRecords(
+export async function dedupeRecords(
   lix: Lix,
   args: {
     object_slug: string;
@@ -196,7 +208,7 @@ export async function mergeRecords(
     prefer: Prefer;
     dryRun: boolean;
   },
-): Promise<MergeResult> {
+): Promise<DedupeResult> {
   const { object_slug, keep_record_id, discard_record_id, prefer, dryRun } =
     args;
 
@@ -223,8 +235,8 @@ export async function mergeRecords(
     keep_record_id,
   );
 
-  const items: MergePlanItem[] = [];
-  const conflicts: MergeResult["conflicts"] = [];
+  const items: DedupePlanItem[] = [];
+  const conflicts: DedupeResult["conflicts"] = [];
 
   // Index keeper values by attribute for O(1) lookups during planning.
   const keeperByAttr = new Map<string, ValueRow[]>();
@@ -350,7 +362,7 @@ export async function mergeRecords(
     }
   }
 
-  const plan: MergePlan = {
+  const plan: DedupePlan = {
     object_slug,
     keep_record_id,
     discard_record_id,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Rename CLI command `acrm merge` to `acrm records dedupe`
- Replaces the top-level `merge` command with a `records` namespace and `dedupe` subcommand in [acrm.ts](https://github.com/cluster-software/agent-crm/pull/43/files#diff-d49d3d7f19bd39ed5d54a5fa89d3b11faf2af5dc160878da331e55fba7c1de44) and [records.ts](https://github.com/cluster-software/agent-crm/pull/43/files#diff-99422b62fefbcfb3f4b6cc7a1f13303389f91346e028a968d16e9a5cfb2e2197); flags (`--keep`, `--discard`, `--prefer`, `--dry-run`) and runtime behavior are unchanged.
- Renames the programmatic export from `mergeRecords` to `dedupeRecords`, with matching type renames (`MergePlanItem/Plan/Result` → `DedupePlanItem/Plan/Result`).
- Updates agent skills docs and help text to reflect the new command name.
- Risk: Breaking CLI change — scripts using `acrm merge <object>` must be updated to `acrm records dedupe <object>`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized aeecf6d.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->