### PR TITLE
make acrm_value a more intuitive

### DIFF
--- a/.changeset/intuitive-acrm-value-schema.md
+++ b/.changeset/intuitive-acrm-value-schema.md
@@ -1,0 +1,18 @@
+---
+"@agent-crm/cli": minor
+---
+
+Make `acrm_value` writable with the obvious four-column INSERT (issue #51). The schema previously required `attribute_type` (already known from `acrm_attribute`) and `active_from` (mechanical bookkeeping), so the natural query failed with a validation error and new developers hit the wall on their first direct write.
+
+- `acrm_value.attribute_type` is removed. The type lives on `acrm_attribute` — join when you need it (`acrm-query` skill has the canonical pattern). The two internal read sites that pulled `attribute_type` from `acrm_value` (the dedupe flow's `loadActiveValues` / `loadInboundRefs`) now JOIN to `acrm_attribute`.
+
+- `acrm_value.active_from` is now Lix-defaulted to `lix_timestamp()`. Writers don't have to pass it. `id` was already defaulted to `lix_uuid_v7()`.
+
+The naive insert from the issue now works:
+
+```sql
+INSERT INTO acrm_value (object_slug, record_id, attribute_slug, value_json)
+VALUES ('people', 'person_1', 'name', '{"full_name":"Ada Lovelace"}');
+```
+
+`normalized_key` / `ref_object` / `ref_record_id` stay as nullable indexed columns on `acrm_value` — direct-SQL writers still populate them for unique-keyed attrs and record-references (documented in the `acrm-query` skill).

--- a/skills/acrm-query.md
+++ b/skills/acrm-query.md
@@ -48,12 +48,26 @@ Why no `$1`-free heredoc trick? `acrm execute` rejects `?` placeholders
 ### `acrm_value` columns worth knowing
 
 - `id` — value-row PK. Use this for surgical updates (`UPDATE … WHERE id=$1`).
+  Lix-defaulted to `lix_uuid_v7()` if omitted on insert.
 - `object_slug`, `record_id`, `attribute_slug` — the entity this value belongs to.
 - `value_json` — the typed payload (e.g. `{"value":"Cluster"}` or `{"target_record_id":"…"}`).
 - `normalized_key` — denormalized key for unique-keyed attrs (email_address, domain, url, text).
 - `ref_object`, `ref_record_id` — for record-reference attrs, the indexed link target.
-- `active_from`, `active_until` — versioning. **Always filter `active_until IS NULL` for current values.**
+- `active_from`, `active_until` — versioning. `active_from` is Lix-defaulted to
+  `lix_timestamp()` if omitted. **Always filter `active_until IS NULL` for current values.**
 - `source`, `provenance_json` — where this value came from.
+
+`attribute_type` is **not** a column on `acrm_value` — it lives on
+`acrm_attribute`. JOIN when you need it:
+
+```sql
+SELECT v.attribute_slug, a.attribute_type, v.value_json
+FROM   acrm_value v
+JOIN   acrm_attribute a
+       ON a.object_slug = v.object_slug AND a.attribute_slug = v.attribute_slug
+WHERE  v.object_slug = 'people' AND v.record_id = $1
+       AND v.active_until IS NULL;
+```
 
 ## SQL dialect: DataFusion
 
@@ -207,8 +221,16 @@ provenance, EAV invariants, and enum validation.
 When you need something the CLI doesn't cover, writing directly to the EAV
 tables via `acrm execute` is supported and expected — that's what the CLI
 commands do internally. The `acrm_object`, `acrm_attribute`, `acrm_record`, and
-`acrm_value` tables are stable surfaces. The only thing to watch for on
-`acrm_value` mutations is that you maintain the invariants the CLI handles for
-you: a fresh `id` (`lix_uuid_v7()`), `active_from = NOW`, `active_until = NULL`
-for current values, the right `normalized_key` for unique-keyed attribute
-types, and `ref_object` / `ref_record_id` for record-references.
+`acrm_value` tables are stable surfaces. The minimal insert is:
+
+```sql
+INSERT INTO acrm_value (object_slug, record_id, attribute_slug, value_json)
+VALUES ('people', 'person_1', 'name', '{"full_name":"Ada Lovelace"}');
+```
+
+`id` defaults to `lix_uuid_v7()` and `active_from` to `lix_timestamp()`. The
+invariants `acrm_value` mutations must still maintain themselves: `active_until = NULL`
+for current values (set the previous current row's `active_until` to NOW when
+replacing a single-valued attr), the right `normalized_key` for unique-keyed
+attribute types (`email-address`, `domain`, `url`, `text`), and
+`ref_object` / `ref_record_id` for record-references.

--- a/src/commands/execute.ts
+++ b/src/commands/execute.ts
@@ -24,8 +24,9 @@ Storage model: EAV. Records are not stored in per-object SQL tables.
     acrm_record     (record_id, object_slug)              one row per record
     acrm_value      (id, record_id, object_slug,          one row per attribute
                      attribute_slug, value_json,           value (current OR
-                     normalized_key, ref_object,           historical)
-                     ref_record_id, active_from, active_until, source, …)
+                     normalized_key, ref_object,           historical).
+                     ref_record_id, active_from,           attribute_type is NOT
+                     active_until, source, …)              here — JOIN acrm_attribute.
     acrm_attribute  (object_slug, attribute_slug,         schema: what fields
                      attribute_type, is_multivalued,       exist on each object
                      is_unique, config_json)

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -198,8 +198,6 @@ type PendingValue = {
   record_id: string;
   attribute_slug: string;
   value_json: string;
-  attribute_type: AttributeType;
-  active_from: string;
   normalized_key: string | null;
   ref_object: string | null;
   ref_record_id: string | null;
@@ -262,7 +260,7 @@ class WriteBatcher {
   }
 
   private async flushValues(): Promise<void> {
-    const COLS = 12;
+    const COLS = 10;
     for (let i = 0; i < this.values.length; i += MAX_BATCH_VALUES) {
       const chunk = this.values.slice(i, i + MAX_BATCH_VALUES);
       const placeholders = chunk
@@ -277,8 +275,6 @@ class WriteBatcher {
         v.record_id,
         v.attribute_slug,
         v.value_json,
-        v.attribute_type,
-        v.active_from,
         v.normalized_key,
         v.ref_object,
         v.ref_record_id,
@@ -288,8 +284,8 @@ class WriteBatcher {
       await exec(
         this.lix,
         `INSERT INTO acrm_value
-          (id, object_slug, record_id, attribute_slug, value_json, attribute_type,
-           active_from, normalized_key, ref_object, ref_record_id, source, provenance_json)
+          (id, object_slug, record_id, attribute_slug, value_json,
+           normalized_key, ref_object, ref_record_id, source, provenance_json)
          VALUES ${placeholders}`,
         params,
       );
@@ -332,8 +328,6 @@ function buildValueRow(
     record_id: args.record_id,
     attribute_slug: args.attribute_slug,
     value_json: JSON.stringify(args.value_json),
-    attribute_type: args.attribute_type,
-    active_from: nowIso(),
     normalized_key: normalized,
     ref_object: ref.ref_object,
     ref_record_id: ref.ref_record_id,

--- a/src/commands/records.ts
+++ b/src/commands/records.ts
@@ -696,10 +696,12 @@ async function loadActiveValues(
 ): Promise<ValueRow[]> {
   const r = await exec(
     lix,
-    `SELECT id, attribute_slug, attribute_type, value_json, normalized_key,
-            ref_object, ref_record_id
-     FROM acrm_value
-     WHERE object_slug = $1 AND record_id = $2 AND active_until IS NULL`,
+    `SELECT v.id, v.attribute_slug, a.attribute_type, v.value_json,
+            v.normalized_key, v.ref_object, v.ref_record_id
+     FROM acrm_value v
+     JOIN acrm_attribute a
+       ON a.object_slug = v.object_slug AND a.attribute_slug = v.attribute_slug
+     WHERE v.object_slug = $1 AND v.record_id = $2 AND v.active_until IS NULL`,
     [object_slug, record_id],
   );
   return r.rows.map((row) => ({
@@ -720,10 +722,12 @@ async function loadInboundRefs(
 ): Promise<InboundRow[]> {
   const r = await exec(
     lix,
-    `SELECT id, object_slug, record_id, attribute_slug, attribute_type,
-            value_json, normalized_key, ref_object, ref_record_id
-     FROM acrm_value
-     WHERE ref_object = $1 AND ref_record_id = $2 AND active_until IS NULL`,
+    `SELECT v.id, v.object_slug, v.record_id, v.attribute_slug, a.attribute_type,
+            v.value_json, v.normalized_key, v.ref_object, v.ref_record_id
+     FROM acrm_value v
+     JOIN acrm_attribute a
+       ON a.object_slug = v.object_slug AND a.attribute_slug = v.attribute_slug
+     WHERE v.ref_object = $1 AND v.ref_record_id = $2 AND v.active_until IS NULL`,
     [ref_object, ref_record_id],
   );
   return r.rows.map((row) => ({

--- a/src/db/upsert.ts
+++ b/src/db/upsert.ts
@@ -103,8 +103,6 @@ export async function insertValue(
     args.record_id,
     args.attribute_slug,
     JSON.stringify(args.value_json),
-    args.attribute_type,
-    nowIso(),
     normalized,
     ref.ref_object,
     ref.ref_record_id,
@@ -114,9 +112,9 @@ export async function insertValue(
   await exec(
     lix,
     `INSERT INTO acrm_value
-      (id, object_slug, record_id, attribute_slug, value_json, attribute_type,
-       active_from, normalized_key, ref_object, ref_record_id, source, provenance_json)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+      (id, object_slug, record_id, attribute_slug, value_json,
+       normalized_key, ref_object, ref_record_id, source, provenance_json)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
     params,
   );
 }

--- a/src/workspace/schemas/index.test.ts
+++ b/src/workspace/schemas/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { exec } from "../../db/execute.js";
-import { openTestLix } from "../../test/open-test-lix.js";
+import { openTestLix, openTestWorkspace } from "../../test/open-test-lix.js";
 import { ALL_SCHEMAS, registerAllSchemas } from "./index.js";
 
 describe("registerAllSchemas", () => {
@@ -78,5 +78,42 @@ describe("registerAllSchemas", () => {
       await expect(exec(lix, `SELECT * FROM ${tableName} LIMIT 0`)).resolves
         .toMatchObject({ rows: [], rowsAffected: 0 });
     }
+  });
+
+  // Issue #51: a developer who knows the EAV layout should be able to write a
+  // value with only the four logical columns. id + active_from must be filled
+  // by Lix defaults; attribute_type must not be required (it lives on
+  // acrm_attribute).
+  it("accepts the minimal acrm_value insert from issue #51", async () => {
+    const lix = await openTestWorkspace();
+
+    await exec(
+      lix,
+      "INSERT INTO acrm_record (object_slug, record_id) VALUES ($1, $2)",
+      ["people", "person_1"],
+    );
+
+    await exec(
+      lix,
+      `INSERT INTO acrm_value (object_slug, record_id, attribute_slug, value_json)
+       VALUES ($1, $2, $3, $4)`,
+      ["people", "person_1", "name", '{"full_name":"Ada Lovelace"}'],
+    );
+
+    const r = await exec(
+      lix,
+      `SELECT v.value_json, a.attribute_type, v.id, v.active_from
+       FROM acrm_value v
+       JOIN acrm_attribute a
+         ON a.object_slug = v.object_slug AND a.attribute_slug = v.attribute_slug
+       WHERE v.object_slug = 'people' AND v.record_id = 'person_1'
+         AND v.active_until IS NULL`,
+    );
+    expect(r.rows).toHaveLength(1);
+    const row = r.rows[0]!;
+    expect(row.value_json).toContain("Ada Lovelace");
+    expect(row.attribute_type).toBe("personal-name");
+    expect(row.id).toBeTruthy();
+    expect(row.active_from).toBeTruthy();
   });
 });

--- a/src/workspace/schemas/index.ts
+++ b/src/workspace/schemas/index.ts
@@ -84,8 +84,6 @@ export const SCHEMA_VALUE: LixSchema = {
     "record_id",
     "attribute_slug",
     "value_json",
-    "attribute_type",
-    "active_from",
   ],
   properties: {
     id: { type: "string", "x-lix-default": "lix_uuid_v7()" },
@@ -93,8 +91,7 @@ export const SCHEMA_VALUE: LixSchema = {
     record_id: { type: "string" },
     attribute_slug: { type: "string" },
     value_json: { type: "string" },
-    attribute_type: { type: "string" },
-    active_from: { type: "string" },
+    active_from: { type: "string", "x-lix-default": "lix_timestamp()" },
     active_until: nullable("string"),
     normalized_key: nullable("string"),
     ref_object: nullable("string"),


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Remove `attribute_type` and `active_from` from `acrm_value` inserts, using schema defaults
- Removes `attribute_type` from the `acrm_value` table schema; it must now be read via JOIN on `acrm_attribute`.
- Sets `active_from` to default via `lix_timestamp()` so callers no longer need to supply it.
- Updates all insert paths ([import.ts](https://github.com/cluster-software/agent-crm/pull/61/files#diff-4c4494c24ff5666603a350adb37862caa463acf4960e6fa7cea6df709cdf06a4), [upsert.ts](https://github.com/cluster-software/agent-crm/pull/61/files#diff-1f332ffff964298eef808c64739968968065a011f32318f1da0c613fbfc175bb)) and read queries ([records.ts](https://github.com/cluster-software/agent-crm/pull/61/files#diff-99422b62fefbcfb3f4b6cc7a1f13303389f91346e028a968d16e9a5cfb2e2197)) to match the new shape.
- Adds a test verifying the minimal four-column INSERT works end-to-end.
- Behavioral Change: any code that reads `attribute_type` directly from `acrm_value` will need to JOIN `acrm_attribute` instead.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized f001a3d.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->