### PR TITLE
ci: cache deps, parallelize jobs, skip native build on SDK-alone smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,14 @@ on:
     branches:
       - main
 
+# Cancel obsolete runs when a PR gets a new push (or main is pushed again).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  # Two parallel jobs (no `needs:` between them) so total wall clock is
+  # max(build-test, smoke-tarballs) instead of build-test + smoke-tarballs.
   build-test:
     runs-on: ubuntu-latest
     steps:
@@ -14,42 +21,72 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm ci
+          # Cache ~/.npm (npm's download cache). Speeds up `npm ci` whenever
+          # node_modules cache misses, and is also shared with subprocess
+          # `npm install`s elsewhere in this job.
+          cache: npm
+      - name: Restore node_modules
+        id: nm
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: nm-${{ runner.os }}-node20-${{ hashFiles('package-lock.json') }}
+      - name: Install
+        if: steps.nm.outputs.cache-hit != 'true'
+        run: npm ci
       - run: npm run build
       - run: npm test
 
   smoke-tarballs:
-    # Per the issue's "smoke-test discipline" gate: pack both packages and
-    # install them into a clean dir. Catches the failure mode where the CLI
-    # tarball references a `@agent-crm/sdk` version that isn't installable
-    # — a class of bug that local workspaces make easy to ship.
+    # Pack the published-tarball shape of both packages and run the issue's
+    # smoke-test gate (SDK alone exports its API; CLI+SDK install together
+    # and `acrm` works end to end). Runs in parallel with build-test.
     runs-on: ubuntu-latest
-    needs: build-test
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm ci
+          cache: npm
+      - name: Restore node_modules
+        id: nm
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: nm-${{ runner.os }}-node20-${{ hashFiles('package-lock.json') }}
+      - name: Install
+        if: steps.nm.outputs.cache-hit != 'true'
+        run: npm ci
       - run: npm run build
       - name: Pack both packages
         run: |
           npm pack --workspace @agent-crm/sdk --pack-destination "$RUNNER_TEMP"
           npm pack --workspace @agent-crm/cli --pack-destination "$RUNNER_TEMP"
-          ls -la "$RUNNER_TEMP"/*.tgz
       - name: SDK tarball installs and exports its public API
+        # `--ignore-scripts` skips better-sqlite3's ~30s native build. This
+        # smoke check only verifies the SDK module loads and exports a
+        # non-empty named-export set; it never opens a Lix, so no native
+        # binding is needed.
         run: |
           dir=$(mktemp -d)
           cd "$dir"
           npm init -y > /dev/null
-          npm install "$RUNNER_TEMP"/agent-crm-sdk-*.tgz
+          npm install --ignore-scripts --prefer-offline --no-audit --no-fund \
+            "$RUNNER_TEMP"/agent-crm-sdk-*.tgz
           node -e "import('@agent-crm/sdk').then(m => { const k = Object.keys(m); if (k.length === 0) { throw new Error('SDK exported zero names'); } console.log('SDK exports:', k.length, 'names'); })"
       - name: CLI + SDK tarballs install together and acrm runs
+        # Real install (scripts enabled) so better-sqlite3's postinstall and
+        # CLI's skills installer both run end to end — that's the bug class
+        # this check is specifically here to catch.
         run: |
           dir=$(mktemp -d)
           cd "$dir"
           npm init -y > /dev/null
-          npm install \
+          npm install --prefer-offline --no-audit --no-fund \
             "$RUNNER_TEMP"/agent-crm-sdk-*.tgz \
             "$RUNNER_TEMP"/agent-crm-cli-*.tgz
           ./node_modules/.bin/acrm --version


### PR DESCRIPTION
## Why

Previous CI runs were taking **~7 minutes wall clock** (build-test 2m49s + smoke-tarballs 4m11s, sequential via \`needs:\`). Bottlenecks from the last green run on PR #69 (https://github.com/cluster-software/agent-crm/actions/runs/25977221733):

| Step | build-test | smoke-tarballs |
|---|---|---|
| \`npm ci\` | **92s** | **82s** |
| \`npm run build\` | 4s | 4s |
| \`npm test\` | **68s** | — |
| SDK smoke install | — | **77s** |
| CLI+SDK smoke install | — | **81s** |

Most of that is redundancy: two \`npm ci\`s with zero caching, plus two fresh \`npm install\`s that rebuild \`better-sqlite3\` from source.

## What

1. **Parallelize the jobs.** Remove \`needs: build-test\` from smoke-tarballs. Total wall clock becomes \`max(jobA, jobB)\` instead of \`jobA + jobB\`.
2. **Cache \`node_modules\`** via \`actions/cache@v4\` keyed on \`package-lock.json\`. Cache-hit runs skip \`npm ci\` entirely.
3. **Cache \`~/.npm\`** via \`setup-node@v4\`'s \`cache: npm\`. Speeds up cache-miss runs and the smoke installs (which read from this cache via \`--prefer-offline\`).
4. **\`--ignore-scripts\` on the SDK-alone smoke.** That check only verifies module exports; better-sqlite3's ~30s native build is wasted work.
5. **\`--prefer-offline --no-audit --no-fund\`** on smoke installs — skip network and audit chatter.
6. **\`concurrency:\` group** with \`cancel-in-progress: true\` — pushing a new commit to a PR cancels the previous run.

## Expected

- First run (cold cache): ~3 min wall clock
- Cached run (lockfile unchanged): ~80-90 s wall clock

Floors set by GitHub-hosted 2-core runner hardware (these don't go below):
- vitest's 136 lix-touching tests: ~70 s
- better-sqlite3 native compile in CLI smoke: ~30 s

50× isn't possible without bigger runners, but ~5× on cached runs is.

## Test plan

- [x] Workflow runs against this PR — both jobs in parallel, see if they go green
- [ ] Push a second commit to the same PR — verify concurrency cancels the first run
- [ ] Merge — verify main also gets the speedup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache npm deps, parallelize CI jobs, and skip install scripts in SDK smoke test
> - Adds `concurrency` group to [ci.yml]( file:.github/workflows/ci.yml) to cancel in-progress runs when a new push to the same ref occurs.
> - Caches `node_modules` and npm cache keyed by `package-lock.json`; `npm ci` runs only on cache miss in both `build-test` and `smoke-tarballs` jobs.
> - Removes the `needs: build-test` dependency from `smoke-tarballs` so both jobs run in parallel.
> - SDK-only smoke install now uses `--ignore-scripts --prefer-offline` to skip native builds; CLI+SDK smoke adds `--prefer-offline` with audit/fund suppressed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e7f6675.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->