### PR TITLE
fix(cli): add repository, homepage, and bugs to package.json

### DIFF
--- a/.changeset/cli-repo-metadata.md
+++ b/.changeset/cli-repo-metadata.md
@@ -1,0 +1,5 @@
+---
+"@agent-crm/cli": patch
+---
+
+Add `homepage`, `repository`, and `bugs` fields to `package.json` so the npm page links back to the GitHub repo and tooling like `npm bugs` works.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,6 +2,15 @@
   "name": "@agent-crm/cli",
   "version": "0.14.0",
   "description": "The headless CRM for Claude",
+  "homepage": "https://github.com/cluster-software/agent-crm#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cluster-software/agent-crm.git",
+    "directory": "packages/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/cluster-software/agent-crm/issues"
+  },
   "type": "module",
   "bin": {
     "acrm": "dist/bin/acrm.js"


### PR DESCRIPTION
## Summary
- Adds `homepage`, `repository` (with `directory: "packages/cli"`), and `bugs` to `packages/cli/package.json` so the npm page links back to the GitHub repo and `npm bugs @agent-crm/cli` works.
- Includes a patch changeset.

Closes #85.

## Test plan
- [ ] `npm view @agent-crm/cli repository homepage bugs` returns the new fields after the next release.
- [ ] npm page shows GitHub + issue links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add repository, homepage, and bugs metadata to `@agent-crm/cli` package.json
> Adds `homepage`, `repository`, and `bugs.url` fields to [packages/cli/package.json](https://github.com/cluster-software/agent-crm/pull/86/files#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758) to provide standard npm package metadata.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08387d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->