### PR TITLE
chore: add SDK lifecycle changeset

### DIFF
--- a/.changeset/clean-workspaces-walk.md
+++ b/.changeset/clean-workspaces-walk.md
@@ -1,0 +1,8 @@
+---
+"@agent-crm/sdk": minor
+"@agent-crm/cli": patch
+---
+
+Consolidate SDK workspace lifecycle around `Workspace.create()` and
+`Workspace.open()`, removing the functional lifecycle helpers from the public
+API. Update CLI initialization to use the canonical workspace API.


### PR DESCRIPTION
## Summary
- add a changeset for the merged SDK workspace lifecycle cleanup
- bump `@agent-crm/sdk` minor for the canonical API change
- bump `@agent-crm/cli` patch for the CLI update to the canonical workspace API

## Verification
- `npx changeset status`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add changeset for SDK lifecycle consolidation around `Workspace.create()` and `Workspace.open()`
> Adds a [changeset file](.changeset/clean-workspaces-walk.md) declaring a minor release for `@agent-crm/sdk` and a patch release for `@agent-crm/cli`. The SDK consolidates workspace lifecycle management around `Workspace.create()` and `Workspace.open()`, and the CLI is updated to use this canonical workspace API.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4e0255d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->