### PR TITLE
fix: enforce absolute SDK workspace paths

### DIFF
--- a/.changeset/absolute-workspace-paths.md
+++ b/.changeset/absolute-workspace-paths.md
@@ -1,0 +1,5 @@
+---
+"@agent-crm/sdk": patch
+---
+
+Reject relative paths in `Workspace.open` and `Workspace.create` so SDK callers must resolve workspace paths explicitly before opening or creating `.acrm` files.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -21,6 +21,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "test": "vitest run",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/sdk/src/workspace.test.ts
+++ b/packages/sdk/src/workspace.test.ts
@@ -1,0 +1,32 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { AcrmError, ERR } from "./lib/errors.js";
+import { Workspace } from "./workspace.js";
+
+describe("Workspace", () => {
+  it("rejects relative paths before opening a workspace", async () => {
+    await expect(Workspace.open("relative.acrm")).rejects.toMatchObject({
+      code: ERR.INVALID_INPUT,
+      message: "workspace path must be absolute: relative.acrm",
+    });
+  });
+
+  it("rejects relative paths before creating a workspace", async () => {
+    await expect(Workspace.create("relative.acrm")).rejects.toBeInstanceOf(
+      AcrmError,
+    );
+  });
+
+  it("creates a workspace at an absolute path", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "acrm-sdk-workspace-"));
+    try {
+      const workspacePath = path.join(dir, "test.acrm");
+      const workspace = await Workspace.create(workspacePath);
+      await workspace.close();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/sdk/src/workspace.ts
+++ b/packages/sdk/src/workspace.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs";
+import { isAbsolute } from "node:path";
 import { openLix, type Lix } from "@lix-js/sdk";
 import { createBetterSqlite3Backend } from "@lix-js/sdk/sqlite";
 import { AcrmError, ERR } from "./lib/errors.js";
@@ -16,6 +17,7 @@ export class Workspace {
   }
 
   static async open(absolutePath: string): Promise<Workspace> {
+    assertAbsolutePath(absolutePath);
     const lix = await openLix({
       backend: createBetterSqlite3Backend({ path: absolutePath }),
     });
@@ -32,6 +34,7 @@ export class Workspace {
   }
 
   static async create(absolutePath: string): Promise<Workspace> {
+    assertAbsolutePath(absolutePath);
     if (existsSync(absolutePath)) {
       throw new AcrmError(
         `.acrm file already exists at ${absolutePath}`,
@@ -44,4 +47,12 @@ export class Workspace {
   async close(): Promise<void> {
     await this.lix.close();
   }
+}
+
+function assertAbsolutePath(workspacePath: string): void {
+  if (isAbsolute(workspacePath)) return;
+  throw new AcrmError(
+    `workspace path must be absolute: ${workspacePath}`,
+    ERR.INVALID_INPUT,
+  );
 }

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    testTimeout: 30_000,
+  },
+});


### PR DESCRIPTION
## Summary
- reject relative paths in `Workspace.open` and `Workspace.create` before Lix sees them
- add SDK Vitest coverage for relative-path rejection and absolute-path creation
- add a patch changeset for `@agent-crm/sdk`

## Tests
- `npm test`
- `npm run build`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce absolute paths in `Workspace.open` and `Workspace.create`
> Adds an `assertAbsolutePath` helper in [workspace.ts](https://github.com/cluster-software/agent-crm/pull/72/files#diff-5f9d0c12560923ae41e8555c4e585373cb99083c987f8b70f5eee2616c7bfae6) that throws `AcrmError(ERR.INVALID_INPUT)` when a relative path is provided. Both `Workspace.open` and `Workspace.create` now call this check before any other logic. Tests covering the new validation are added in [workspace.test.ts](https://github.com/cluster-software/agent-crm/pull/72/files#diff-824d5330379379c97cf5f78501913e2127a6b2c3ea977c3ce38146cfff3f09ab). Risk: callers passing relative paths will now receive an `AcrmError` instead of silently proceeding or failing with an unrelated error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99a3bbe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->