### PR TITLE
README: replace stateful skills section with use-case gallery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 test-acrm/
 feedback/
 /scripts/
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -56,55 +56,40 @@ Then import your CSVs
 ! acrm import csv ./leads.csv
 ```
 
+View your data
+```bash
+! acrm ui
+```
+
 ## Why Agent CRM
 - **🧩 Headless:** Ships as a CLI.
 - **⚒️ Skills based:** Claude writes skills against the CLI (transcript ingestion, stale-deal sweeps, weekly reports) as `.md` files.
 - **🧱 Modeled:** uses Attio's data model out of the box — `people`, `companies`, `deals`, `posts`, `transcripts`. Typed, related, queryable with plain SQL. Fixed schema = predictable agent edits.
 - **🔀 Version controlled:** every change is a checkpoint on a branch. Diff, merge, revert, time-travel.
-- **🔌 Pluggable transcript providers:** `transcripts` are vendor-agnostic. Drop a new adapter into `.claude/transcript-providers/` to plug in Granola, Otter, Fireflies, Fathom, Zoom, manual paste, or anything else.
+- **🔌 Pluggable transcript providers:** `transcripts` are vendor-agnostic. Drop a `transcript-provider-<vendor>` skill into `~/.claude/skills/` to plug in Granola, Otter, Fireflies, Fathom, Zoom, manual paste, or anything else.
 
 
-## Stateful skills for GTM
+## Use cases
 
-Skills are how Claude does the work. Bring your own, or use the ones we ship — `prep-call`, `post-call`, `follow-up`, `setup-transcripts`. Claude can write new ones in seconds.
+A grab-bag of jobs Agent CRM handles today. Each is a skill or a CLI command — bring your own, or use the ones we ship.
 
-**[`prep-call`](.claude/skills/prep-call.md).** Before a meeting, Claude pulls the person's full history from your `.acrm`, fetches their LinkedIn profile (cached, 14-day TTL), and hands you a one-pager with discovery questions tied to what they've actually been talking about.
+**Prep for a sales call.** [`/prep-call`](skills/prep-call.md) pulls the person's full history from your `.acrm`, fetches their LinkedIn profile (cached, 14-day TTL), and hands you a one-pager with discovery questions tied to what they've actually been talking about.
 
-**[`post-call`](.claude/skills/post-call.md).** After a meeting, Claude pulls the transcript from whichever provider you've connected (Granola today; plug in Otter, Fireflies, or any vendor by dropping an adapter into `.claude/transcript-providers/`), resolves the participants in `.acrm` by email, extracts the problem + would-pay signal, and imports it as a `transcripts` record linked to the attendees via `acrm import transcript`. You review the summary before the next sync.
+**Pull call transcripts from Granola.** [`/post-call`](skills/post-call.md) fetches the transcript from your connected provider, resolves participants by email, and imports it as a `transcripts` record linked to the attendees. Local, queryable, and easy to spot patterns across calls.
 
-**[`follow-up`](.claude/skills/follow-up.md).** Claude queries `.acrm` for leads with stale activity, reads the prior thread (and any past-call transcripts linked via `people.associated_transcripts`), and drafts the next message in your tone of voice. You review and send.
+**Draft follow-ups in your voice.** [`/follow-up`](skills/follow-up.md) finds leads with stale activity, reads the prior thread plus any past-call transcripts, and drafts the next message. You review and send.
 
-**[`setup-transcripts`](.claude/skills/setup-transcripts.md).** One-time setup that scans `.claude/transcript-providers/` and walks you through connecting whichever meeting/call sources you use — Granola today (OAuth), manual paste/file always, and any new vendor you've dropped an adapter for. Run it before your first `/post-call`.
+**Import a scraped list.** `acrm import csv ./leads.csv` ingests a CSV with auto-derived attributes. New columns become typed attributes on the right object — no schema setup.
 
-Each skill is a markdown file in `.claude/skills/`. Here's what `post-call` looks like:
+**Sweep stale deals.** Ask Claude to query your `.acrm` for deals untouched in N days and surface them. It's just SQL underneath, so any filter you can describe, Claude can run.
 
-```markdown
----
-description: Pull a meeting transcript from whichever provider you have connected (Granola, manual paste, or any adapter in .claude/transcript-providers/) and import it into .acrm as a `transcripts` record linked to participants.
----
+**Import X / LinkedIn posts.** You're scrolling and see a post worth following up on. Paste the URL into Claude Code — `acrm import post <url>` upserts the post and adds the author as a contact, viewable in the UI.
 
-## Steps
+**Import X / LinkedIn profiles.** Come across someone you want to chat to. Paste the profile URL into Claude Code — `acrm import linkedin <url>` or `acrm import x <handle>` pulls the enriched profile and dedupes against existing people.
 
-1. **Resolve the person** with a SQL lookup:
-   `acrm execute "SELECT DISTINCT record_id FROM acrm_value WHERE object_slug = 'people' AND attribute_slug = 'email_addresses' AND active_until IS NULL AND normalized_key = $1" '["<lowercased-email>"]' --json`
+**Plug in a new transcript provider.** Adapters are themselves skills. Drop a `transcript-provider-<vendor>` SKILL.md into `~/.claude/skills/` following the contract in [`docs/transcript-provider-protocol.md`](docs/transcript-provider-protocol.md) (Otter, Fireflies, Fathom, Zoom). [`/setup-transcripts`](skills/setup-transcripts.md) picks it up and walks you through connecting it before your first `/post-call`.
 
-2. **Pick a provider.** Read every file in `.claude/transcript-providers/`
-   except `README.md`, run each adapter's Detect step, dispatch to the one
-   that's connected.
+**Write your own skill.** Ask Claude for _"a skill that reads my call transcripts, updates deal stages, and posts a summary to Slack"_ and it writes a `.md` file into `~/.claude/skills/`. No code.
 
-3. **Fetch the transcript** via the chosen adapter (e.g. `mcp__granola__get_meeting_transcript` for Granola; user paste for the manual adapter).
-
-4. **Extract the call fields** (problem, would-pay, next steps) and fold them into a summary block.
-
-5. **Import via the CLI.** Build canonical JSON and pipe to
-   `acrm import transcript` — the CLI dedups by `source_id`,
-   resolves participants by email, and writes bidirectional links.
-
-6. **Report a short summary.** The user reviews `resolved` /
-   `unresolved` participants and the new `transcript_record_id`.
-```
-
-Need something custom? Just ask:
-
-> _"Write me a skill that reads my call transcripts, updates deal stages, and posts a summary to Slack."_
+**Query with plain SQL.** `acrm execute "SELECT ..."` runs against the Attio-style schema. It's just SQLite — bring any client you like.
 


### PR DESCRIPTION
## Summary
- Replaces the "Stateful skills for GTM" section with a 10-entry "Use cases" gallery covering skills, CSV import, SQL sweeps, X/LinkedIn post + profile ingestion, transcript providers, and custom skill authoring.
- Updates stale references to the old `.claude/transcript-providers/` mechanism — adapters are themselves skills now (drop `transcript-provider-<vendor>` into `~/.claude/skills/`), per the new model in `setup-transcripts.md`.
- Fixes broken `.claude/skills/<name>.md` links to point at the actual bundled location (`skills/<name>.md`).
- Bundles a small `.gitignore` addition for `.claude/settings.local.json`.

Closes #56

## Test plan
- [ ] Eyeball the rendered README on this PR page — gallery formatting, link targets resolve, section flow reads cleanly.
- [ ] Confirm `docs/transcript-provider-protocol.md` and each `skills/<name>.md` link click through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace stateful skills section with use-case gallery in README
> - Replaces the 'Stateful skills for GTM' section in [README.md](https://github.com/cluster-software/agent-crm/pull/65/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) with a 'Use cases' section listing concise scenarios: prep-call, post-call, follow-up, CSV import, stale deal sweeps, importing posts/profiles, adding transcript providers, writing custom skills, and SQL queries.
> - Removes the long illustrative `post-call` skill YAML example and step-by-step breakdown in favor of brief use-case descriptions.
> - Updates transcript provider instructions to reference dropping a `transcript-provider-<vendor>` skill into `~/.claude/skills/` and links to `docs/transcript-provider-protocol.md`.
> - Adds a 'View your data' section with a `! acrm ui` CLI snippet.
> - Adjusts skill links from `.claude/skills/*.md` to `skills/*.md`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 012dfeb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->