### PR TITLE
test: verify CI NPM_TOKEN can publish both packages

### DIFF
--- a/.changeset/verify-ci-token.md
+++ b/.changeset/verify-ci-token.md
@@ -1,0 +1,9 @@
+---
+"@agent-crm/sdk": patch
+"@agent-crm/cli": patch
+---
+
+Verify the CI `NPM_TOKEN` has rights to publish both `@agent-crm/sdk` and
+`@agent-crm/cli` after the granular-token allowlist fix. Adds a SDK
+README and bumps both packages by a patch to exercise the full
+changesets → publish pipeline.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,22 @@
+# @agent-crm/sdk
+
+Programmatic API for the [Agent CRM](https://github.com/cluster-software/agent-crm) `.acrm` workspace — the same operations the [`@agent-crm/cli`](https://www.npmjs.com/package/@agent-crm/cli) `acrm` command runs, but as typed functions you can call in-process.
+
+```ts
+import { Workspace, createWorkspace, importTranscript } from "@agent-crm/sdk";
+
+const { workspace, workspaceId } = await createWorkspace("/path/to/file.acrm");
+try {
+  const result = await importTranscript(workspace, {
+    source: "granola",
+    source_id: "meeting-123",
+    title: "Discovery — Acme",
+    participants: [{ email: "alice@acme.com" }],
+  });
+  console.log(result.transcript_record_id);
+} finally {
+  await workspace.close();
+}
+```
+
+See the [main README](https://github.com/cluster-software/agent-crm) for an overview of the workspace model, the EAV schema, and the CLI on top of this SDK.


### PR DESCRIPTION
## Why

The previous \`Release\` run published \`@agent-crm/cli@0.13.0\` but failed to publish \`@agent-crm/sdk@0.1.0\` (E404 — \`NPM_TOKEN\` lacked rights to create the new package). SDK was published manually from local to fix the broken state. Token has since been updated.

This PR exercises the full pipeline end to end so we know the token works for **both** packages before the next real release.

## What

- Adds \`packages/sdk/README.md\` (we had none — purely useful, no behavior change).
- Adds a changeset that patch-bumps both packages.

## Expected outcome

1. Merging this opens a \`chore: version packages\` PR bumping \`@agent-crm/sdk\` → \`0.1.1\` and \`@agent-crm/cli\` → \`0.13.1\` (with CLI's SDK pin updated to \`0.1.1\`).
2. Merging that PR runs \`Release\` → both packages publish cleanly.

If SDK 404s again, the token still doesn't authorize \`@agent-crm/sdk\` and the npm token settings need another look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add README for @agent-crm/sdk and bump both packages to verify CI publish token
> Adds a [README.md](https://github.com/cluster-software/agent-crm/pull/69/files#diff-fb389a13c110d5b92cb85e2a1eb937b649ff8adc09a19626ab6cbc9218bb6d83) to `@agent-crm/sdk` with a basic usage example and repo links. Includes a [changeset](https://github.com/cluster-software/agent-crm/pull/69/files#diff-055ed7c35402708cf70b41a4495600eddd5720c45d325e159342aa88343f9d69) that triggers patch releases for both `@agent-crm/sdk` and `@agent-crm/cli` to confirm the CI `NPM_TOKEN` has publish rights after a granular-token allowlist fix.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d716d14.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->