### PR TITLE
release: build workspaces before changesets publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Build both packages before changesets/action runs `npm publish`.
+      # changesets v1 publishes packages in parallel, and each `npm publish`
+      # invocation triggers `prepublishOnly` (= `tsc`) in its own dir. CLI's
+      # tsc resolves `@agent-crm/sdk` via the workspace symlink and reads
+      # the package's declared `types: dist/index.d.ts`; without a prior
+      # build the SDK's `dist/` may not exist yet when CLI's tsc starts,
+      # and CLI's compilation fails (TS code 2). Building topologically
+      # here guarantees both `dist/` trees exist before any publish.
+      - name: Build
+        run: npm run build
+
       - name: Create Release Pull Request or Publish
         uses: changesets/action@v1
         with:


### PR DESCRIPTION
## Why

The release run that just failed (https://github.com/cluster-software/agent-crm/actions/runs/25976824914) hit two bugs:

1. **CLI \`tsc\` exited with code 2.** \`changesets/action\` runs \`npm publish\` per package in parallel, and each invocation triggers \`prepublishOnly\` (= \`tsc\`) inside its own dir. CLI's \`tsc\` resolves \`@agent-crm/sdk\` through the workspace symlink and reads the SDK package's declared \`types: dist/index.d.ts\` — which hadn't been built yet when CLI's compilation started.
2. **SDK publish 404'd.** Unrelated; the \`NPM_TOKEN\` likely lacks rights to create \`@agent-crm/sdk\` (the existing CLI token may be granular). Not fixed in this PR — needs a token update or a one-time manual publish.

This PR addresses (1).

## What

Add an explicit \`npm run build\` step in \`release.yml\` before \`changesets/action\`. The root build script is topologically ordered (SDK first, then CLI), so both \`dist/\` trees exist before any \`npm publish\` runs. The redundant per-package \`prepublishOnly\` then runs against already-built state.

## Test plan

- [x] Same workflow change runs on this PR via the existing CI (verifies syntax / no regressions).
- [ ] After merging this and updating \`NPM_TOKEN\` (or running a manual \`npm publish\` of \`@agent-crm/sdk@0.1.0\`), re-running \`Release\` on \`main\` should publish both packages cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Build workspaces before changesets publishes in the release workflow
> Adds a `Build` step that runs `npm run build` in [release.yml](.github/workflows/release.yml) before the `changesets/action` publish step, ensuring packages are built prior to being published. Also removes the job-level `runs-on: ubuntu-latest` from the `release` job.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bccfc27.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->