### PR TITLE
Making EAV schema discoverable by claude

### DIFF
--- a/.changeset/custom-schema-and-records-update.md
+++ b/.changeset/custom-schema-and-records-update.md
@@ -1,0 +1,19 @@
+---
+"@agent-crm/cli": minor
+---
+
+Custom schema commands: agents and humans can now register their own objects, attributes, and enum options without hand-rolling EAV INSERTs. Driven by an ax-eval that showed 10/10 cold agents coerce hiring pipelines into `deals` because no CLI verb exists for the custom-object path.
+
+- `acrm object create <slug>` — register a new object (e.g. `candidates`, `tasks`, `accounts`) alongside the built-in five (`people` / `companies` / `deals` / `posts` / `transcripts`). Singular and plural display labels are derived from the slug (`candidates` → `Candidate` / `Candidates`), overridable with `--singular` / `--plural`.
+
+- `acrm attribute add <object>.<slug> --type <type>` — add a field to any object (built-in or custom). Supports all 12 attribute types, plus `--multivalued`, `--unique`, `--option <id[:title]>` (repeatable, required for `status`/`select`), `--target-object` and `--inverse` for `record-reference`, and `--currency-code` for `currency`.
+
+- `acrm attribute edit-options <object>.<slug> add|remove <option>` — extend (or trim) a `status`/`select` enum without writing raw SQL. Works on built-in objects too: `acrm attribute edit-options deals.stage add renewed`.
+
+- `acrm records create <object> --field <slug>=<value>` — create a single record. Repeatable `--field` flag; record-reference values use `<target_object>:<target_record_id>`. Validation runs before any write — bad enum values, unknown attributes, or unknown objects fail loudly without leaving an orphan `record_id` behind.
+
+- `acrm records update <object> <record_id> --field <slug>=<value>` — edit fields on an existing record. Single-valued attributes are replaced (use this to advance a candidate from `sourced` → `screen` without writing raw `UPDATE acrm_value` SQL); multivalued attributes get the new value added alongside existing ones (use `acrm records dedupe` to collapse if needed). Same validation guarantees as `create`.
+
+Enum validation: `acrm import csv` and `acrm records create` / `update` now hard-error when a `status`/`select` value doesn't match a configured option. Pre-this-release silently coerced unknown values into `{title: raw}`, which round-tripped through the UI as a free-text option that couldn't be filtered with `WHERE id=...`. Error includes a copy-paste hint pointing at `acrm attribute edit-options`.
+
+Docs: `acrm execute --help` and the `acrm-query` skill now document JSON value shapes per attribute type (the `lix_json_get_text(value_json, 'value')` returning NULL on status/currency/personal-name was the second-most-common ax-eval friction). The "hand-rolled mutation should be the last resort" guidance was removed — direct writes to `acrm_object` / `acrm_attribute` / `acrm_value` are supported and expected when the CLI doesn't cover a case.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @agent-crm/cli
 
+## Unreleased
+
+### Minor Changes
+
+- Custom schema: agents and humans can now register their own objects, attributes, and enum options without hand-rolling EAV INSERTs. Driven by an ax-eval that showed 10/10 cold agents coerce hiring pipelines into `deals` because no CLI verb exists for the custom-object path.
+
+  - `acrm object create <slug>` — register a new object (e.g. `candidates`, `tasks`, `accounts`) alongside the built-in five.
+  - `acrm attribute add <object>.<slug> --type <type>` — add a field. Supports `--multivalued`, `--unique`, `--option <id[:title]>` for status/select, `--target-object` and `--inverse` for record-reference, `--currency-code` for currency.
+  - `acrm attribute edit-options <object>.<slug> add|remove <option>` — extend (or trim) a status/select enum. Works on built-in objects too: `acrm attribute edit-options deals.stage add renewed`.
+  - `acrm records create <object> --field <slug>=<value>` — create a single record. Repeatable `--field` flag; record-reference values use `<target_object>:<target_record_id>`. Validation runs before any write — bad enum values, unknown attributes, or unknown objects fail loudly without leaving an orphan record_id behind.
+  - `acrm records update <object> <record_id> --field <slug>=<value>` — edit fields on an existing record. Single-valued attributes are replaced (use this to advance a candidate from `sourced` → `screen` without writing raw `UPDATE acrm_value` SQL); multivalued attributes get the new value added alongside existing ones (use `acrm records dedupe` to collapse if needed). Same validation guarantees as `create`.
+
+- Enum validation: `acrm import csv` and `acrm records create` now hard-error when a status/select value doesn't match a configured option. Pre-0.11 silently coerced unknown values into `{title: raw}`, which round-tripped through the UI as a free-text option that couldn't be filtered with `WHERE id=...`. Error includes a copy-paste hint pointing at `acrm attribute edit-options`.
+
+- Docs: `acrm execute --help` and the `acrm-query` skill now document JSON value shapes per attribute type (the `lix_json_get_text(value_json, 'value')` returning NULL on status/currency/personal-name was the second-most-common ax-eval friction). The "hand-rolled mutation should be the last resort" guidance was removed — direct writes to `acrm_object` / `acrm_attribute` / `acrm_value` are supported and expected when the CLI doesn't cover a case.
+
 ## 0.10.0
 
 ### Minor Changes

--- a/skills/acrm-query.md
+++ b/skills/acrm-query.md
@@ -143,10 +143,72 @@ multivalued attributes, applies a conflict policy on single-valued attributes
 > The verb is `dedupe`, not `merge` — `merge` in lix-land means version/branch
 > merging (`mergeVersion`), which is a different operation.
 
-## Mutating directly (rare)
+## Custom schema (registering objects + attributes)
 
-Prefer the CLI's `acrm import …` and `acrm records dedupe …` commands — they
-handle soft-delete (`active_until`), provenance, and EAV invariants. Hand-rolled
-`INSERT`/`UPDATE` on `acrm_value` should be the last resort, and you should
-read [the upsert helpers](https://github.com/cluster-software/agent-crm) once
-before doing it.
+The five seeded objects (`people`, `companies`, `deals`, `posts`, `transcripts`)
+are not the only ones you can have. When the user's domain doesn't fit (hiring
+pipeline, fundraising, projects, …), register a custom object rather than
+coercing data into `deals`:
+
+```sh
+# 1. register the object
+acrm object create candidates
+
+# 2. add fields (status options are first-class — no need to overload next_step)
+acrm attribute add candidates.name --type personal-name
+acrm attribute add candidates.email_addresses --type email-address \
+    --multivalued --unique
+acrm attribute add candidates.stage --type status \
+    --option sourced --option screen --option onsite --option offer
+acrm attribute add candidates.applied_for --type record-reference \
+    --target-object deals
+
+# 3. create records
+acrm records create candidates \
+    --field name="Daria Volkov" \
+    --field stage=screen \
+    --field email_addresses=daria@example.com
+```
+
+To extend a *built-in* enum (e.g. add a stage to `deals.stage`):
+
+```sh
+acrm attribute edit-options deals.stage add renewed
+```
+
+## value_json shape per attribute_type
+
+`lix_json_get_text(value_json, 'value')` returns NULL on most non-text types
+because they don't use a `value` key. Use the right key:
+
+| attribute_type     | shape                                                            |
+|--------------------|------------------------------------------------------------------|
+| `text`, `url`      | `{"value": "<string>"}`                                          |
+| `number`           | `{"value": <number>}`                                            |
+| `date`             | `{"date": "<YYYY-MM-DD>"}`                                       |
+| `timestamp`        | `{"timestamp": "<ISO-8601>"}`                                    |
+| `personal-name`    | `{"full_name": ..., "first_name": ..., "last_name": ...}`        |
+| `email-address`    | `{"email_address": "<lower>", "email_domain": "<lower>", ...}`   |
+| `domain`           | `{"domain": "<lower>", "root_domain": "<lower>"}`                |
+| `currency`         | `{"currency_value": <number>, "currency_code": "<code>"}`        |
+| `status`, `select` | `{"id": "<option_id>", "title": "<display>"}`                    |
+| `record-reference` | `{"target_object": "<slug>", "target_record_id": "<uuid>"}`      |
+
+For `record-reference` attributes, prefer the indexed columns (`ref_object`,
+`ref_record_id`) for joins/filters over digging into `value_json.target_record_id`.
+
+## Mutating directly
+
+The CLI wraps the common cases: use `acrm import …`, `acrm records create …`,
+`acrm records dedupe …`, `acrm object create …`, `acrm attribute add …`, and
+`acrm attribute edit-options …`. They handle soft-delete (`active_until`),
+provenance, EAV invariants, and enum validation.
+
+When you need something the CLI doesn't cover, writing directly to the EAV
+tables via `acrm execute` is supported and expected — that's what the CLI
+commands do internally. The `acrm_object`, `acrm_attribute`, `acrm_record`, and
+`acrm_value` tables are stable surfaces. The only thing to watch for on
+`acrm_value` mutations is that you maintain the invariants the CLI handles for
+you: a fresh `id` (`lix_uuid_v7()`), `active_from = NOW`, `active_until = NULL`
+for current values, the right `normalized_key` for unique-keyed attribute
+types, and `ref_object` / `ref_record_id` for record-references.

--- a/src/bin/acrm.ts
+++ b/src/bin/acrm.ts
@@ -4,6 +4,7 @@ import { Command } from "commander";
 import { registerInit } from "../commands/init.js";
 import { registerExecute } from "../commands/execute.js";
 import { registerRecords } from "../commands/records.js";
+import { registerSchema } from "../commands/schema.js";
 import { registerImport, getOrCreateImportCommand } from "../commands/import.js";
 import { attachLinkedinSubcommand } from "../commands/import-linkedin.js";
 import { attachXSubcommand } from "../commands/import-x.js";
@@ -50,6 +51,11 @@ Data model:
   posts       LinkedIn/X posts the user wants to track, linked to author via \`posts.author\` + \`people.associated_posts\`
   transcripts meeting/call transcripts (e.g. Granola), linked to attendees via \`transcripts.participants\` + \`people.associated_transcripts\`
 
+  Need a different shape (hiring pipeline, fundraising, projects, …)? Register
+  a custom object: \`acrm object create candidates\`, then add fields with
+  \`acrm attribute add\`. Don't coerce non-sales data into \`deals\` — the
+  \`deals.stage\` enum is locked to sales values (lead/in_progress/won/lost).
+
 Typical flow:
   acrm init <name>.acrm           create a workspace
   acrm import csv ./leads.csv     load people + companies (and deals if columns present)
@@ -59,7 +65,15 @@ Typical flow:
   acrm import transcript          import a meeting transcript — use \`--from <provider>\` for the fast path, or pipe JSON via stdin / \`--file\`
   acrm ui                         browse the workspace in a local UI
   acrm execute "SELECT ..."       run SQL against the workspace
+  acrm records create deals --field name=... --field stage=...  create a single record
+  acrm records update candidates <id> --field stage=screen      advance / edit fields on an existing record
   acrm records dedupe people --keep <id> --discard <id>   collapse two duplicate records into one
+
+Custom schema:
+  acrm object create candidates                                  register a new object
+  acrm attribute add candidates.stage --type status \\
+      --option sourced --option screen --option onsite --option offer
+  acrm attribute edit-options deals.stage add custom_value       extend a built-in enum
 
 Provider auth (one-time, for \`acrm import transcript --from <provider>\`):
 ${PROVIDERS.filter((p) => p.oauth)
@@ -81,6 +95,17 @@ Introspection (run via \`acrm execute "<sql>"\`):
   SELECT * FROM acrm_object                                     -- registered objects
   SELECT object_slug, attribute_slug, attribute_type FROM acrm_attribute
   SELECT object_slug, COUNT(*) FROM acrm_record GROUP BY object_slug
+
+JSON value shapes per attribute_type (key for lix_json_get_text):
+  text / url / number   {"value": ...}
+  date                  {"date": ...}        timestamp     {"timestamp": ...}
+  personal-name         {"full_name": ..., "first_name": ..., "last_name": ...}
+  email-address         {"email_address": ..., "email_domain": ..., ...}
+  domain                {"domain": ..., "root_domain": ...}
+  currency              {"currency_value": ..., "currency_code": ...}
+  status / select       {"id": ..., "title": ...}
+  record-reference      {"target_object": ..., "target_record_id": ...}
+  (for record-references, prefer the indexed \`ref_record_id\` column)
 `,
   );
 
@@ -92,6 +117,7 @@ attachPostSubcommand(getOrCreateImportCommand(program));
 attachTranscriptSubcommand(getOrCreateImportCommand(program));
 registerExecute(program);
 registerRecords(program);
+registerSchema(program);
 registerUi(program);
 registerSkills(program);
 registerAuth(program);

--- a/src/commands/execute.ts
+++ b/src/commands/execute.ts
@@ -81,6 +81,39 @@ JSON columns to be aware of:
   acrm_value.provenance_json   import row index, source metadata
   acrm_attribute.config_json   per-attribute config (status options, ref target, ...)
 
+value_json shape by attribute_type (the key to use with lix_json_get_text):
+  text / url                 {"value": "<string>"}
+  number                     {"value": <number>}
+  date                       {"date": "<YYYY-MM-DD>"}
+  timestamp                  {"timestamp": "<ISO-8601>"}
+  personal-name              {"full_name": "...", "first_name": "...", "last_name": "..."}
+  email-address              {"email_address": "<lower>", "email_domain": "<lower>", ...}
+  domain                     {"domain": "<lower>", "root_domain": "<lower>"}
+  currency                   {"currency_value": <number>, "currency_code": "<USD>"}
+  status / select            {"id": "<option_id>", "title": "<display>"}
+  record-reference           {"target_object": "<slug>", "target_record_id": "<uuid>"}
+
+  Why this matters: \`lix_json_get_text(value_json, 'value')\` returns NULL on
+  status/currency/personal-name/email-address rows because those types don't
+  use a "value" key. Pick the right key from the table above (or for
+  record-reference attrs, prefer the indexed \`ref_record_id\` column over
+  digging into value_json).
+
+Custom schema (mutations work — there is no "last resort" warning):
+  acrm object create <slug>                                       register a new object
+  acrm attribute add <object>.<slug> --type <type> [...]          add a field
+  acrm attribute edit-options <object>.<slug> add <id>[:<title>]  extend a status enum
+  acrm records create <object> --field <slug>=<value> [...]       create one record
+
+  If you need something the CLI doesn't expose, writing directly to
+  \`acrm_object\` / \`acrm_attribute\` via \`acrm execute\` is supported and
+  expected — see \`acrm execute --schema\` for the current layout, then
+  INSERT with the standard columns (\`object_slug\`, \`singular_name\`,
+  \`plural_name\` for objects; \`object_slug\`, \`attribute_slug\`, \`title\`,
+  \`attribute_type\`, \`is_multivalued\`, \`is_unique\`, \`config_json\` for
+  attributes). The CLI commands above just wrap those INSERTs with input
+  validation.
+
 Introspection (use these instead of sqlite_master):
   acrm execute --schema                                          # full EAV layout for this workspace
   acrm execute "SELECT table_name FROM information_schema.tables WHERE table_schema='public'"

--- a/src/commands/records.ts
+++ b/src/commands/records.ts
@@ -6,6 +6,13 @@ import { exec } from "../db/execute.js";
 import { fail, isJson, ok, setJsonMode } from "../output/json.js";
 import { AcrmError, ERR } from "../lib/errors.js";
 import { nowIso } from "../lib/time.js";
+import { generateUuid } from "../lib/ids.js";
+import {
+  addMultiValue,
+  insertRecord,
+  setSingleValue,
+} from "../db/upsert.js";
+import { encode, type AttributeConfig, type AttributeType } from "../domain/values.js";
 
 type Prefer = "keep" | "discard" | "interactive";
 
@@ -117,6 +124,137 @@ export function registerRecords(program: Command): void {
     .command("records")
     .description(
       "operations on records as a group (dedupe duplicates, etc.). Subcommands act on any object — `people`, `companies`, `deals`, `posts`, `transcripts`.",
+    );
+
+  records
+    .command("create <object>")
+    .description(
+      "create a single record on <object> with one or more fields. Use this for ad-hoc creation against any object (built-in or custom) — for bulk loads use `acrm import csv`.",
+    )
+    .option(
+      "--field <slug=value>",
+      "set an attribute on the new record. Repeatable. For record-reference attributes, pass `<slug>=<target_object>:<target_record_id>`. For multivalued attributes, pass --field <slug>=<value> multiple times.",
+      (val: string, prev: string[]) => [...(prev ?? []), val],
+      [] as string[],
+    )
+    .addHelpText(
+      "after",
+      `
+Examples:
+  # create a deal linked to an existing person
+  acrm records create deals \\
+      --field name="Acme renewal" \\
+      --field stage=in_progress \\
+      --field value=50000 \\
+      --field associated_people=people:<person_record_id>
+
+  # create a record on a custom object (e.g. candidates registered via
+  # \`acrm object create candidates\`)
+  acrm records create candidates \\
+      --field name="Daria Volkov" \\
+      --field stage=screen \\
+      --field email_addresses=daria@example.com
+
+  # multivalued: repeat the same --field slug
+  acrm records create candidates --field name="Liam" \\
+      --field email_addresses=liam@home.com \\
+      --field email_addresses=liam@work.com
+
+Field syntax:
+  <slug>=<value>
+  <slug>=<target_object>:<target_record_id>   for record-reference attributes
+  <slug>=                                     omit value to clear (no-op on create)
+
+Status / select values must match a configured option id or title. To add a
+new option to an enum, use \`acrm attribute edit-options\`.
+
+Returns the new record_id, which you can pass to subsequent --field arguments
+to wire up references.
+`,
+    )
+    .action(async (object: string, opts: { field?: string[] }) => {
+      const root = program.opts() as { json?: boolean; workspace?: string };
+      setJsonMode(root.json);
+      try {
+        const lix = await openWorkspace({ workspace: root.workspace });
+        try {
+          const result = await createRecord(lix, {
+            object_slug: object,
+            fields: opts.field ?? [],
+          });
+          ok(result);
+        } finally {
+          await lix.close();
+        }
+      } catch (e) {
+        if (e instanceof AcrmError) fail(e.message, e.code, e.hint);
+        else fail(e instanceof Error ? e.message : String(e), ERR.UNHANDLED);
+        process.exit(1);
+      }
+    });
+
+  records
+    .command("update <object> <record_id>")
+    .description(
+      "update fields on an existing record. For single-valued attributes (e.g. `stage`, `name`), replaces the current value. For multivalued attributes (e.g. `email_addresses`), adds a new value alongside existing ones — use `acrm records dedupe` to collapse duplicates.",
+    )
+    .option(
+      "--field <slug=value>",
+      "set an attribute. Repeatable. For record-reference attributes, pass `<slug>=<target_object>:<target_record_id>`. For multivalued attributes, repeat --field <slug> to add multiple values.",
+      (val: string, prev: string[]) => [...(prev ?? []), val],
+      [] as string[],
+    )
+    .addHelpText(
+      "after",
+      `
+Examples:
+  # advance a candidate through the pipeline
+  acrm records update candidates <candidate_id> --field stage=screen
+  acrm records update candidates <candidate_id> --field stage=onsite --field notes="great fit on async/io"
+
+  # change a deal's value or close date
+  acrm records update deals <deal_id> --field value=75000 --field close_date=2026-07-01
+
+  # add another email to an existing person (multivalued)
+  acrm records update people <person_id> --field email_addresses=alice@work.com
+
+Field syntax (same as \`records create\`):
+  <slug>=<value>
+  <slug>=<target_object>:<target_record_id>   for record-reference attributes
+
+Status / select values must match a configured option id or title — use
+\`acrm attribute edit-options\` to extend an enum.
+
+Validation runs before any write: bad enum values, unknown attributes, or a
+missing record_id all fail loudly without touching the workspace.
+`,
+    )
+    .action(
+      async (
+        object: string,
+        record_id: string,
+        opts: { field?: string[] },
+      ) => {
+        const root = program.opts() as { json?: boolean; workspace?: string };
+        setJsonMode(root.json);
+        try {
+          const lix = await openWorkspace({ workspace: root.workspace });
+          try {
+            const result = await updateRecord(lix, {
+              object_slug: object,
+              record_id,
+              fields: opts.field ?? [],
+            });
+            ok(result);
+          } finally {
+            await lix.close();
+          }
+        } catch (e) {
+          if (e instanceof AcrmError) fail(e.message, e.code, e.hint);
+          else fail(e instanceof Error ? e.message : String(e), ERR.UNHANDLED);
+          process.exit(1);
+        }
+      },
     );
 
   records
@@ -671,4 +809,237 @@ async function resolveConflict(
 function truncate(s: string, n = 80): string {
   if (s.length <= n) return s;
   return s.slice(0, n) + "…";
+}
+
+type AttributeRow = {
+  attribute_type: AttributeType;
+  is_multivalued: boolean;
+  config?: AttributeConfig;
+};
+
+function parseField(raw: string): { slug: string; value: string } {
+  const i = raw.indexOf("=");
+  if (i <= 0) {
+    throw new AcrmError(
+      `invalid --field value: ${raw} (expected <slug>=<value>)`,
+      ERR.INVALID_INPUT,
+    );
+  }
+  return { slug: raw.slice(0, i).trim(), value: raw.slice(i + 1) };
+}
+
+function coerceFieldValue(
+  attr: AttributeRow,
+  attribute_slug: string,
+  raw: string,
+): unknown {
+  if (attr.attribute_type === "record-reference") {
+    const i = raw.indexOf(":");
+    if (i <= 0 || i === raw.length - 1) {
+      throw new AcrmError(
+        `invalid record-reference value for ${attribute_slug}: ${raw} (expected <target_object>:<target_record_id>)`,
+        ERR.INVALID_INPUT,
+      );
+    }
+    return {
+      target_object: raw.slice(0, i).trim(),
+      target_record_id: raw.slice(i + 1).trim(),
+    };
+  }
+  return raw;
+}
+
+export type CreateRecordResult = {
+  created: true;
+  object_slug: string;
+  record_id: string;
+  values_inserted: number;
+};
+
+export type UpdateRecordResult = {
+  updated: true;
+  object_slug: string;
+  record_id: string;
+  values_changed: number;
+};
+
+type PreparedField = {
+  slug: string;
+  attr: AttributeRow;
+  value: unknown;
+};
+
+async function assertObjectRegistered(
+  lix: Lix,
+  object_slug: string,
+): Promise<void> {
+  const obj = await exec(
+    lix,
+    "SELECT object_slug FROM acrm_object WHERE object_slug = $1",
+    [object_slug],
+  );
+  if (!obj.rows.length) {
+    throw new AcrmError(
+      `unknown object: ${object_slug}. Run \`acrm execute "SELECT object_slug FROM acrm_object"\` to list, or \`acrm object create ${object_slug}\` to register it.`,
+      ERR.NOT_FOUND,
+    );
+  }
+}
+
+// Parse + validate every --field up front. encode() runs in dry-run mode here
+// to catch invalid enum values, unparseable emails, etc.; doing it before any
+// write means we never leave a half-populated record behind. The actual
+// insert path re-runs encode on the raw value — we don't pass the encoded
+// form through because the upsert helpers can't re-handle already-encoded
+// text (encoding {value: "..."} twice produces "[object Object]").
+async function prepareFields(
+  lix: Lix,
+  object_slug: string,
+  fields: string[],
+): Promise<PreparedField[]> {
+  const parsed = fields.map(parseField).filter((f) => f.value !== "");
+  const attrMeta = new Map<string, AttributeRow>();
+  for (const f of parsed) {
+    if (attrMeta.has(f.slug)) continue;
+    const r = await exec(
+      lix,
+      "SELECT attribute_type, is_multivalued, config_json FROM acrm_attribute WHERE object_slug = $1 AND attribute_slug = $2",
+      [object_slug, f.slug],
+    );
+    const row = r.rows[0];
+    if (!row) {
+      throw new AcrmError(
+        `unknown attribute: ${object_slug}.${f.slug}. Run \`acrm attribute add ${object_slug}.${f.slug} --type <type>\` to register it, or \`acrm execute --schema\` to list existing attributes.`,
+        ERR.NOT_FOUND,
+      );
+    }
+    let config: AttributeConfig | undefined;
+    const raw = row.config_json as string | null | undefined;
+    if (raw) {
+      try {
+        config = JSON.parse(raw) as AttributeConfig;
+      } catch {
+        config = undefined;
+      }
+    }
+    attrMeta.set(f.slug, {
+      attribute_type: row.attribute_type as AttributeType,
+      is_multivalued: Boolean(row.is_multivalued),
+      config,
+    });
+  }
+
+  return parsed.map((f) => {
+    const attr = attrMeta.get(f.slug)!;
+    const value = coerceFieldValue(attr, f.slug, f.value);
+    encode(attr.attribute_type, value, attr.config);
+    return { slug: f.slug, attr, value };
+  });
+}
+
+async function applyFields(
+  lix: Lix,
+  object_slug: string,
+  record_id: string,
+  prepared: PreparedField[],
+  source: string,
+): Promise<number> {
+  const provenance: Record<string, unknown> = { command: source };
+  let n = 0;
+  for (const e of prepared) {
+    if (e.attr.is_multivalued) {
+      await addMultiValue(lix, {
+        object_slug,
+        record_id,
+        attribute_slug: e.slug,
+        attribute_type: e.attr.attribute_type,
+        value: e.value,
+        source,
+        provenance,
+      });
+    } else {
+      await setSingleValue(lix, {
+        object_slug,
+        record_id,
+        attribute_slug: e.slug,
+        attribute_type: e.attr.attribute_type,
+        value: e.value,
+        source,
+        provenance,
+      });
+    }
+    n++;
+  }
+  return n;
+}
+
+export async function createRecord(
+  lix: Lix,
+  args: { object_slug: string; fields: string[] },
+): Promise<CreateRecordResult> {
+  const { object_slug, fields } = args;
+
+  await assertObjectRegistered(lix, object_slug);
+  const prepared = await prepareFields(lix, object_slug, fields);
+
+  const record_id = await generateUuid(lix);
+  await insertRecord(lix, object_slug, record_id);
+  const inserted = await applyFields(
+    lix,
+    object_slug,
+    record_id,
+    prepared,
+    "cli:records-create",
+  );
+
+  return {
+    created: true,
+    object_slug,
+    record_id,
+    values_inserted: inserted,
+  };
+}
+
+export async function updateRecord(
+  lix: Lix,
+  args: { object_slug: string; record_id: string; fields: string[] },
+): Promise<UpdateRecordResult> {
+  const { object_slug, record_id, fields } = args;
+
+  await assertObjectRegistered(lix, object_slug);
+
+  const exists = await exec(
+    lix,
+    "SELECT record_id FROM acrm_record WHERE object_slug = $1 AND record_id = $2",
+    [object_slug, record_id],
+  );
+  if (!exists.rows.length) {
+    throw new AcrmError(
+      `record not found: ${object_slug}/${record_id}`,
+      ERR.NOT_FOUND,
+    );
+  }
+
+  const prepared = await prepareFields(lix, object_slug, fields);
+  if (prepared.length === 0) {
+    throw new AcrmError(
+      "no --field arguments provided (nothing to update)",
+      ERR.INVALID_INPUT,
+    );
+  }
+
+  const changed = await applyFields(
+    lix,
+    object_slug,
+    record_id,
+    prepared,
+    "cli:records-update",
+  );
+
+  return {
+    updated: true,
+    object_slug,
+    record_id,
+    values_changed: changed,
+  };
 }

--- a/src/commands/schema.test.ts
+++ b/src/commands/schema.test.ts
@@ -1,0 +1,483 @@
+import { describe, expect, it } from "vitest";
+import { openTestWorkspace } from "../test/open-test-lix.js";
+import { exec } from "../db/execute.js";
+import { createRecord, updateRecord } from "./records.js";
+import { AcrmError } from "../lib/errors.js";
+import { encode } from "../domain/values.js";
+
+// These tests cover the schema-mutation surface (`acrm object create`,
+// `acrm attribute add`, `acrm attribute edit-options`) and the
+// `acrm records create` verb. They exercise the same SQL the commands run via
+// the same `exec`/`upsert` helpers; the CLI layer is a thin commander wrapper
+// validated separately by the smoke-test in scripts/.
+
+async function readAttribute(
+  lix: Awaited<ReturnType<typeof openTestWorkspace>>,
+  object_slug: string,
+  attribute_slug: string,
+) {
+  const r = await exec(
+    lix,
+    "SELECT attribute_type, is_multivalued, is_unique, config_json FROM acrm_attribute WHERE object_slug = $1 AND attribute_slug = $2",
+    [object_slug, attribute_slug],
+  );
+  return r.rows[0] ?? null;
+}
+
+describe("object create (raw INSERT)", () => {
+  it("registers a custom object alongside the built-ins", async () => {
+    const lix = await openTestWorkspace();
+    try {
+      await exec(
+        lix,
+        "INSERT INTO acrm_object (object_slug, singular_name, plural_name) VALUES ($1, $2, $3)",
+        ["candidates", "Candidate", "Candidates"],
+      );
+      const r = await exec(
+        lix,
+        "SELECT object_slug FROM acrm_object ORDER BY object_slug",
+      );
+      const slugs = r.rows.map((row) => row.object_slug as string);
+      expect(slugs).toContain("candidates");
+      expect(slugs).toContain("people");
+    } finally {
+      await lix.close();
+    }
+  });
+});
+
+describe("attribute add (raw INSERT)", () => {
+  it("adds a status attribute with options to a custom object", async () => {
+    const lix = await openTestWorkspace();
+    try {
+      await exec(
+        lix,
+        "INSERT INTO acrm_object (object_slug, singular_name, plural_name) VALUES ($1, $2, $3)",
+        ["candidates", "Candidate", "Candidates"],
+      );
+      const config = {
+        options: [
+          { id: "sourced", title: "Sourced" },
+          { id: "screen", title: "Screen" },
+          { id: "onsite", title: "Onsite" },
+          { id: "offer", title: "Offer" },
+        ],
+      };
+      await exec(
+        lix,
+        `INSERT INTO acrm_attribute
+          (object_slug, attribute_slug, title, attribute_type,
+           is_multivalued, is_unique, config_json)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [
+          "candidates",
+          "stage",
+          "Stage",
+          "status",
+          false,
+          false,
+          JSON.stringify(config),
+        ],
+      );
+      const row = await readAttribute(lix, "candidates", "stage");
+      expect(row).not.toBeNull();
+      expect(row!.attribute_type).toBe("status");
+      expect(JSON.parse(row!.config_json as string).options).toEqual(
+        config.options,
+      );
+    } finally {
+      await lix.close();
+    }
+  });
+});
+
+describe("encode() enum validation", () => {
+  it("accepts a valid option id", () => {
+    const out = encode("status", "sourced", {
+      options: [
+        { id: "sourced", title: "Sourced" },
+        { id: "screen", title: "Screen" },
+      ],
+    });
+    expect(out).toEqual({ id: "sourced", title: "Sourced" });
+  });
+
+  it("accepts a valid option title (case-insensitive)", () => {
+    const out = encode("status", "SCREEN", {
+      options: [
+        { id: "sourced", title: "Sourced" },
+        { id: "screen", title: "Screen" },
+      ],
+    });
+    expect(out).toEqual({ id: "screen", title: "Screen" });
+  });
+
+  it("throws when input doesn't match a configured option", () => {
+    expect(() =>
+      encode("status", "won_lol", {
+        options: [
+          { id: "lead", title: "Lead" },
+          { id: "won", title: "Won" },
+        ],
+      }),
+    ).toThrow(/invalid status/);
+  });
+
+  it("hints the user toward `attribute edit-options`", async () => {
+    const { AcrmError } = await import("../lib/errors.js");
+    try {
+      encode("status", "renewed", {
+        options: [{ id: "won", title: "Won" }],
+      });
+      throw new Error("expected throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(AcrmError);
+      expect((e as InstanceType<typeof AcrmError>).hint).toMatch(
+        /edit-options/,
+      );
+    }
+  });
+
+  it("free-form mode (no options) still works", () => {
+    const out = encode("status", "anything", undefined);
+    expect(out).toEqual({ title: "anything" });
+  });
+});
+
+describe("records create", () => {
+  it("creates a deal with name + stage + value", async () => {
+    const lix = await openTestWorkspace();
+    try {
+      const result = await createRecord(lix, {
+        object_slug: "deals",
+        fields: [
+          "name=Acme renewal",
+          "stage=in_progress",
+          "value=50000",
+        ],
+      });
+      expect(result.created).toBe(true);
+      expect(result.values_inserted).toBe(3);
+
+      const vals = await exec(
+        lix,
+        "SELECT attribute_slug, value_json FROM acrm_value WHERE object_slug = 'deals' AND record_id = $1 AND active_until IS NULL ORDER BY attribute_slug",
+        [result.record_id],
+      );
+      const byAttr = new Map(
+        vals.rows.map((r) => [
+          r.attribute_slug as string,
+          JSON.parse(r.value_json as string) as Record<string, unknown>,
+        ]),
+      );
+      expect(byAttr.get("name")).toEqual({ value: "Acme renewal" });
+      expect(byAttr.get("stage")).toEqual({
+        id: "in_progress",
+        title: "In Progress",
+      });
+      expect(byAttr.get("value")).toEqual({
+        currency_value: 50000,
+        currency_code: "USD",
+      });
+    } finally {
+      await lix.close();
+    }
+  });
+
+  it("rejects unknown attributes before writing", async () => {
+    const lix = await openTestWorkspace();
+    try {
+      await expect(
+        createRecord(lix, {
+          object_slug: "deals",
+          fields: ["name=Acme", "bogus=hello"],
+        }),
+      ).rejects.toThrow(/unknown attribute/);
+
+      // No partial record left behind.
+      const recs = await exec(
+        lix,
+        "SELECT COUNT(*) AS n FROM acrm_record WHERE object_slug = 'deals'",
+      );
+      expect(recs.rows[0]!.n).toBe(0);
+    } finally {
+      await lix.close();
+    }
+  });
+
+  it("rejects an invalid status against a locked enum", async () => {
+    const lix = await openTestWorkspace();
+    try {
+      await expect(
+        createRecord(lix, {
+          object_slug: "deals",
+          fields: ["name=Hiring D.V.", "stage=sourced"],
+        }),
+      ).rejects.toThrow(/invalid status/);
+    } finally {
+      await lix.close();
+    }
+  });
+
+  it("does not leave an orphan record_id when validation fails after some fields are valid", async () => {
+    const lix = await openTestWorkspace();
+    try {
+      await expect(
+        createRecord(lix, {
+          object_slug: "deals",
+          fields: ["name=Hiring D.V.", "stage=sourced"], // name valid, stage invalid
+        }),
+      ).rejects.toThrow();
+      const recs = await exec(
+        lix,
+        "SELECT COUNT(*) AS n FROM acrm_record WHERE object_slug = 'deals'",
+      );
+      expect(recs.rows[0]!.n).toBe(0);
+    } finally {
+      await lix.close();
+    }
+  });
+
+  it("rejects an unknown object slug", async () => {
+    const lix = await openTestWorkspace();
+    try {
+      await expect(
+        createRecord(lix, {
+          object_slug: "candidates",
+          fields: ["name=Daria"],
+        }),
+      ).rejects.toThrow(/unknown object/);
+    } finally {
+      await lix.close();
+    }
+  });
+
+  it("parses record-reference values as <target_object>:<target_record_id>", async () => {
+    const lix = await openTestWorkspace();
+    try {
+      const company = await createRecord(lix, {
+        object_slug: "companies",
+        fields: ["name=Acme Co", "domains=acme.test"],
+      });
+      const deal = await createRecord(lix, {
+        object_slug: "deals",
+        fields: [
+          "name=Acme renewal",
+          `associated_company=companies:${company.record_id}`,
+        ],
+      });
+      const refs = await exec(
+        lix,
+        "SELECT ref_object, ref_record_id FROM acrm_value WHERE object_slug = 'deals' AND record_id = $1 AND attribute_slug = 'associated_company' AND active_until IS NULL",
+        [deal.record_id],
+      );
+      expect(refs.rows[0]!.ref_object).toBe("companies");
+      expect(refs.rows[0]!.ref_record_id).toBe(company.record_id);
+    } finally {
+      await lix.close();
+    }
+  });
+
+  it("supports multivalued attributes via repeated --field", async () => {
+    const lix = await openTestWorkspace();
+    try {
+      const result = await createRecord(lix, {
+        object_slug: "people",
+        fields: [
+          "name=Liam",
+          "email_addresses=liam@home.com",
+          "email_addresses=liam@work.com",
+        ],
+      });
+      const emails = await exec(
+        lix,
+        "SELECT normalized_key FROM acrm_value WHERE object_slug = 'people' AND record_id = $1 AND attribute_slug = 'email_addresses' AND active_until IS NULL ORDER BY normalized_key",
+        [result.record_id],
+      );
+      expect(emails.rows.map((r) => r.normalized_key)).toEqual([
+        "liam@home.com",
+        "liam@work.com",
+      ]);
+    } finally {
+      await lix.close();
+    }
+  });
+});
+
+describe("records update", () => {
+  it("advances a single-valued field (replaces the current value)", async () => {
+    const lix = await openTestWorkspace();
+    try {
+      const deal = await createRecord(lix, {
+        object_slug: "deals",
+        fields: ["name=Acme renewal", "stage=lead"],
+      });
+      const result = await updateRecord(lix, {
+        object_slug: "deals",
+        record_id: deal.record_id,
+        fields: ["stage=in_progress"],
+      });
+      expect(result.updated).toBe(true);
+      expect(result.values_changed).toBe(1);
+
+      const active = await exec(
+        lix,
+        "SELECT lix_json_get_text(value_json, 'id') AS id FROM acrm_value WHERE object_slug = 'deals' AND record_id = $1 AND attribute_slug = 'stage' AND active_until IS NULL",
+        [deal.record_id],
+      );
+      expect(active.rows.length).toBe(1);
+      expect(active.rows[0]!.id).toBe("in_progress");
+    } finally {
+      await lix.close();
+    }
+  });
+
+  it("rejects updates to a missing record", async () => {
+    const lix = await openTestWorkspace();
+    try {
+      await expect(
+        updateRecord(lix, {
+          object_slug: "deals",
+          record_id: "019e2d00-0000-7000-0000-000000000000",
+          fields: ["stage=in_progress"],
+        }),
+      ).rejects.toThrow(/record not found/);
+    } finally {
+      await lix.close();
+    }
+  });
+
+  it("rejects invalid enum values without touching the record", async () => {
+    const lix = await openTestWorkspace();
+    try {
+      const deal = await createRecord(lix, {
+        object_slug: "deals",
+        fields: ["name=Acme", "stage=lead"],
+      });
+      await expect(
+        updateRecord(lix, {
+          object_slug: "deals",
+          record_id: deal.record_id,
+          fields: ["stage=sourced"],
+        }),
+      ).rejects.toThrow(/invalid status/);
+      // The original lead stage is still active.
+      const active = await exec(
+        lix,
+        "SELECT lix_json_get_text(value_json, 'id') AS id FROM acrm_value WHERE object_slug = 'deals' AND record_id = $1 AND attribute_slug = 'stage' AND active_until IS NULL",
+        [deal.record_id],
+      );
+      expect(active.rows[0]!.id).toBe("lead");
+    } finally {
+      await lix.close();
+    }
+  });
+
+  it("rejects empty --field list", async () => {
+    const lix = await openTestWorkspace();
+    try {
+      const deal = await createRecord(lix, {
+        object_slug: "deals",
+        fields: ["name=Acme", "stage=lead"],
+      });
+      await expect(
+        updateRecord(lix, {
+          object_slug: "deals",
+          record_id: deal.record_id,
+          fields: [],
+        }),
+      ).rejects.toThrow(/nothing to update/);
+    } finally {
+      await lix.close();
+    }
+  });
+
+  it("adds another value to a multivalued attribute (dedupe handles collapse)", async () => {
+    const lix = await openTestWorkspace();
+    try {
+      const person = await createRecord(lix, {
+        object_slug: "people",
+        fields: ["name=Liam", "email_addresses=liam@home.com"],
+      });
+      await updateRecord(lix, {
+        object_slug: "people",
+        record_id: person.record_id,
+        fields: ["email_addresses=liam@work.com"],
+      });
+      const emails = await exec(
+        lix,
+        "SELECT normalized_key FROM acrm_value WHERE object_slug = 'people' AND record_id = $1 AND attribute_slug = 'email_addresses' AND active_until IS NULL ORDER BY normalized_key",
+        [person.record_id],
+      );
+      expect(emails.rows.map((r) => r.normalized_key)).toEqual([
+        "liam@home.com",
+        "liam@work.com",
+      ]);
+    } finally {
+      await lix.close();
+    }
+  });
+});
+
+describe("end-to-end: custom hiring pipeline", () => {
+  it("registers an object + attributes + records that the ax-eval agents could not", async () => {
+    const lix = await openTestWorkspace();
+    try {
+      // 1. Register the object.
+      await exec(
+        lix,
+        "INSERT INTO acrm_object (object_slug, singular_name, plural_name) VALUES ($1, $2, $3)",
+        ["candidates", "Candidate", "Candidates"],
+      );
+
+      // 2. Add fields with custom status options (the affordance that was
+      // missing — agents had to overload deals.next_step).
+      await exec(
+        lix,
+        `INSERT INTO acrm_attribute
+          (object_slug, attribute_slug, title, attribute_type,
+           is_multivalued, is_unique, config_json)
+         VALUES ('candidates', 'name', 'Name', 'personal-name', $1, $2, NULL)`,
+        [false, false],
+      );
+      await exec(
+        lix,
+        `INSERT INTO acrm_attribute
+          (object_slug, attribute_slug, title, attribute_type,
+           is_multivalued, is_unique, config_json)
+         VALUES ('candidates', 'stage', 'Stage', 'status', $1, $2, $3)`,
+        [
+          false,
+          false,
+          JSON.stringify({
+            options: [
+              { id: "sourced", title: "Sourced" },
+              { id: "screen", title: "Screen" },
+              { id: "onsite", title: "Onsite" },
+              { id: "offer", title: "Offer" },
+            ],
+          }),
+        ],
+      );
+
+      // 3. Create candidate records that the locked deals.stage enum could
+      // never have accepted.
+      await createRecord(lix, {
+        object_slug: "candidates",
+        fields: ["name=Daria Volkov", "stage=screen"],
+      });
+      await createRecord(lix, {
+        object_slug: "candidates",
+        fields: ["name=Liam O'Connell", "stage=onsite"],
+      });
+
+      const r = await exec(
+        lix,
+        "SELECT lix_json_get_text(value_json, 'id') AS stage_id, COUNT(*) AS n FROM acrm_value WHERE object_slug = 'candidates' AND attribute_slug = 'stage' AND active_until IS NULL GROUP BY lix_json_get_text(value_json, 'id') ORDER BY stage_id",
+      );
+      expect(r.rows.map((x) => x.stage_id).sort()).toEqual(["onsite", "screen"]);
+    } finally {
+      await lix.close();
+    }
+  });
+});

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -1,0 +1,543 @@
+import type { Command } from "commander";
+import type { Lix, LixRuntimeValue } from "@lix-js/sdk";
+import { openWorkspace } from "../workspace/open.js";
+import { exec } from "../db/execute.js";
+import { fail, ok, setJsonMode } from "../output/json.js";
+import { AcrmError, ERR } from "../lib/errors.js";
+import type { AttributeType, StatusOption } from "../domain/values.js";
+
+const ATTRIBUTE_TYPES: AttributeType[] = [
+  "text",
+  "personal-name",
+  "email-address",
+  "domain",
+  "url",
+  "number",
+  "currency",
+  "date",
+  "timestamp",
+  "select",
+  "status",
+  "record-reference",
+];
+
+const SLUG_RE = /^[a-z][a-z0-9_]*$/;
+
+function parseSlug(input: string, label: string): string {
+  const s = input.trim();
+  if (!SLUG_RE.test(s)) {
+    throw new AcrmError(
+      `invalid ${label}: ${input} (expected lowercase, starts with a letter, underscores allowed)`,
+      ERR.INVALID_INPUT,
+    );
+  }
+  return s;
+}
+
+function titleCase(slug: string): string {
+  return slug
+    .split("_")
+    .filter(Boolean)
+    .map((p) => p[0]!.toUpperCase() + p.slice(1))
+    .join(" ");
+}
+
+// Cheap heuristic for the default `--singular` label: drop a trailing 's' or
+// turn '…ies' into '…y'. Object slugs are conventionally plural
+// (people, companies, deals); irregular forms (people → person) require the
+// user to pass --singular explicitly.
+function defaultSingular(plural: string): string {
+  if (plural.endsWith("ies") && plural.length > 3) {
+    return plural.slice(0, -3) + "y";
+  }
+  if (plural.endsWith("s") && plural.length > 1) {
+    return plural.slice(0, -1);
+  }
+  return plural;
+}
+
+function parseAttributeRef(ref: string): { object: string; attribute: string } {
+  const i = ref.indexOf(".");
+  if (i <= 0 || i === ref.length - 1) {
+    throw new AcrmError(
+      `expected <object>.<attribute>, got: ${ref}`,
+      ERR.INVALID_INPUT,
+    );
+  }
+  return {
+    object: parseSlug(ref.slice(0, i), "object slug"),
+    attribute: parseSlug(ref.slice(i + 1), "attribute slug"),
+  };
+}
+
+function parseAttributeType(input: string): AttributeType {
+  const s = input.trim().toLowerCase();
+  if ((ATTRIBUTE_TYPES as string[]).includes(s)) return s as AttributeType;
+  throw new AcrmError(
+    `invalid --type: ${input}. One of: ${ATTRIBUTE_TYPES.join(", ")}`,
+    ERR.INVALID_INPUT,
+  );
+}
+
+function parseOption(raw: string): StatusOption {
+  const i = raw.indexOf(":");
+  const id = (i < 0 ? raw : raw.slice(0, i)).trim();
+  if (!id) {
+    throw new AcrmError(
+      `invalid option (empty id): ${raw}`,
+      ERR.INVALID_INPUT,
+    );
+  }
+  const title = i < 0 || !raw.slice(i + 1).trim() ? titleCase(id) : raw.slice(i + 1).trim();
+  return { id, title };
+}
+
+async function loadAttribute(
+  lix: Lix,
+  object_slug: string,
+  attribute_slug: string,
+): Promise<{
+  attribute_type: AttributeType;
+  is_multivalued: boolean;
+  is_unique: boolean;
+  config: Record<string, unknown> | null;
+} | null> {
+  const r = await exec(
+    lix,
+    "SELECT attribute_type, is_multivalued, is_unique, config_json FROM acrm_attribute WHERE object_slug = $1 AND attribute_slug = $2",
+    [object_slug, attribute_slug],
+  );
+  const row = r.rows[0];
+  if (!row) return null;
+  let config: Record<string, unknown> | null = null;
+  const raw = row.config_json as string | null | undefined;
+  if (raw) {
+    try {
+      config = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      config = null;
+    }
+  }
+  return {
+    attribute_type: row.attribute_type as AttributeType,
+    is_multivalued: Boolean(row.is_multivalued),
+    is_unique: Boolean(row.is_unique),
+    config,
+  };
+}
+
+async function assertObjectExists(lix: Lix, object_slug: string): Promise<void> {
+  const r = await exec(
+    lix,
+    "SELECT object_slug FROM acrm_object WHERE object_slug = $1",
+    [object_slug],
+  );
+  if (!r.rows.length) {
+    throw new AcrmError(
+      `unknown object: ${object_slug}. Run \`acrm execute "SELECT object_slug FROM acrm_object"\` to list, or \`acrm object create ${object_slug}\` to register it.`,
+      ERR.NOT_FOUND,
+    );
+  }
+}
+
+export function registerSchema(program: Command): void {
+  // `object create` and `attribute add` / `edit-options` are the canonical
+  // CLI affordance for shaping the workspace's schema. Without these, agents
+  // hit a wall when the five built-in objects don't fit their domain and
+  // either coerce data into the wrong object (the deals-as-hiring-pipeline
+  // anti-pattern) or hand-roll INSERTs into acrm_object/acrm_attribute that
+  // the docs steer them away from.
+  const object = program
+    .command("object")
+    .description(
+      "register or list custom objects (alongside the built-in people / companies / deals / posts / transcripts).",
+    );
+
+  object
+    .command("create <slug>")
+    .description(
+      "register a new object (e.g. `candidates`, `tasks`, `accounts`). After creation, add fields with `acrm attribute add <object>.<slug> --type <type>` and create records with `acrm records create <object> --field <slug>=<value>`.",
+    )
+    .option(
+      "--singular <name>",
+      "human-friendly singular label (default: derived from slug, e.g. `candidates` → `Candidate`)",
+    )
+    .option(
+      "--plural <name>",
+      "human-friendly plural label (default: derived from slug, e.g. `candidates` → `Candidates`)",
+    )
+    .addHelpText(
+      "after",
+      `
+Slug rules: lowercase ASCII, starts with a letter, underscores allowed.
+
+Examples:
+  acrm object create candidates
+  acrm object create candidates --singular Candidate --plural Candidates
+  acrm object create job_applications
+
+Next steps after creation:
+  acrm attribute add candidates.name --type personal-name
+  acrm attribute add candidates.stage --type status \\
+      --option sourced --option screen --option onsite --option offer
+  acrm attribute add candidates.applied_for --type record-reference \\
+      --target-object deals
+  acrm records create candidates --field name="Daria Volkov" --field stage=screen
+`,
+    )
+    .action(
+      async (
+        slug: string,
+        opts: { singular?: string; plural?: string },
+      ) => {
+        const root = program.opts() as { json?: boolean; workspace?: string };
+        setJsonMode(root.json);
+        try {
+          const object_slug = parseSlug(slug, "object slug");
+          const plural = opts.plural?.trim() || titleCase(object_slug);
+          const singular = opts.singular?.trim() || defaultSingular(plural);
+          const lix = await openWorkspace({ workspace: root.workspace });
+          try {
+            const exists = await exec(
+              lix,
+              "SELECT object_slug FROM acrm_object WHERE object_slug = $1",
+              [object_slug],
+            );
+            if (exists.rows.length) {
+              throw new AcrmError(
+                `object already exists: ${object_slug}`,
+                ERR.UNIQUE_VIOLATION,
+              );
+            }
+            await exec(
+              lix,
+              "INSERT INTO acrm_object (object_slug, singular_name, plural_name) VALUES ($1, $2, $3)",
+              [object_slug, singular, plural],
+            );
+            ok({
+              created: true,
+              object_slug,
+              singular_name: singular,
+              plural_name: plural,
+            });
+          } finally {
+            await lix.close();
+          }
+        } catch (e) {
+          if (e instanceof AcrmError) fail(e.message, e.code, e.hint);
+          else fail(e instanceof Error ? e.message : String(e), ERR.UNHANDLED);
+          process.exit(1);
+        }
+      },
+    );
+
+  const attribute = program
+    .command("attribute")
+    .description(
+      "add or edit attributes (fields) on any object. Works on built-in objects (people/companies/deals/posts/transcripts) and on custom objects created via `acrm object create`.",
+    );
+
+  attribute
+    .command("add <ref>")
+    .description(
+      "add a new attribute to an object. <ref> is `<object>.<attribute>` (e.g. `candidates.stage`, `people.years_experience`).",
+    )
+    .requiredOption(
+      "--type <type>",
+      `attribute type — one of: ${ATTRIBUTE_TYPES.join(", ")}`,
+    )
+    .option(
+      "--title <title>",
+      "human-friendly label (default: derived from attribute slug)",
+    )
+    .option("--multivalued", "allow multiple values per record (default: false)")
+    .option(
+      "--unique",
+      "values are unique across records (used for identifiers like email_addresses) (default: false)",
+    )
+    .option(
+      "--option <id[:title]>",
+      "for --type status / --type select: add a selectable option. Repeat for multiple. `id` is the canonical value; `title` is the display label (default: titlecased id).",
+      (val: string, prev: string[]) => [...(prev ?? []), val],
+      [] as string[],
+    )
+    .option(
+      "--target-object <slug>",
+      "for --type record-reference: the object this attribute points at (e.g. `companies`)",
+    )
+    .option(
+      "--inverse <attribute_slug>",
+      "for --type record-reference: optional inverse attribute slug on the target object (used by the UI for back-references)",
+    )
+    .option(
+      "--currency-code <code>",
+      "for --type currency: default currency code (e.g. `USD`)",
+      "USD",
+    )
+    .addHelpText(
+      "after",
+      `
+Examples:
+  # add a text field to people
+  acrm attribute add people.years_experience --type number
+
+  # add a status field with options (the canonical hiring-pipeline shape)
+  acrm attribute add candidates.stage --type status \\
+      --option sourced --option screen --option onsite --option offer
+
+  # add a record-reference to another object
+  acrm attribute add candidates.applied_for --type record-reference \\
+      --target-object deals --inverse candidates
+
+  # add a multivalued, unique identifier (e.g. extra email_addresses)
+  acrm attribute add people.secondary_emails --type email-address \\
+      --multivalued --unique
+
+To edit status/select options after the fact, use \`acrm attribute edit-options\`.
+`,
+    )
+    .action(
+      async (
+        ref: string,
+        opts: {
+          type: string;
+          title?: string;
+          multivalued?: boolean;
+          unique?: boolean;
+          option?: string[];
+          targetObject?: string;
+          inverse?: string;
+          currencyCode?: string;
+        },
+      ) => {
+        const root = program.opts() as { json?: boolean; workspace?: string };
+        setJsonMode(root.json);
+        try {
+          const { object: object_slug, attribute: attribute_slug } =
+            parseAttributeRef(ref);
+          const attribute_type = parseAttributeType(opts.type);
+          const title = opts.title?.trim() || titleCase(attribute_slug);
+          const is_multivalued = Boolean(opts.multivalued);
+          const is_unique = Boolean(opts.unique);
+          const config = buildAttributeConfig({
+            attribute_type,
+            options: opts.option,
+            target_object: opts.targetObject,
+            inverse: opts.inverse,
+            currency_code: opts.currencyCode,
+          });
+
+          const lix = await openWorkspace({ workspace: root.workspace });
+          try {
+            await assertObjectExists(lix, object_slug);
+            if (config && config.target_object) {
+              await assertObjectExists(lix, config.target_object as string);
+            }
+            const have = await exec(
+              lix,
+              "SELECT attribute_slug FROM acrm_attribute WHERE object_slug = $1 AND attribute_slug = $2",
+              [object_slug, attribute_slug],
+            );
+            if (have.rows.length) {
+              throw new AcrmError(
+                `attribute already exists: ${object_slug}.${attribute_slug}`,
+                ERR.UNIQUE_VIOLATION,
+              );
+            }
+            const params: LixRuntimeValue[] = [
+              object_slug,
+              attribute_slug,
+              title,
+              attribute_type,
+              is_multivalued,
+              is_unique,
+              config ? JSON.stringify(config) : null,
+            ];
+            await exec(
+              lix,
+              `INSERT INTO acrm_attribute
+                (object_slug, attribute_slug, title, attribute_type, is_multivalued, is_unique, config_json)
+               VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+              params,
+            );
+            ok({
+              added: true,
+              object_slug,
+              attribute_slug,
+              attribute_type,
+              is_multivalued,
+              is_unique,
+              ...(config ? { config } : {}),
+            });
+          } finally {
+            await lix.close();
+          }
+        } catch (e) {
+          if (e instanceof AcrmError) fail(e.message, e.code, e.hint);
+          else fail(e instanceof Error ? e.message : String(e), ERR.UNHANDLED);
+          process.exit(1);
+        }
+      },
+    );
+
+  attribute
+    .command("edit-options <ref> <action> <option>")
+    .description(
+      "add or remove an option from a status/select attribute. <action> is `add` or `remove`; <option> is `<id>[:<title>]`.",
+    )
+    .addHelpText(
+      "after",
+      `
+Examples:
+  # extend deals.stage with a custom recruiting-funnel value
+  acrm attribute edit-options deals.stage add sourced
+  acrm attribute edit-options deals.stage add screen:Screening
+
+  # drop an option no longer in use
+  acrm attribute edit-options deals.stage remove lost
+
+The id is the canonical value stored in acrm_value.value_json.id. The title is
+what the UI / agents see. If you omit the title on \`add\`, it's derived from
+the id (e.g. \`in_progress\` → \`In Progress\`). Removing an option does NOT
+rewrite existing values — historical rows continue to reference the old id.
+`,
+    )
+    .action(async (ref: string, action: string, option: string) => {
+      const root = program.opts() as { json?: boolean; workspace?: string };
+      setJsonMode(root.json);
+      try {
+        const { object: object_slug, attribute: attribute_slug } =
+          parseAttributeRef(ref);
+        const verb = action.trim().toLowerCase();
+        if (verb !== "add" && verb !== "remove") {
+          throw new AcrmError(
+            `invalid action: ${action} (expected add | remove)`,
+            ERR.INVALID_INPUT,
+          );
+        }
+
+        const lix = await openWorkspace({ workspace: root.workspace });
+        try {
+          const attr = await loadAttribute(lix, object_slug, attribute_slug);
+          if (!attr) {
+            throw new AcrmError(
+              `attribute not found: ${object_slug}.${attribute_slug}`,
+              ERR.NOT_FOUND,
+            );
+          }
+          if (
+            attr.attribute_type !== "status" &&
+            attr.attribute_type !== "select"
+          ) {
+            throw new AcrmError(
+              `edit-options is only valid for status/select attributes; ${object_slug}.${attribute_slug} is ${attr.attribute_type}`,
+              ERR.INVALID_INPUT,
+            );
+          }
+
+          const current = (attr.config?.options as StatusOption[] | undefined) ?? [];
+          let next: StatusOption[];
+          if (verb === "add") {
+            const opt = parseOption(option);
+            if (current.some((o) => o.id === opt.id)) {
+              throw new AcrmError(
+                `option already exists: ${opt.id}`,
+                ERR.UNIQUE_VIOLATION,
+              );
+            }
+            next = [...current, opt];
+          } else {
+            const id = option.trim();
+            if (!current.some((o) => o.id === id)) {
+              throw new AcrmError(
+                `option not found: ${id} (current: ${current.map((o) => o.id).join(", ") || "<none>"})`,
+                ERR.NOT_FOUND,
+              );
+            }
+            next = current.filter((o) => o.id !== id);
+          }
+
+          const nextConfig: Record<string, unknown> = {
+            ...(attr.config ?? {}),
+            options: next,
+          };
+          await exec(
+            lix,
+            "UPDATE acrm_attribute SET config_json = $1 WHERE object_slug = $2 AND attribute_slug = $3",
+            [JSON.stringify(nextConfig), object_slug, attribute_slug],
+          );
+          ok({
+            updated: true,
+            object_slug,
+            attribute_slug,
+            attribute_type: attr.attribute_type,
+            options: next,
+          });
+        } finally {
+          await lix.close();
+        }
+      } catch (e) {
+        if (e instanceof AcrmError) fail(e.message, e.code, e.hint);
+        else fail(e instanceof Error ? e.message : String(e), ERR.UNHANDLED);
+        process.exit(1);
+      }
+    });
+}
+
+function buildAttributeConfig(args: {
+  attribute_type: AttributeType;
+  options?: string[];
+  target_object?: string;
+  inverse?: string;
+  currency_code?: string;
+}): Record<string, unknown> | null {
+  const cfg: Record<string, unknown> = {};
+  if (args.attribute_type === "status" || args.attribute_type === "select") {
+    const opts = (args.options ?? []).map(parseOption);
+    if (opts.length === 0) {
+      throw new AcrmError(
+        `--type ${args.attribute_type} requires at least one --option <id[:title]>`,
+        ERR.INVALID_INPUT,
+        "Example: --option sourced --option screen --option onsite --option offer",
+      );
+    }
+    const seen = new Set<string>();
+    for (const o of opts) {
+      if (seen.has(o.id)) {
+        throw new AcrmError(
+          `duplicate option id: ${o.id}`,
+          ERR.INVALID_INPUT,
+        );
+      }
+      seen.add(o.id);
+    }
+    cfg.options = opts;
+  } else if (args.options && args.options.length > 0) {
+    throw new AcrmError(
+      `--option is only valid for --type status / --type select (got --type ${args.attribute_type})`,
+      ERR.INVALID_INPUT,
+    );
+  }
+
+  if (args.attribute_type === "record-reference") {
+    if (!args.target_object) {
+      throw new AcrmError(
+        "--type record-reference requires --target-object <slug>",
+        ERR.INVALID_INPUT,
+      );
+    }
+    cfg.target_object = parseSlug(args.target_object, "target object");
+    if (args.inverse) cfg.inverse = parseSlug(args.inverse, "inverse slug");
+  } else if (args.target_object || args.inverse) {
+    throw new AcrmError(
+      "--target-object / --inverse are only valid for --type record-reference",
+      ERR.INVALID_INPUT,
+    );
+  }
+
+  if (args.attribute_type === "currency") {
+    cfg.currency_code = (args.currency_code ?? "USD").trim().toUpperCase();
+  }
+
+  return Object.keys(cfg).length ? cfg : null;
+}

--- a/src/domain/values.ts
+++ b/src/domain/values.ts
@@ -1,3 +1,5 @@
+import { AcrmError, ERR } from "../lib/errors.js";
+
 export type AttributeType =
   | "text"
   | "personal-name"
@@ -92,6 +94,20 @@ export function encode(
       const raw = String(input).trim();
       const match = resolveStatusOption(raw, config?.options);
       if (match) return { id: match.id, title: match.title };
+      // If options are configured, reject unknown values rather than silently
+      // creating a "free-text" option that won't roundtrip through the UI and
+      // can't be filtered with `WHERE id=...`. Pre-0.11 builds coerced into
+      // `{title: raw}`, which made `acrm import csv` accept e.g.
+      // `deal_stage,sourced` against the locked sales enum without complaint —
+      // see the ax-eval write-up.
+      if (config?.options && config.options.length > 0) {
+        const labels = config.options.map((o) => o.id).join(", ");
+        throw new AcrmError(
+          `invalid ${type} value: "${raw}" — expected one of: ${labels}`,
+          ERR.INVALID_INPUT,
+          `To add a new option, run \`acrm attribute edit-options <object>.<slug> add ${raw}\`.`,
+        );
+      }
       return { title: raw };
     }
     case "record-reference": {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add EAV custom schema commands and record create/update to the CLI
- Adds `acrm schema object create`, `acrm schema attribute add`, and `acrm schema attribute edit-options` commands in [schema.ts](https://github.com/cluster-software/agent-crm/pull/59/files#diff-84aef64fdd1479ac34ebba5c095b5c0f6f08a1c98664f6e7c945386bd3e044cc) for registering objects, adding typed attributes, and managing enum options.
- Adds `acrm records create <object>` and `acrm records update <object> <record_id>` in [records.ts](https://github.com/cluster-software/agent-crm/pull/59/files#diff-99422b62fefbcfb3f4b6cc7a1f13303389f91346e028a968d16e9a5cfb2e2197), with upfront validation of object/attribute existence and enum values before any writes.
- Updates the [acrm-query.md](https://github.com/cluster-software/agent-crm/pull/59/files#diff-f2987b7eb9387a18a91af1944eb6a7c5ceb15dd18b92071d3f5036dafd656442) skill doc so Claude can discover and reason about the custom schema and EAV structure.
- Behavioral Change: encoding a `status`/`select` value with configured options now throws an error on unknown values instead of accepting free-text input; callers must use a valid option or add it via `attribute edit-options` first.

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 436d065. 8 files reviewed, 2 issues evaluated, 1 issue filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>src/commands/records.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 971](https://github.com/cluster-software/agent-crm/blob/436d065381cd7f1be74d5b8c22e599963441632f/src/commands/records.ts#L971): The counter `n` in `applyFields` is incremented unconditionally after calling `addMultiValue`, but `addMultiValue` (in `src/db/upsert.ts`) returns early without inserting when a duplicate value already exists. This causes `values_inserted` / `values_changed` to report a higher count than the actual number of values written. For example, calling `createRecord` with `fields: ["email_addresses=same@test.com", "email_addresses=same@test.com"]` would report `values_inserted: 2` when only 1 value was actually inserted. <b>[ Out of scope (triage) ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->