### PR TITLE
Auto detect CLI updates

### DIFF
--- a/.changeset/cli-update-check.md
+++ b/.changeset/cli-update-check.md
@@ -1,0 +1,22 @@
+---
+"@agent-crm/cli": minor
+---
+
+Detect when the installed `acrm` CLI is outdated and prompt agents/users to update before continuing.
+
+**Why.** Agents follow whichever `acrm` is already on the box. If an old global install lingers (e.g. `0.1.0`), the agent proceeds with stale `init` behavior and misses newer affordances. Filed as #47.
+
+**How it works.** On every CLI startup, `acrm` reads `~/.config/acrm/update-check.json` (honors `ACRM_CONFIG_DIR`). If a newer version is cached, it prints to **stderr**:
+
+```
+⚠ A newer @agent-crm/cli is available: 0.9.0 (you are using 0.1.0).
+  Run: npm install -g @agent-crm/cli@latest
+```
+
+If the cache is missing or older than 24h, `acrm` spawns a detached, unref'd worker that hits `registry.npmjs.org/@agent-crm/cli/latest` and rewrites the cache. The current command returns immediately — the *next* invocation sees the fresh result. Same pattern npm itself uses.
+
+**Output stays clean.** The warning is stderr-only, so `--json` stdout remains parseable.
+
+**Opt-outs.** Set `ACRM_NO_UPDATE_CHECK=1`, `NO_UPDATE_NOTIFIER=1`, or `CI=true` to suppress entirely. Dev/pre-release versions (anything containing a `-` suffix) skip the check.
+
+**No new dependencies.** ~150 lines of stdlib, including a tiny numeric semver comparator (so `0.10.0 > 0.9.0` works correctly).

--- a/.changeset/cli-update-check.md
+++ b/.changeset/cli-update-check.md
@@ -2,21 +2,36 @@
 "@agent-crm/cli": minor
 ---
 
-Detect when the installed `acrm` CLI is outdated and prompt agents/users to update before continuing.
+Detect when the installed `acrm` CLI is outdated and prompt to update before continuing. Fixes #47.
 
-**Why.** Agents follow whichever `acrm` is already on the box. If an old global install lingers (e.g. `0.1.0`), the agent proceeds with stale `init` behavior and misses newer affordances. Filed as #47.
+**Interactive TTY (humans).** When both stdin and stdout are TTYs, `acrm` shows a Codex-style block before running the command:
 
-**How it works.** On every CLI startup, `acrm` reads `~/.config/acrm/update-check.json` (honors `ACRM_CONFIG_DIR`). If a newer version is cached, it prints to **stderr**:
+```
+✨ Update available! 0.1.0 → 0.9.0
+
+Release notes: https://github.com/cluster-software/agent-crm/releases/latest
+
+› 1. Update now (runs `npm install -g @agent-crm/cli@latest`)
+  2. Skip
+
+Press enter to continue
+```
+
+Arrow keys (or number keys) move the cursor; Enter confirms. "Update now" runs `npm install -g @agent-crm/cli@latest` with inherited stdio and exits when it finishes, asking you to re-run your command with the new binary. "Skip" continues with your original command and is remembered for the cached latest version — once a *newer* version is published, the prompt fires again.
+
+**Non-TTY (agents, pipes, CI).** Falls back to a one-line stderr warning so agents and pipelines see the update signal without anything to interact with:
 
 ```
 ⚠ A newer @agent-crm/cli is available: 0.9.0 (you are using 0.1.0).
   Run: npm install -g @agent-crm/cli@latest
 ```
 
-If the cache is missing or older than 24h, `acrm` spawns a detached, unref'd worker that hits `registry.npmjs.org/@agent-crm/cli/latest` and rewrites the cache. The current command returns immediately — the *next* invocation sees the fresh result. Same pattern npm itself uses.
+This was the original ask in #47 — agents reading `acrm --help` need an explicit, parseable instruction to update before initializing a workspace.
 
-**Output stays clean.** The warning is stderr-only, so `--json` stdout remains parseable.
+**How the version check works.** On every CLI startup, `acrm` reads `~/.config/acrm/update-check.json` (honors `ACRM_CONFIG_DIR`). If the cache shows a newer published version, the prompt or warning fires. If the cache is missing or older than 24h, a detached, unref'd worker is spawned that hits `registry.npmjs.org/@agent-crm/cli/latest` and rewrites the cache — the current command returns immediately and the *next* invocation sees the fresh result. Same pattern npm itself uses.
 
-**Opt-outs.** Set `ACRM_NO_UPDATE_CHECK=1`, `NO_UPDATE_NOTIFIER=1`, or `CI=true` to suppress entirely. Dev/pre-release versions (anything containing a `-` suffix) skip the check.
+**Output stays clean.** All update-check output goes to **stderr**, never stdout. `acrm execute "..." --json | jq .` parses normally even when a warning is firing.
 
-**No new dependencies.** ~150 lines of stdlib, including a tiny numeric semver comparator (so `0.10.0 > 0.9.0` works correctly).
+**Opt-outs.** Set `ACRM_NO_UPDATE_CHECK=1`, `NO_UPDATE_NOTIFIER=1`, or `CI=true` to suppress entirely. Dev/pre-release versions (anything with a `-` suffix) are skipped automatically.
+
+**No new dependencies.** ~250 lines of stdlib (`node:fs`, `node:child_process`, `node:readline`), including a small numeric semver comparator so `0.10.0 > 0.9.0` works correctly.

--- a/src/bin/acrm.ts
+++ b/src/bin/acrm.ts
@@ -16,19 +16,13 @@ import { PROVIDERS } from "../integrations/providers.js";
 import { fail } from "../output/json.js";
 import { ERR } from "../lib/errors.js";
 import {
-  notifyIfOutdated,
+  promptIfOutdated,
   scheduleBackgroundRefreshIfStale,
 } from "../lib/update-check.js";
 
 const pkg = createRequire(import.meta.url)("../../package.json") as {
   version: string;
 };
-
-// Print a stderr warning if a newer published version is cached, then kick
-// off a detached worker to refresh the cache for next time. Both calls are
-// non-blocking and swallow all errors — see src/lib/update-check.ts.
-notifyIfOutdated(pkg.version);
-scheduleBackgroundRefreshIfStale(pkg.version);
 
 const program = new Command();
 
@@ -102,7 +96,17 @@ registerUi(program);
 registerSkills(program);
 registerAuth(program);
 
-program.parseAsync(process.argv).catch((err) => {
+async function main() {
+  // Interactive TTYs get a Codex-style update prompt; non-TTY callers (agents,
+  // pipes, CI) get a plain stderr warning. Either way, kick off a detached
+  // worker to refresh the version cache for next time. All update-check
+  // failures are swallowed — see src/lib/update-check.ts.
+  await promptIfOutdated(pkg.version);
+  scheduleBackgroundRefreshIfStale(pkg.version);
+  await program.parseAsync(process.argv);
+}
+
+main().catch((err) => {
   fail(err instanceof Error ? err.message : String(err), ERR.UNHANDLED);
   process.exit(1);
 });

--- a/src/bin/acrm.ts
+++ b/src/bin/acrm.ts
@@ -15,10 +15,20 @@ import { registerAuth } from "../commands/auth.js";
 import { PROVIDERS } from "../integrations/providers.js";
 import { fail } from "../output/json.js";
 import { ERR } from "../lib/errors.js";
+import {
+  notifyIfOutdated,
+  scheduleBackgroundRefreshIfStale,
+} from "../lib/update-check.js";
 
 const pkg = createRequire(import.meta.url)("../../package.json") as {
   version: string;
 };
+
+// Print a stderr warning if a newer published version is cached, then kick
+// off a detached worker to refresh the cache for next time. Both calls are
+// non-blocking and swallow all errors — see src/lib/update-check.ts.
+notifyIfOutdated(pkg.version);
+scheduleBackgroundRefreshIfStale(pkg.version);
 
 const program = new Command();
 

--- a/src/lib/update-check.test.ts
+++ b/src/lib/update-check.test.ts
@@ -139,6 +139,23 @@ describe("update-check cache + notify", () => {
     expect(output()).toBe("");
   });
 
+  it("writeCache overwrites a prior skipped_version", () => {
+    // Simulate the background worker running after the user dismissed the
+    // prompt: the cache must reset so the next published bump re-prompts.
+    writeFileSync(
+      cachePath(),
+      JSON.stringify({
+        checked_at: Date.now(),
+        latest_version: "0.9.0",
+        skipped_version: "0.9.0",
+      }),
+    );
+    writeCache("0.10.0");
+    const parsed = JSON.parse(readFileSync(cachePath(), "utf8"));
+    expect(parsed.latest_version).toBe("0.10.0");
+    expect(parsed.skipped_version).toBeUndefined();
+  });
+
   for (const optOut of ["ACRM_NO_UPDATE_CHECK", "NO_UPDATE_NOTIFIER", "CI"]) {
     it(`stays silent when ${optOut} is set`, () => {
       writeCache("0.9.0");

--- a/src/lib/update-check.test.ts
+++ b/src/lib/update-check.test.ts
@@ -1,0 +1,252 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Writable } from "node:stream";
+import {
+  cachePath,
+  compareVersions,
+  configDir,
+  lockPath,
+  notifyIfOutdated,
+  parseVersion,
+  scheduleBackgroundRefreshIfStale,
+  writeCache,
+} from "./update-check.js";
+
+function captureStream(): { stream: Writable; output: () => string } {
+  const chunks: Buffer[] = [];
+  const stream = new Writable({
+    write(chunk, _enc, cb) {
+      chunks.push(Buffer.from(chunk));
+      cb();
+    },
+  });
+  return {
+    stream,
+    output: () => Buffer.concat(chunks).toString("utf8"),
+  };
+}
+
+describe("parseVersion", () => {
+  it("parses valid semver triples", () => {
+    expect(parseVersion("0.1.0")).toEqual([0, 1, 0]);
+    expect(parseVersion("0.10.5")).toEqual([0, 10, 5]);
+    expect(parseVersion("12.34.56")).toEqual([12, 34, 56]);
+  });
+
+  it("rejects pre-release suffixes", () => {
+    expect(parseVersion("0.9.0-dev")).toBeNull();
+    expect(parseVersion("1.0.0-rc.1")).toBeNull();
+  });
+
+  it("rejects malformed strings", () => {
+    expect(parseVersion("0.1")).toBeNull();
+    expect(parseVersion("v0.1.0")).toBeNull();
+    expect(parseVersion("")).toBeNull();
+  });
+});
+
+describe("compareVersions", () => {
+  it("compares numerically, not lexically", () => {
+    // This is the classic bug — string compare would say "0.10.0" < "0.9.0".
+    expect(compareVersions("0.10.0", "0.9.0")).toBe(1);
+    expect(compareVersions("0.9.0", "0.10.0")).toBe(-1);
+  });
+
+  it("orders by major, minor, patch", () => {
+    expect(compareVersions("1.0.0", "0.99.0")).toBe(1);
+    expect(compareVersions("0.7.0", "0.1.0")).toBe(1);
+    expect(compareVersions("0.9.0", "0.9.0")).toBe(0);
+  });
+
+  it("returns 0 when either side is unparseable", () => {
+    expect(compareVersions("0.9.0-dev", "0.9.0")).toBe(0);
+    expect(compareVersions("garbage", "0.9.0")).toBe(0);
+  });
+});
+
+describe("update-check cache + notify", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(path.join(tmpdir(), "acrm-update-check-"));
+    process.env.ACRM_CONFIG_DIR = tmp;
+    delete process.env.ACRM_NO_UPDATE_CHECK;
+    delete process.env.NO_UPDATE_NOTIFIER;
+    delete process.env.CI;
+  });
+
+  afterEach(() => {
+    delete process.env.ACRM_CONFIG_DIR;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("honors ACRM_CONFIG_DIR for cache location", () => {
+    expect(configDir()).toBe(tmp);
+    expect(cachePath()).toBe(path.join(tmp, "update-check.json"));
+  });
+
+  it("writes the cache file with 0600 permissions", () => {
+    writeCache("0.9.0");
+    const mode = statSync(cachePath()).mode & 0o777;
+    expect(mode & 0o077).toBe(0);
+    const parsed = JSON.parse(readFileSync(cachePath(), "utf8"));
+    expect(parsed.latest_version).toBe("0.9.0");
+    expect(typeof parsed.checked_at).toBe("number");
+  });
+
+  it("warns when cache shows a newer version", () => {
+    writeCache("0.9.0");
+    const { stream, output } = captureStream();
+    notifyIfOutdated("0.1.0", stream);
+    expect(output()).toMatch(/A newer @agent-crm\/cli is available: 0\.9\.0/);
+    expect(output()).toMatch(/you are using 0\.1\.0/);
+    expect(output()).toMatch(/npm install -g @agent-crm\/cli@latest/);
+  });
+
+  it("stays silent when current version equals cached latest", () => {
+    writeCache("0.9.0");
+    const { stream, output } = captureStream();
+    notifyIfOutdated("0.9.0", stream);
+    expect(output()).toBe("");
+  });
+
+  it("stays silent when current version is newer than cached latest", () => {
+    writeCache("0.9.0");
+    const { stream, output } = captureStream();
+    notifyIfOutdated("0.10.0", stream);
+    expect(output()).toBe("");
+  });
+
+  it("stays silent when no cache exists", () => {
+    const { stream, output } = captureStream();
+    notifyIfOutdated("0.1.0", stream);
+    expect(output()).toBe("");
+  });
+
+  it("stays silent when cache JSON is malformed", () => {
+    writeFileSync(cachePath(), "not json", { encoding: "utf8" });
+    const { stream, output } = captureStream();
+    notifyIfOutdated("0.1.0", stream);
+    expect(output()).toBe("");
+  });
+
+  it("stays silent on a dev/pre-release current version", () => {
+    writeCache("0.9.0");
+    const { stream, output } = captureStream();
+    notifyIfOutdated("0.9.0-dev", stream);
+    expect(output()).toBe("");
+  });
+
+  for (const optOut of ["ACRM_NO_UPDATE_CHECK", "NO_UPDATE_NOTIFIER", "CI"]) {
+    it(`stays silent when ${optOut} is set`, () => {
+      writeCache("0.9.0");
+      process.env[optOut] = "1";
+      const { stream, output } = captureStream();
+      notifyIfOutdated("0.1.0", stream);
+      expect(output()).toBe("");
+      delete process.env[optOut];
+    });
+  }
+});
+
+describe("scheduleBackgroundRefreshIfStale", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(path.join(tmpdir(), "acrm-update-refresh-"));
+    process.env.ACRM_CONFIG_DIR = tmp;
+    delete process.env.ACRM_NO_UPDATE_CHECK;
+    delete process.env.NO_UPDATE_NOTIFIER;
+    delete process.env.CI;
+  });
+
+  afterEach(() => {
+    delete process.env.ACRM_CONFIG_DIR;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function fakeSpawn() {
+    const unref = vi.fn();
+    const fn = vi.fn().mockReturnValue({ unref });
+    // Cast through unknown to satisfy the spawn typing — we only exercise
+    // the two methods the production code actually uses.
+    return { fn: fn as unknown as typeof import("node:child_process").spawn, calls: fn, unref };
+  }
+
+  it("spawns a detached worker when cache is missing", () => {
+    const { fn, calls, unref } = fakeSpawn();
+    const scheduled = scheduleBackgroundRefreshIfStale("0.9.0", {
+      workerPath: "/fake/worker.js",
+      spawnFn: fn,
+    });
+    expect(scheduled).toBe(true);
+    expect(calls).toHaveBeenCalledOnce();
+    const [, args, opts] = calls.mock.calls[0];
+    expect(args).toEqual(["/fake/worker.js"]);
+    expect((opts as { detached?: boolean }).detached).toBe(true);
+    expect(unref).toHaveBeenCalledOnce();
+  });
+
+  it("does not spawn when cache is fresh", () => {
+    writeCache("0.9.0");
+    const { fn, calls } = fakeSpawn();
+    const scheduled = scheduleBackgroundRefreshIfStale("0.9.0", {
+      workerPath: "/fake/worker.js",
+      spawnFn: fn,
+    });
+    expect(scheduled).toBe(false);
+    expect(calls).not.toHaveBeenCalled();
+  });
+
+  it("spawns when cache is older than the TTL", () => {
+    // Hand-write a cache with an ancient timestamp.
+    writeFileSync(
+      cachePath(),
+      JSON.stringify({
+        checked_at: Date.now() - 48 * 60 * 60 * 1000,
+        latest_version: "0.9.0",
+      }),
+    );
+    const { fn, calls } = fakeSpawn();
+    const scheduled = scheduleBackgroundRefreshIfStale("0.9.0", {
+      workerPath: "/fake/worker.js",
+      spawnFn: fn,
+    });
+    expect(scheduled).toBe(true);
+    expect(calls).toHaveBeenCalledOnce();
+  });
+
+  it("respects the lock file to avoid concurrent worker storms", () => {
+    writeFileSync(lockPath(), String(Date.now()));
+    const { fn, calls } = fakeSpawn();
+    const scheduled = scheduleBackgroundRefreshIfStale("0.9.0", {
+      workerPath: "/fake/worker.js",
+      spawnFn: fn,
+    });
+    expect(scheduled).toBe(false);
+    expect(calls).not.toHaveBeenCalled();
+  });
+
+  it("does not spawn when opted out", () => {
+    process.env.ACRM_NO_UPDATE_CHECK = "1";
+    const { fn, calls } = fakeSpawn();
+    const scheduled = scheduleBackgroundRefreshIfStale("0.9.0", {
+      workerPath: "/fake/worker.js",
+      spawnFn: fn,
+    });
+    expect(scheduled).toBe(false);
+    expect(calls).not.toHaveBeenCalled();
+  });
+
+  it("does not spawn for dev/pre-release current versions", () => {
+    const { fn, calls } = fakeSpawn();
+    const scheduled = scheduleBackgroundRefreshIfStale("0.9.0-dev", {
+      workerPath: "/fake/worker.js",
+      spawnFn: fn,
+    });
+    expect(scheduled).toBe(false);
+    expect(calls).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/update-check.ts
+++ b/src/lib/update-check.ts
@@ -1,0 +1,186 @@
+// Background update notifier — same pattern as npm's `update-notifier`:
+//   1. On every CLI startup, read a tiny JSON cache. If it shows a newer
+//      published version than what's installed, print a warning to STDERR
+//      (never stdout, so --json output stays clean).
+//   2. If the cache is missing or older than TTL_MS, spawn a detached,
+//      unref'd child process that fetches the npm registry and rewrites
+//      the cache. The current command returns immediately; the *next*
+//      invocation sees the fresh result.
+//
+// All failures are swallowed silently. An update check must never break,
+// slow down, or fail an acrm command.
+import { readFileSync, writeFileSync, mkdirSync, statSync, chmodSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const TTL_MS = 24 * 60 * 60 * 1000;
+const LOCK_TTL_MS = 60 * 1000;
+
+export type UpdateCheckCache = {
+  checked_at: number;
+  latest_version: string;
+};
+
+export function configDir(): string {
+  if (process.env.ACRM_CONFIG_DIR && process.env.ACRM_CONFIG_DIR.trim().length) {
+    return process.env.ACRM_CONFIG_DIR;
+  }
+  return path.join(homedir(), ".config", "acrm");
+}
+
+export function cachePath(): string {
+  return path.join(configDir(), "update-check.json");
+}
+
+export function lockPath(): string {
+  return path.join(configDir(), "update-check.lock");
+}
+
+// Parse "0.7.0" → [0, 7, 0]. Returns null for anything non-numeric or with a
+// pre-release suffix ("0.9.0-dev", "1.0.0-rc.1") — those should not trigger
+// a warning at all.
+export function parseVersion(v: string): [number, number, number] | null {
+  if (typeof v !== "string") return null;
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(v.trim());
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+// Returns 1 if a > b, -1 if a < b, 0 if equal. Throws never — non-parseable
+// inputs return 0 so callers default to "do nothing".
+export function compareVersions(a: string, b: string): number {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  if (!pa || !pb) return 0;
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] > pb[i]) return 1;
+    if (pa[i] < pb[i]) return -1;
+  }
+  return 0;
+}
+
+function readCache(): UpdateCheckCache | null {
+  try {
+    const raw = readFileSync(cachePath(), "utf8");
+    const parsed = JSON.parse(raw) as UpdateCheckCache;
+    if (
+      !parsed ||
+      typeof parsed.checked_at !== "number" ||
+      typeof parsed.latest_version !== "string"
+    ) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function writeCache(latest: string): void {
+  try {
+    const dir = configDir();
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    const file = cachePath();
+    const payload: UpdateCheckCache = {
+      checked_at: Date.now(),
+      latest_version: latest,
+    };
+    writeFileSync(file, JSON.stringify(payload) + "\n", {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    chmodSync(file, 0o600);
+  } catch {
+    // Swallow — we'd rather skip future checks than break this command.
+  }
+}
+
+function isOptedOut(): boolean {
+  return Boolean(
+    process.env.ACRM_NO_UPDATE_CHECK ||
+      process.env.NO_UPDATE_NOTIFIER ||
+      process.env.CI,
+  );
+}
+
+// Pre-release / dev builds should not nag (e.g. when running `tsx src/...`
+// against a 0.9.0 install but the published version is 0.9.0 too).
+function isComparableVersion(v: string): boolean {
+  return parseVersion(v) !== null;
+}
+
+export function notifyIfOutdated(
+  currentVersion: string,
+  stderr: NodeJS.WritableStream = process.stderr,
+): void {
+  if (isOptedOut()) return;
+  if (!isComparableVersion(currentVersion)) return;
+  const cached = readCache();
+  if (!cached) return;
+  if (compareVersions(cached.latest_version, currentVersion) <= 0) return;
+  stderr.write(
+    `\n⚠ A newer @agent-crm/cli is available: ${cached.latest_version} (you are using ${currentVersion}).\n` +
+      `  Run: npm install -g @agent-crm/cli@latest\n\n`,
+  );
+}
+
+function isCacheStale(): boolean {
+  const cached = readCache();
+  if (!cached) return true;
+  return Date.now() - cached.checked_at > TTL_MS;
+}
+
+// Returns false if another invocation already holds the lock recently —
+// prevents two near-simultaneous commands from both spawning workers.
+function tryAcquireLock(): boolean {
+  try {
+    const p = lockPath();
+    try {
+      const s = statSync(p);
+      if (Date.now() - s.mtimeMs < LOCK_TTL_MS) return false;
+    } catch {
+      // ENOENT — fall through to create the lock.
+    }
+    mkdirSync(configDir(), { recursive: true, mode: 0o700 });
+    writeFileSync(p, String(Date.now()), { encoding: "utf8", mode: 0o600 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Spawn the refresh worker as a detached, unref'd child. Returns immediately.
+// The worker writes the cache file when it finishes; the next acrm invocation
+// will pick it up.
+export function scheduleBackgroundRefreshIfStale(
+  currentVersion: string,
+  opts: { workerPath?: string; spawnFn?: typeof spawn } = {},
+): boolean {
+  if (isOptedOut()) return false;
+  if (!isComparableVersion(currentVersion)) return false;
+  if (!isCacheStale()) return false;
+  if (!tryAcquireLock()) return false;
+
+  const worker = opts.workerPath ?? defaultWorkerPath();
+  const spawnFn = opts.spawnFn ?? spawn;
+  try {
+    const child = spawnFn(process.execPath, [worker], {
+      detached: true,
+      stdio: "ignore",
+      env: process.env,
+    });
+    child.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// The compiled worker sits next to this file's compiled output:
+//   dist/lib/update-check.js  →  dist/scripts/refresh-version-cache.js
+function defaultWorkerPath(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.join(here, "..", "scripts", "refresh-version-cache.js");
+}

--- a/src/lib/update-check.ts
+++ b/src/lib/update-check.ts
@@ -14,13 +14,20 @@ import { homedir } from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import * as readline from "node:readline";
 
 const TTL_MS = 24 * 60 * 60 * 1000;
 const LOCK_TTL_MS = 60 * 1000;
+const RELEASES_URL =
+  "https://github.com/cluster-software/agent-crm/releases/latest";
 
 export type UpdateCheckCache = {
   checked_at: number;
   latest_version: string;
+  // Set when the user picks "Skip" at the interactive prompt. We keep the
+  // prompt suppressed for this version only — a newer published version
+  // will replace latest_version and re-trigger the prompt next time.
+  skipped_version?: string;
 };
 
 export function configDir(): string {
@@ -78,16 +85,12 @@ function readCache(): UpdateCheckCache | null {
   }
 }
 
-export function writeCache(latest: string): void {
+function writeCacheRaw(cache: UpdateCheckCache): void {
   try {
     const dir = configDir();
     mkdirSync(dir, { recursive: true, mode: 0o700 });
     const file = cachePath();
-    const payload: UpdateCheckCache = {
-      checked_at: Date.now(),
-      latest_version: latest,
-    };
-    writeFileSync(file, JSON.stringify(payload) + "\n", {
+    writeFileSync(file, JSON.stringify(cache) + "\n", {
       encoding: "utf8",
       mode: 0o600,
     });
@@ -95,6 +98,19 @@ export function writeCache(latest: string): void {
   } catch {
     // Swallow — we'd rather skip future checks than break this command.
   }
+}
+
+export function writeCache(latest: string): void {
+  // Background-worker entry point — overwrites the cache wholesale, dropping
+  // any prior skipped_version because a fresh fetch may have surfaced a new
+  // latest that the user hasn't dismissed yet.
+  writeCacheRaw({ checked_at: Date.now(), latest_version: latest });
+}
+
+function markSkipped(version: string): void {
+  const existing = readCache();
+  if (!existing) return;
+  writeCacheRaw({ ...existing, skipped_version: version });
 }
 
 function isOptedOut(): boolean {
@@ -183,4 +199,155 @@ export function scheduleBackgroundRefreshIfStale(
 function defaultWorkerPath(): string {
   const here = path.dirname(fileURLToPath(import.meta.url));
   return path.join(here, "..", "scripts", "refresh-version-cache.js");
+}
+
+// Interactive TTY prompt — Codex-style heading, release notes link, and a
+// 2-option selector. Non-TTY callers (agents, pipes, CI) fall back to the
+// plain stderr warning from notifyIfOutdated.
+export async function promptIfOutdated(currentVersion: string): Promise<void> {
+  if (isOptedOut()) return;
+  if (!isComparableVersion(currentVersion)) return;
+  const cached = readCache();
+  if (!cached) return;
+  if (compareVersions(cached.latest_version, currentVersion) <= 0) return;
+
+  const interactive =
+    Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY);
+  if (!interactive) {
+    notifyIfOutdated(currentVersion);
+    return;
+  }
+
+  // The user already chose "Skip" for this exact latest version — stay quiet
+  // until a newer one is published.
+  if (cached.skipped_version === cached.latest_version) return;
+
+  const choice = await renderPrompt(currentVersion, cached.latest_version);
+  if (choice === "update") {
+    await runUpdate();
+  } else {
+    markSkipped(cached.latest_version);
+  }
+}
+
+type PromptChoice = "update" | "skip";
+
+function renderPrompt(
+  current: string,
+  latest: string,
+): Promise<PromptChoice> {
+  const out = process.stderr;
+  const noColor = Boolean(process.env.NO_COLOR);
+  const c = (code: string, s: string) =>
+    noColor ? s : `\x1b[${code}m${s}\x1b[0m`;
+  const bold = (s: string) => c("1", s);
+  const dim = (s: string) => c("2", s);
+  const cyan = (s: string) => c("36", s);
+  const yellow = (s: string) => c("33", s);
+
+  const options = [
+    "Update now (runs `npm install -g @agent-crm/cli@latest`)",
+    "Skip",
+  ];
+  let selected = 0;
+
+  // Header is drawn once; only the option block + hint redraw on keypress.
+  out.write("\n");
+  out.write(`${yellow("✨")} ${bold("Update available!")} ${dim(current)} → ${latest}\n`);
+  out.write("\n");
+  out.write(`Release notes: ${cyan(RELEASES_URL)}\n`);
+  out.write("\n");
+
+  const REDRAW_LINES = options.length + 2; // options + blank + hint
+
+  const drawOptions = (firstPaint: boolean) => {
+    if (!firstPaint) {
+      for (let i = 0; i < REDRAW_LINES; i++) {
+        out.write("\x1b[1A\x1b[2K");
+      }
+    }
+    options.forEach((opt, i) => {
+      const marker = i === selected ? cyan("›") : " ";
+      const label = `${i + 1}. ${opt}`;
+      out.write(`${marker} ${i === selected ? bold(label) : label}\n`);
+    });
+    out.write("\n");
+    out.write(dim("Press enter to continue") + "\n");
+  };
+
+  drawOptions(true);
+
+  return new Promise<PromptChoice>((resolve) => {
+    const stdin = process.stdin;
+    readline.emitKeypressEvents(stdin);
+    const hadRawMode = stdin.isRaw;
+    if (stdin.setRawMode) stdin.setRawMode(true);
+    stdin.resume();
+
+    const cleanup = () => {
+      stdin.removeListener("keypress", onKey);
+      if (stdin.setRawMode) stdin.setRawMode(hadRawMode ?? false);
+      stdin.pause();
+      out.write("\n");
+    };
+
+    const onKey = (
+      _str: string,
+      key: { name?: string; ctrl?: boolean } | undefined,
+    ) => {
+      if (!key) return;
+      if (key.ctrl && key.name === "c") {
+        cleanup();
+        process.exit(130);
+      }
+      if (key.name === "up" || key.name === "k") {
+        if (selected > 0) {
+          selected--;
+          drawOptions(false);
+        }
+      } else if (key.name === "down" || key.name === "j") {
+        if (selected < options.length - 1) {
+          selected++;
+          drawOptions(false);
+        }
+      } else if (key.name === "1") {
+        selected = 0;
+        drawOptions(false);
+      } else if (key.name === "2") {
+        selected = 1;
+        drawOptions(false);
+      } else if (key.name === "return") {
+        cleanup();
+        resolve(selected === 0 ? "update" : "skip");
+      }
+    };
+
+    stdin.on("keypress", onKey);
+  });
+}
+
+function runUpdate(): Promise<void> {
+  return new Promise((resolve) => {
+    const out = process.stderr;
+    out.write("\nRunning `npm install -g @agent-crm/cli@latest`...\n\n");
+    const child = spawn("npm", ["install", "-g", "@agent-crm/cli@latest"], {
+      stdio: "inherit",
+    });
+    child.on("exit", (code) => {
+      if (code === 0) {
+        out.write("\n✓ Updated. Please re-run your command.\n");
+        process.exit(0);
+      }
+      out.write(
+        `\nnpm install exited with code ${code}. Continuing with your command anyway.\n`,
+      );
+      resolve();
+    });
+    child.on("error", (err) => {
+      out.write(
+        `\nFailed to run npm install: ${err.message}. Continuing with your command anyway.\n`,
+      );
+      resolve();
+    });
+  });
 }

--- a/src/scripts/refresh-version-cache.ts
+++ b/src/scripts/refresh-version-cache.ts
@@ -1,0 +1,40 @@
+// Detached worker spawned by src/lib/update-check.ts. Fetches the latest
+// published version from the npm registry and writes the cache file.
+//
+// Hard rule: this script must never throw. All errors are swallowed.
+// It also has a short timeout so a slow registry never leaves orphaned
+// background processes lingering on the user's machine.
+import { writeCache } from "../lib/update-check.js";
+
+const DEFAULT_REGISTRY = "https://registry.npmjs.org";
+const PACKAGE_NAME = "@agent-crm/cli";
+const TIMEOUT_MS = 5000;
+
+async function main(): Promise<void> {
+  const base = process.env.ACRM_REGISTRY_URL?.trim() || DEFAULT_REGISTRY;
+  // /<pkg>/latest returns the dist-tag manifest with `version` at the root.
+  const url = `${base.replace(/\/+$/, "")}/${encodeURIComponent(
+    PACKAGE_NAME,
+  )}/latest`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: { accept: "application/json" },
+    });
+    if (!res.ok) return;
+    const body = (await res.json()) as { version?: unknown };
+    if (typeof body.version !== "string" || !body.version) return;
+    writeCache(body.version);
+  } catch {
+    // Network error, abort, malformed JSON — all silently ignored.
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+main().catch(() => {
+  /* never throw out of a detached child */
+});


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add auto-detection of CLI updates with interactive TTY prompt and background cache refresh
- On each CLI startup, `promptIfOutdated` checks a local JSON cache (`~/.config/acrm/update-check.json`) and, in TTY sessions, shows an interactive prompt to update or skip when a newer version is available; in non-TTY contexts, writes a one-line stderr warning instead.
- A detached, unref'd background worker ([refresh-version-cache.ts](https://github.com/cluster-software/agent-crm/pull/57/files#diff-352653b2c56b05ceea34359de7a5f836fbaa348ee798f4db2363e27469e666b8)) is spawned via `scheduleBackgroundRefreshIfStale` when the cache is missing or stale, fetching the latest version from the npm registry with a 5s timeout.
- A mtime-based lock file prevents concurrent background worker spawns.
- Opting out is supported via `ACRM_NO_UPDATE_CHECK`, `NO_UPDATE_NOTIFIER`, or `CI` env vars; pre-release versions are excluded from update checks.
- Behavioral Change: CLI startup now performs a cache file read and may spawn a background process on every invocation unless opted out.

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized aaf2e8e. 4 files reviewed, 4 issues evaluated, 3 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>src/lib/update-check.ts — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 35](https://github.com/cluster-software/agent-crm/blob/aaf2e8e2aa0ee31c61699ebd053e7a706b779fe6/src/lib/update-check.ts#L35): In `configDir()`, the condition checks `process.env.ACRM_CONFIG_DIR.trim().length` to determine if the env var has content, but the function returns the untrimmed `process.env.ACRM_CONFIG_DIR`. If a user sets `ACRM_CONFIG_DIR=" /some/path "` (with leading/trailing whitespace), the check passes but the returned path includes the whitespace. A leading space would make the path relative (e.g., `" /some/path"` is not the same as `"/some/path"`), causing cache files to be written to an unexpected location. <b>[ Out of scope (triage) ]</b>
- [line 333](https://github.com/cluster-software/agent-crm/blob/aaf2e8e2aa0ee31c61699ebd053e7a706b779fe6/src/lib/update-check.ts#L333): On Windows, `spawn("npm", ...)` without `shell: true` will fail with ENOENT because `npm` is typically installed as `npm.cmd` (a batch script), not as a directly executable binary. When a Windows user selects "Update now", the spawn call fails and the error handler prints "Failed to run npm install: spawn npm ENOENT." The update feature silently fails to work on Windows. Add `shell: true` to the spawn options to resolve this cross-platform issue. <b>[ Out of scope (triage) ]</b>
- [line 336](https://github.com/cluster-software/agent-crm/blob/aaf2e8e2aa0ee31c61699ebd053e7a706b779fe6/src/lib/update-check.ts#L336): In the `exit` event handler, `code` can be `null` if the child process was terminated by a signal rather than exiting normally. This results in the confusing message "npm install exited with code null" being printed. Consider checking for `signal` in the callback or handling `null` code separately to provide a clearer message like "npm install was terminated by signal". <b>[ Out of scope (triage) ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->