### PR TITLE
fix(cli): remove non-existent attribute_type column from enrich-x-bio skill

### DIFF
--- a/.changeset/fix-enrich-x-bio-schema.md
+++ b/.changeset/fix-enrich-x-bio-schema.md
@@ -1,0 +1,10 @@
+---
+"@agent-crm/cli": patch
+---
+
+Fix `enrich-x-bio` skill: the documented INSERT templates referenced a
+non-existent `attribute_type` column on `acrm_value`, so every enrichment
+write failed with `LIX_COLUMN_NOT_FOUND` on first execution. Remove the
+column (and its `'text'` / `'record-reference'` literals) from the three
+INSERTs and add a hint pointing to `SELECT * FROM <table> LIMIT 1` as the
+schema-inspection workaround now that `DESCRIBE` is unsupported.

--- a/packages/cli/skills/enrich-x-bio.md
+++ b/packages/cli/skills/enrich-x-bio.md
@@ -28,6 +28,8 @@ If a slug is not in `missing[]`, **don't write it** — it already has a value f
 
 Each write is one `acrm execute` call. Use `$1`, `$2` placeholders (not `?`) and `lix_uuid_v7()` for new IDs. **Important:** DataFusion has no `strftime` / `now()` returning ISO strings — generate the timestamp client-side and pass it as a literal parameter:
 
+> **Schema inspection:** `DESCRIBE <table>` is not supported. To inspect columns, run `acrm execute "SELECT * FROM <table> LIMIT 1"` and read the keys off the first row.
+
 ```sh
 NOW=$(node -e "console.log(new Date().toISOString())")
 ```
@@ -36,9 +38,9 @@ NOW=$(node -e "console.log(new Date().toISOString())")
 
 ```sh
 acrm execute "INSERT INTO acrm_value
-  (id, object_slug, record_id, attribute_slug, value_json, attribute_type,
+  (id, object_slug, record_id, attribute_slug, value_json,
    active_from, normalized_key, source, provenance_json)
-  VALUES (lix_uuid_v7(), 'people', \$1, 'job_title', \$2, 'text',
+  VALUES (lix_uuid_v7(), 'people', \$1, 'job_title', \$2,
           \$3, NULL, 'x-bio-enrichment', \$4)" \
   "[\"<person_record_id>\", \"{\\\"value\\\":\\\"<title>\\\"}\", \"$NOW\", \"{\\\"bio\\\":\\\"<bio>\\\",\\\"confidence\\\":\\\"high\\\"}\"]"
 ```
@@ -61,9 +63,9 @@ acrm execute "INSERT INTO acrm_value
    acrm execute "INSERT INTO acrm_record (object_slug, record_id) VALUES ('companies', \$1)" "[\"$COMPANY_ID\"]"
 
    acrm execute "INSERT INTO acrm_value
-     (id, object_slug, record_id, attribute_slug, value_json, attribute_type,
+     (id, object_slug, record_id, attribute_slug, value_json,
       active_from, normalized_key, source, provenance_json)
-     VALUES (lix_uuid_v7(), 'companies', \$1, 'name', \$2, 'text',
+     VALUES (lix_uuid_v7(), 'companies', \$1, 'name', \$2,
              \$3, \$4, 'x-bio-enrichment', \$5)" \
      "[\"$COMPANY_ID\", \"{\\\"value\\\":\\\"<Company>\\\"}\", \"$NOW\", \"<Company>\", \"{\\\"bio\\\":\\\"<bio>\\\"}\"]"
    ```
@@ -71,9 +73,9 @@ acrm execute "INSERT INTO acrm_value
 3. Link the person to the company:
    ```sh
    acrm execute "INSERT INTO acrm_value
-     (id, object_slug, record_id, attribute_slug, value_json, attribute_type,
+     (id, object_slug, record_id, attribute_slug, value_json,
       active_from, normalized_key, ref_object, ref_record_id, source, provenance_json)
-     VALUES (lix_uuid_v7(), 'people', \$1, 'company', \$2, 'record-reference',
+     VALUES (lix_uuid_v7(), 'people', \$1, 'company', \$2,
              \$3, NULL, 'companies', \$4, 'x-bio-enrichment', \$5)" \
      "[\"<person_record_id>\", \"{\\\"target_object\\\":\\\"companies\\\",\\\"target_record_id\\\":\\\"$COMPANY_ID\\\"}\", \"$NOW\", \"$COMPANY_ID\", \"{\\\"bio\\\":\\\"<bio>\\\"}\"]"
    ```


### PR DESCRIPTION
## Summary

- The `enrich-x-bio` skill's three INSERT templates referenced an `attribute_type` column on `acrm_value` that doesn't exist in the current schema, so every enrichment write failed with `LIX_COLUMN_NOT_FOUND` on first run.
- Removed the `attribute_type` column (and its `'text'` / `'record-reference'` literals) from all three INSERTs in `packages/cli/skills/enrich-x-bio.md`.
- Added a callout noting that `DESCRIBE` is unsupported and pointing to `SELECT * FROM <table> LIMIT 1` as the schema-inspection workaround.
- Verified the rest of the repo: no other skills, docs, or SQL templates contain the same bug. `acrm-query.md` already documents that `attribute_type` lives on `acrm_attribute`, and SDK/CLI internals JOIN to `acrm_attribute` correctly.

## Test plan

- [ ] `acrm import x <handle>` returning `needs_enrichment` followed by the documented job_title INSERT succeeds with `rows_affected: 1`.
- [ ] Company create + person→company link INSERTs from the skill succeed end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove non-existent `attribute_type` column from `enrich-x-bio` INSERT templates
> Three SQL INSERT statements in [enrich-x-bio.md](https://github.com/cluster-software/agent-crm/pull/80/files#diff-fd642fd024709037f4c1ff255733c88610cde61a615bdf69d467bf7c211870fa) referenced an `attribute_type` column that does not exist in the target table, causing inserts to fail. The column and its corresponding literal values (`'text'` and `'record-reference'`) are removed from all three templates. Also adds a note that `DESCRIBE` is unsupported and `SELECT * FROM <table> LIMIT 1` should be used for schema inspection instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e877e34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->