### PR TITLE
feat(cli): phone numbers as first-class identifier for `acrm import csv`

### DIFF
--- a/.changeset/csv-import-phone-identifier.md
+++ b/.changeset/csv-import-phone-identifier.md
@@ -1,0 +1,31 @@
+---
+"@agent-crm/cli": minor
+"@agent-crm/sdk": minor
+---
+
+`acrm import csv` now treats phone numbers as a first-class person identifier.
+Address-book exports (macOS Contacts, Google Contacts, iCloud) that carry
+phone-only rows used to be silently dropped — fixes #84, where 931 of 1112
+contacts in one user's import never landed.
+
+- Recognized headers: `phone | mobile | cell | telephone | tel`, with
+  optional `_number` suffix, optional `_N` index, and optional `work_` /
+  `personal_` / `home_` / `mobile_` / `cell_` / `primary_` / `business_` /
+  `other_` prefix. Multiple numbers per column are split on `,` or `;`.
+- Dedup cascade is now: email → linkedin → twitter → **phone**. Phones are
+  parsed to E.164 via `libphonenumber-js`, so `(415) 555-1234`,
+  `1-415-555-1234`, and `+1 (415) 555-1234` all dedupe to `+14155551234`.
+- New `--default-country <iso>` flag on `acrm import csv` (defaults to
+  `US`) controls how locally-formatted numbers are parsed. Numbers that
+  already include a `+<dial-code>` prefix are parsed independent of the
+  default. Pass `--default-country=GB` (etc.) when importing contacts
+  from another locale.
+- New schema attribute `people.phone_numbers` (multivalued + unique,
+  type `phone-number`). New workspaces get it via `acrm init`; existing
+  `.acrm` files will pick it up the next time you create a new workspace.
+- The SDK gains a new `phone-number` `AttributeType`, a
+  `normalizePhoneNumber(input, defaultCountry?)` helper backed by
+  `libphonenumber-js/min`, and `phones` / `phone` fields on
+  `PersonIdentifiers`. `resolvePersonByIdentifiers` / `normalizeIdentifiers`
+  now accept `{ default_country }` so the cascade is shared between
+  `acrm import csv` and `acrm import transcript`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2058,6 +2058,12 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.2.tgz",
+      "integrity": "sha512-S3kmBrptp3yRTm83NUcHy9g1vbwiWMzI8WvY22+koBJ6zkRteLnedBL2VX0MIAGwx2yiyxX4J85pceZyQ6ffgg==",
+      "license": "MIT"
+    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
@@ -3541,10 +3547,10 @@
     },
     "packages/cli": {
       "name": "@agent-crm/cli",
-      "version": "0.12.0",
+      "version": "0.14.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@agent-crm/sdk": "0.0.0",
+        "@agent-crm/sdk": "0.3.0",
         "@lix-js/sdk": "0.6.0-preview.3",
         "better-sqlite3": "^12.9.0",
         "commander": "^12.1.0"
@@ -3558,10 +3564,11 @@
     },
     "packages/sdk": {
       "name": "@agent-crm/sdk",
-      "version": "0.0.0",
+      "version": "0.3.0",
       "dependencies": {
         "@lix-js/sdk": "0.6.0-preview.3",
-        "better-sqlite3": "^12.9.0"
+        "better-sqlite3": "^12.9.0",
+        "libphonenumber-js": "^1.13.2"
       },
       "engines": {
         "node": ">=20"

--- a/packages/cli/src/commands/import-csv.test.ts
+++ b/packages/cli/src/commands/import-csv.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import type { Lix } from "@lix-js/sdk";
+import { openTestWorkspace } from "../test/open-test-lix.js";
+import { exec, importCsv, Workspace } from "@agent-crm/sdk";
+
+async function rowsForAttribute(
+  lix: Lix,
+  attribute_slug: string,
+): Promise<Array<{ record_id: string; normalized_key: string | null }>> {
+  const r = await exec(
+    lix,
+    `SELECT record_id, normalized_key FROM acrm_value
+     WHERE object_slug = 'people' AND attribute_slug = $1
+       AND active_until IS NULL
+     ORDER BY normalized_key`,
+    [attribute_slug],
+  );
+  return r.rows.map((row) => ({
+    record_id: row.record_id as string,
+    normalized_key: (row.normalized_key as string | null) ?? null,
+  }));
+}
+
+describe("importCsv phone identifier", () => {
+  it("creates a person from a row with only name + phone (no email/linkedin/twitter)", async () => {
+    const lix = await openTestWorkspace();
+    const csv = "name,phone\nAlice Phoneonly,+1 (415) 555-1234\n";
+    const result = await importCsv(Workspace.fromLix(lix), {
+      csvText: csv,
+      source: "csv:test",
+      default_country: "US",
+    });
+    expect(result.stats.people_created).toBe(1);
+    expect(result.stats.people_skipped_no_identifier).toBe(0);
+    const phones = await rowsForAttribute(lix, "phone_numbers");
+    expect(phones).toHaveLength(1);
+    expect(phones[0]?.normalized_key).toBe("+14155551234");
+    await lix.close();
+  });
+
+  it("dedupes locally-formatted and +-prefixed phones under default_country=US", async () => {
+    const lix = await openTestWorkspace();
+    const csv =
+      "name,phone\nAlice One,+1 (415) 555-1234\nAlice Two,(415) 555-1234\nAlice Three,1-415-555-1234\n";
+    const result = await importCsv(Workspace.fromLix(lix), {
+      csvText: csv,
+      source: "csv:test",
+      default_country: "US",
+    });
+    expect(result.stats.people_created).toBe(1);
+    const phones = await rowsForAttribute(lix, "phone_numbers");
+    expect(phones).toHaveLength(1);
+    expect(phones[0]?.normalized_key).toBe("+14155551234");
+    await lix.close();
+  });
+
+  it("parses +-prefixed non-US numbers independent of default_country", async () => {
+    const lix = await openTestWorkspace();
+    const csv = "name,phone\nLondon Lou,+44 20 7946 0958\n";
+    const result = await importCsv(Workspace.fromLix(lix), {
+      csvText: csv,
+      source: "csv:test",
+      default_country: "US",
+    });
+    expect(result.stats.people_created).toBe(1);
+    const phones = await rowsForAttribute(lix, "phone_numbers");
+    expect(phones[0]?.normalized_key).toBe("+442079460958");
+    await lix.close();
+  });
+
+  it("recognizes work_phone[_N] and personal_phone columns and splits comma-separated values", async () => {
+    const lix = await openTestWorkspace();
+    const csv =
+      "name,work_phone_1,personal_phone\nMulti Phone,+1 415 555 1111; +1 415 555 2222,(212) 555-3333\n";
+    const result = await importCsv(Workspace.fromLix(lix), {
+      csvText: csv,
+      source: "csv:test",
+      default_country: "US",
+    });
+    expect(result.stats.people_created).toBe(1);
+    const phones = await rowsForAttribute(lix, "phone_numbers");
+    expect(phones.map((p) => p.normalized_key).sort()).toEqual([
+      "+14155551111",
+      "+14155552222",
+      "+12125553333",
+    ].sort());
+    await lix.close();
+  });
+
+  it("prefers email over phone for dedup when both match different people", async () => {
+    const lix = await openTestWorkspace();
+    const seed1 = "name,email\nEmail Person,alice@acme.com\n";
+    const seed2 = "name,phone\nPhone Person,(415) 555-1234\n";
+    await importCsv(Workspace.fromLix(lix), {
+      csvText: seed1,
+      source: "csv:t",
+      default_country: "US",
+    });
+    await importCsv(Workspace.fromLix(lix), {
+      csvText: seed2,
+      source: "csv:t",
+      default_country: "US",
+    });
+
+    // A row carrying both — email should win the cascade.
+    const csv = "name,email,phone\nAlice,alice@acme.com,(415) 555-1234\n";
+    const result = await importCsv(Workspace.fromLix(lix), {
+      csvText: csv,
+      source: "csv:test",
+      default_country: "US",
+    });
+    expect(result.stats.people_created).toBe(0);
+    await lix.close();
+  });
+});

--- a/packages/cli/src/commands/import.ts
+++ b/packages/cli/src/commands/import.ts
@@ -28,7 +28,12 @@ export function registerImport(program: Command): void {
   importCmd
     .command("csv <path>")
     .description(
-      "import a CSV. Creates one person per email, LinkedIn URL, or Twitter/X URL, and one company per domain. Creates a deal only when the CSV has a 'deal_name' or 'deal' column — leads alone do not become deals.",
+      "import a CSV. Creates one person per email, LinkedIn URL, Twitter/X URL, or phone number, and one company per domain. Creates a deal only when the CSV has a 'deal_name' or 'deal' column — leads alone do not become deals.",
+    )
+    .option(
+      "--default-country <iso>",
+      "ISO country code (e.g. US, GB, DE) used to parse locally-formatted phone numbers into E.164. Numbers that already include '+<dial-code>' are unaffected.",
+      "US",
     )
     .addHelpText(
       "after",
@@ -45,6 +50,10 @@ Recognized columns (header is trim+lowercase only — use snake_case, not "Compa
                  (or any column whose values are linkedin.com URLs)
              twitter_url | twitter | x_url | x
                  (or any column whose values are x.com / twitter.com URLs)
+             phone | mobile | cell | telephone | tel | phone_number
+             work_phone[_N] | personal_phone[_N] | home_phone | mobile_number
+                 (comma/semicolon-separated; parsed to E.164 using
+                 --default-country if no '+' prefix is present)
 
   Company    company | company_name | organization
              domain | website | company_domain
@@ -60,15 +69,20 @@ Identity:
     When a row has a company name but no domain/email, the company is
     deduplicated by case-insensitive name instead.
   - people are deduplicated in priority order: lowercased email, then canonical
-    LinkedIn URL, then canonical Twitter/X URL. URLs are normalized by stripping
-    protocol/www/query/fragment/trailing-slash; twitter.com is unified to x.com;
-    bare handles ("@foo") are accepted for twitter and become "x.com/foo"
-  - rows with none of email/linkedin/twitter skip person creation
+    LinkedIn URL, then canonical Twitter/X URL, then E.164 phone number.
+    URLs are normalized by stripping protocol/www/query/fragment/trailing-slash;
+    twitter.com is unified to x.com; bare handles ("@foo") are accepted for
+    twitter and become "x.com/foo". Phone numbers are parsed via libphonenumber
+    using --default-country (defaults to US) — "(415) 555-1234" and
+    "+14155551234" dedupe to the same person. Numbers that already start with
+    "+" are parsed independent of the default country. Pass
+    --default-country=GB (etc.) when importing contacts from another locale.
+  - rows with none of email/linkedin/twitter/phone skip person creation
   - rows without a domain, email, or company name skip company creation
 `,
     )
     .action(
-      async (csvPath: string) => {
+      async (csvPath: string, options: { defaultCountry?: string }) => {
         const root = program.opts() as { json?: boolean; workspace?: string };
         setJsonMode(root.json);
         let ws: Workspace | null = null;
@@ -95,11 +109,13 @@ Identity:
           const result = await importCsv(ws, {
             csvText,
             source,
+            default_country: options.defaultCountry,
             onStart: ({ total, detected }) => {
               const personHints = [
                 ...detected.email_headers,
                 ...detected.linkedin_headers,
                 ...detected.twitter_headers,
+                ...detected.phone_headers,
                 ...(detected.linkedin_by_value ? ["<linkedin-by-value>"] : []),
                 ...(detected.twitter_by_value ? ["<twitter-by-value>"] : []),
               ];

--- a/packages/cli/src/domain/resolve-person.test.ts
+++ b/packages/cli/src/domain/resolve-person.test.ts
@@ -27,6 +27,7 @@ describe("normalizeIdentifiers", () => {
       emails: ["alice@example.com"],
       linkedin_url: null,
       twitter_url: null,
+      phones: [],
     });
   });
 
@@ -35,6 +36,7 @@ describe("normalizeIdentifiers", () => {
       emails: ["bob@acme.com"],
       linkedin_url: null,
       twitter_url: null,
+      phones: [],
     });
   });
 
@@ -48,6 +50,7 @@ describe("normalizeIdentifiers", () => {
       emails: ["shared@x.com", "other@x.com"],
       linkedin_url: null,
       twitter_url: null,
+      phones: [],
     });
   });
 
@@ -61,13 +64,88 @@ describe("normalizeIdentifiers", () => {
       emails: [],
       linkedin_url: "linkedin.com/in/foo",
       twitter_url: "x.com/bar",
+      phones: [],
     });
   });
 
   it("returns null for whitespace-only urls", () => {
     expect(
       normalizeIdentifiers({ linkedin_url: "   ", twitter_url: "   " }),
-    ).toEqual({ emails: [], linkedin_url: null, twitter_url: null });
+    ).toEqual({
+      emails: [],
+      linkedin_url: null,
+      twitter_url: null,
+      phones: [],
+    });
+  });
+
+  it("parses E.164 inputs and dedupes formatted duplicates", () => {
+    expect(
+      normalizeIdentifiers({
+        phones: ["+1 (415) 555-1234", "+14155551234", "  no digits  "],
+      }),
+    ).toEqual({
+      emails: [],
+      linkedin_url: null,
+      twitter_url: null,
+      phones: ["+14155551234"],
+    });
+  });
+
+  it("parses locally-formatted numbers when a default country is given", () => {
+    expect(
+      normalizeIdentifiers(
+        { phone: "(212) 555-9999" },
+        { default_country: "US" },
+      ),
+    ).toEqual({
+      emails: [],
+      linkedin_url: null,
+      twitter_url: null,
+      phones: ["+12125559999"],
+    });
+  });
+
+  it("dedupes local and +-prefixed forms under the same country", () => {
+    expect(
+      normalizeIdentifiers(
+        { phones: ["(415) 555-1234", "+1 415 555 1234", "1-415-555-1234"] },
+        { default_country: "US" },
+      ),
+    ).toEqual({
+      emails: [],
+      linkedin_url: null,
+      twitter_url: null,
+      phones: ["+14155551234"],
+    });
+  });
+
+  it("parses non-US numbers when +-prefixed regardless of default country", () => {
+    expect(
+      normalizeIdentifiers(
+        { phone: "+44 20 7946 0958" },
+        { default_country: "US" },
+      ),
+    ).toEqual({
+      emails: [],
+      linkedin_url: null,
+      twitter_url: null,
+      phones: ["+442079460958"],
+    });
+  });
+
+  it("drops phone candidates that have no digits", () => {
+    expect(
+      normalizeIdentifiers(
+        { phones: ["not a phone", "()", "   "] },
+        { default_country: "US" },
+      ),
+    ).toEqual({
+      emails: [],
+      linkedin_url: null,
+      twitter_url: null,
+      phones: [],
+    });
   });
 });
 
@@ -168,6 +246,68 @@ describe("resolvePersonByIdentifiers", () => {
     expect(calls.map((c) => c.key)).toEqual([
       "first@acme.com",
       "second@acme.com",
+    ]);
+  });
+
+  it("falls through to phone when email/linkedin/twitter miss", async () => {
+    const { fn, calls } = makeLookup({
+      phone_numbers: { "+14155551234": "person-4" },
+    });
+    const result = await resolvePersonByIdentifiers(
+      fn,
+      {
+        email: "ghost@nowhere.com",
+        linkedin_url: "linkedin.com/in/ghost",
+        twitter_url: "@ghost",
+        phone: "+1 (415) 555-1234",
+      },
+      { default_country: "US" },
+    );
+    expect(result.person_record_id).toBe("person-4");
+    expect(result.matched_by).toBe("phone_numbers");
+    expect(result.matched_key).toBe("+14155551234");
+    expect(result.tried).toEqual([
+      "email_addresses",
+      "linkedin_url",
+      "twitter_url",
+      "phone_numbers",
+    ]);
+    expect(calls.map((c) => c.attr)).toEqual([
+      "email_addresses",
+      "linkedin_url",
+      "twitter_url",
+      "phone_numbers",
+    ]);
+  });
+
+  it("resolves locally-formatted phones via default_country", async () => {
+    const { fn } = makeLookup({
+      phone_numbers: { "+12125559999": "person-5" },
+    });
+    const result = await resolvePersonByIdentifiers(
+      fn,
+      { phone: "(212) 555-9999" },
+      { default_country: "US" },
+    );
+    expect(result.person_record_id).toBe("person-5");
+    expect(result.matched_by).toBe("phone_numbers");
+    expect(result.tried).toEqual(["phone_numbers"]);
+  });
+
+  it("tries every phone before falling through", async () => {
+    const { fn, calls } = makeLookup({
+      phone_numbers: { "+12125559999": "person-6" },
+    });
+    const result = await resolvePersonByIdentifiers(
+      fn,
+      { phones: ["415-555-1234", "212-555-9999"] },
+      { default_country: "US" },
+    );
+    expect(result.person_record_id).toBe("person-6");
+    expect(result.matched_key).toBe("+12125559999");
+    expect(calls.map((c) => c.key)).toEqual([
+      "+14155551234",
+      "+12125559999",
     ]);
   });
 });

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -26,7 +26,8 @@
   },
   "dependencies": {
     "@lix-js/sdk": "0.6.0-preview.3",
-    "better-sqlite3": "^12.9.0"
+    "better-sqlite3": "^12.9.0",
+    "libphonenumber-js": "^1.13.2"
   },
   "engines": {
     "node": ">=20"

--- a/packages/sdk/src/domain/resolve-person.ts
+++ b/packages/sdk/src/domain/resolve-person.ts
@@ -1,21 +1,29 @@
-import { normalizeLinkedinUrl, normalizeTwitterUrl } from "./values.js";
+import {
+  normalizeLinkedinUrl,
+  normalizePhoneNumber,
+  normalizeTwitterUrl,
+} from "./values.js";
 
 export type PersonIdentifiers = {
   emails?: readonly string[];
   email?: string;
   linkedin_url?: string;
   twitter_url?: string;
+  phones?: readonly string[];
+  phone?: string;
 };
 
 export type IdentifierAttribute =
   | "email_addresses"
   | "linkedin_url"
-  | "twitter_url";
+  | "twitter_url"
+  | "phone_numbers";
 
 export type NormalizedIdentifiers = {
   emails: string[];
   linkedin_url: string | null;
   twitter_url: string | null;
+  phones: string[];
 };
 
 export type Lookup = (
@@ -32,26 +40,48 @@ export type ResolveResult = {
 };
 
 // Why this exists: both /post-call (transcript import) and `acrm import csv`
-// resolve people by the same priority — email → linkedin → twitter — but they
-// used to implement the cascade independently. The CSV path had all three; the
-// transcript path was email-only, so a meeting attendee whose record carried
-// only a LinkedIn URL would silently land in `unresolved`. Funnel both through
-// this so the next identifier added (phone, handle, …) lands in one place.
+// resolve people by the same priority — email → linkedin → twitter → phone —
+// but they used to implement the cascade independently. The CSV path had
+// email/linkedin/twitter; the transcript path was email-only, so a meeting
+// attendee whose record carried only a LinkedIn URL would silently land in
+// `unresolved`. Funnel both through this so the next identifier added (handle,
+// …) lands in one place.
+export type ResolveOptions = {
+  // ISO country code (e.g. "US") used to parse locally-formatted phone
+  // numbers into E.164. Without it, only numbers that already include a
+  // "+<dial-code>" prefix will dedupe correctly.
+  default_country?: string;
+};
+
 export function normalizeIdentifiers(
   ids: PersonIdentifiers,
+  opts: ResolveOptions = {},
 ): NormalizedIdentifiers {
-  const seen = new Set<string>();
+  const seenEmail = new Set<string>();
   const emails: string[] = [];
-  const candidates: string[] = [];
-  if (ids.email != null) candidates.push(ids.email);
-  if (ids.emails) for (const e of ids.emails) candidates.push(e);
-  for (const raw of candidates) {
+  const emailCandidates: string[] = [];
+  if (ids.email != null) emailCandidates.push(ids.email);
+  if (ids.emails) for (const e of ids.emails) emailCandidates.push(e);
+  for (const raw of emailCandidates) {
     if (typeof raw !== "string") continue;
     const s = raw.trim().toLowerCase();
     if (!s || !s.includes("@")) continue;
-    if (seen.has(s)) continue;
-    seen.add(s);
+    if (seenEmail.has(s)) continue;
+    seenEmail.add(s);
     emails.push(s);
+  }
+  const seenPhone = new Set<string>();
+  const phones: string[] = [];
+  const phoneCandidates: string[] = [];
+  if (ids.phone != null) phoneCandidates.push(ids.phone);
+  if (ids.phones) for (const p of ids.phones) phoneCandidates.push(p);
+  for (const raw of phoneCandidates) {
+    if (typeof raw !== "string") continue;
+    const n = normalizePhoneNumber(raw, opts.default_country);
+    if (!n) continue;
+    if (seenPhone.has(n)) continue;
+    seenPhone.add(n);
+    phones.push(n);
   }
   return {
     emails,
@@ -61,14 +91,16 @@ export function normalizeIdentifiers(
     twitter_url: ids.twitter_url
       ? normalizeTwitterUrl(ids.twitter_url)
       : null,
+    phones,
   };
 }
 
 export async function resolvePersonByIdentifiers(
   lookup: Lookup,
   ids: PersonIdentifiers,
+  opts: ResolveOptions = {},
 ): Promise<ResolveResult> {
-  const normalized = normalizeIdentifiers(ids);
+  const normalized = normalizeIdentifiers(ids, opts);
   const tried: IdentifierAttribute[] = [];
 
   if (normalized.emails.length) {
@@ -113,6 +145,23 @@ export async function resolvePersonByIdentifiers(
         normalized,
       };
     }
+  }
+
+  if (normalized.phones.length) {
+    for (const phone of normalized.phones) {
+      const hit = await lookup("phone_numbers", phone);
+      if (hit) {
+        if (!tried.includes("phone_numbers")) tried.push("phone_numbers");
+        return {
+          person_record_id: hit,
+          matched_by: "phone_numbers",
+          matched_key: phone,
+          tried,
+          normalized,
+        };
+      }
+    }
+    tried.push("phone_numbers");
   }
 
   return {

--- a/packages/sdk/src/domain/values.ts
+++ b/packages/sdk/src/domain/values.ts
@@ -1,9 +1,14 @@
+import {
+  parsePhoneNumberFromString,
+  type CountryCode,
+} from "libphonenumber-js/min";
 import { AcrmError, ERR } from "../lib/errors.js";
 
 export type AttributeType =
   | "text"
   | "personal-name"
   | "email-address"
+  | "phone-number"
   | "domain"
   | "url"
   | "number"
@@ -74,6 +79,13 @@ export function encode(
         email_local_specifier: local,
       };
     }
+    case "phone-number": {
+      const raw = String(input).trim();
+      const defaultCountry = config?.default_country as string | undefined;
+      const normalized = normalizePhoneNumber(raw, defaultCountry);
+      if (!normalized) throw new Error(`invalid phone number: ${raw}`);
+      return { phone_number: normalized, original_phone_number: raw };
+    }
     case "domain": {
       const d = normalizeDomain(String(input));
       return { domain: d, root_domain: rootDomain(d) };
@@ -127,6 +139,8 @@ export function normalizeUniqueKey(
   switch (type) {
     case "email-address":
       return (value.email_address as string | undefined)?.toLowerCase() ?? null;
+    case "phone-number":
+      return (value.phone_number as string | undefined) ?? null;
     case "domain":
       return (value.domain as string | undefined)?.toLowerCase() ?? null;
     case "url":
@@ -165,6 +179,33 @@ export function domainFromEmail(email: string): string | null {
   const at = email.indexOf("@");
   if (at < 0) return null;
   return email.slice(at + 1).toLowerCase();
+}
+
+// Parse to E.164 via libphonenumber-js. With `defaultCountry`, a local-format
+// number ("(415) 555-1234") resolves to E.164 ("+14155551234"); without it,
+// only numbers that already carry a "+<dial-code>" prefix parse cleanly. When
+// the parser can't make sense of the input we fall back to a digit-strip
+// (preserving a leading `+`) so short codes, extensions, and other oddities
+// still produce a stable dedup key instead of getting silently dropped.
+export function normalizePhoneNumber(
+  input: string,
+  defaultCountry?: string,
+): string | null {
+  const s = input.trim();
+  if (!s) return null;
+  const country = (defaultCountry?.toUpperCase() || undefined) as
+    | CountryCode
+    | undefined;
+  try {
+    const parsed = parsePhoneNumberFromString(s, country);
+    if (parsed?.number) return parsed.number;
+  } catch {
+    // libphonenumber-js can throw on malformed input — fall through.
+  }
+  const hasPlus = s.startsWith("+");
+  const digits = s.replace(/\D+/g, "");
+  if (!digits) return null;
+  return hasPlus ? `+${digits}` : digits;
 }
 
 export function normalizeLinkedinUrl(input: string): string | null {

--- a/packages/sdk/src/operations/import-csv.ts
+++ b/packages/sdk/src/operations/import-csv.ts
@@ -8,6 +8,7 @@ import {
   encode,
   normalizeUniqueKey,
   normalizeDomain,
+  normalizePhoneNumber,
   domainFromEmail,
   type AttributeConfig,
   type AttributeType,
@@ -330,6 +331,8 @@ const EMAIL_HEADER_RE = /^(?:(?:work|personal|primary|business|other)_)?email(?:
 const EMAIL_SPLIT_RE = /[,;]\s*/;
 const LINKEDIN_HEADER_RE = /^(?:linkedin(?:_url|_profile)?|li_url)$/;
 const TWITTER_HEADER_RE = /^(?:twitter(?:_url)?|x(?:_url)?)$/;
+const PHONE_HEADER_RE = /^(?:(?:work|personal|primary|business|other|home|mobile|cell)_)?(?:phone|mobile|cell|tel|telephone)(?:_number)?(?:_\d+)?$/;
+const PHONE_SPLIT_RE = /[,;]\s*/;
 
 function collectEmails(row: CsvRow): string[] {
   const seen = new Set<string>();
@@ -372,10 +375,31 @@ function findTwitter(row: CsvRow): string | null {
   return null;
 }
 
+function collectPhones(row: CsvRow, defaultCountry?: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const k of Object.keys(row)) {
+    if (!PHONE_HEADER_RE.test(k)) continue;
+    const raw = row[k];
+    if (!raw) continue;
+    for (const piece of raw.split(PHONE_SPLIT_RE)) {
+      const trimmed = piece.trim();
+      if (!trimmed) continue;
+      const norm = normalizePhoneNumber(trimmed, defaultCountry);
+      if (!norm) continue;
+      if (seen.has(norm)) continue;
+      seen.add(norm);
+      out.push(trimmed);
+    }
+  }
+  return out;
+}
+
 export type DetectedColumns = {
   email_headers: string[];
   linkedin_headers: string[];
   twitter_headers: string[];
+  phone_headers: string[];
   domain_headers: string[];
   company_name_headers: string[];
   linkedin_by_value: boolean;
@@ -387,6 +411,7 @@ function detectColumns(rows: CsvRow[]): DetectedColumns {
   const email_headers = headers.filter((h) => EMAIL_HEADER_RE.test(h));
   const linkedin_headers = headers.filter((h) => LINKEDIN_HEADER_RE.test(h));
   const twitter_headers = headers.filter((h) => TWITTER_HEADER_RE.test(h));
+  const phone_headers = headers.filter((h) => PHONE_HEADER_RE.test(h));
   const domain_headers = headers.filter((h) => (DOMAIN_HEADERS as readonly string[]).includes(h));
   const company_name_headers = headers.filter((h) => (COMPANY_NAME_HEADERS as readonly string[]).includes(h));
   const sample = rows.slice(0, 50);
@@ -400,6 +425,7 @@ function detectColumns(rows: CsvRow[]): DetectedColumns {
     email_headers,
     linkedin_headers,
     twitter_headers,
+    phone_headers,
     domain_headers,
     company_name_headers,
     linkedin_by_value,
@@ -417,6 +443,7 @@ function diagnoseEmptyImport(
     detected.email_headers.length > 0 ||
     detected.linkedin_headers.length > 0 ||
     detected.twitter_headers.length > 0 ||
+    detected.phone_headers.length > 0 ||
     detected.linkedin_by_value ||
     detected.twitter_by_value;
   const hasCompanyHeader =
@@ -425,7 +452,7 @@ function diagnoseEmptyImport(
     detected.company_name_headers.length > 0;
   if (!hasPersonHeader) {
     warnings.push(
-      `no person-identifier column found — people not created. Accepted: email | email_address | work_email[_N] | personal_email[_N] | primary_email[_N] | other_emails | linkedin_url | linkedin | twitter_url | x_url (or any column whose values are linkedin.com / x.com URLs).`,
+      `no person-identifier column found — people not created. Accepted: email | email_address | work_email[_N] | personal_email[_N] | primary_email[_N] | other_emails | linkedin_url | linkedin | twitter_url | x_url | phone | mobile | phone_number | work_phone[_N] | personal_phone[_N] (or any column whose values are linkedin.com / x.com URLs).`,
     );
   } else if (stats.people_created === 0 && stats.people_skipped_no_identifier === rows.length) {
     warnings.push(
@@ -433,6 +460,7 @@ function diagnoseEmptyImport(
         ...detected.email_headers,
         ...detected.linkedin_headers,
         ...detected.twitter_headers,
+        ...detected.phone_headers,
         ...(detected.linkedin_by_value ? ["<linkedin-by-value>"] : []),
         ...(detected.twitter_by_value ? ["<twitter-by-value>"] : []),
       ].join(", ")}) but every row had empty values for them — people not created.`,
@@ -459,11 +487,13 @@ async function importRow(
   source: string,
   rowIndex: number,
   stats: ImportCsvStats,
+  defaultCountry: string | undefined,
 ): Promise<void> {
   const provenance = { row: rowIndex };
 
   const emails = collectEmails(row);
   const primaryEmail = emails[0] ?? null;
+  const phones = collectPhones(row, defaultCountry);
   const composed = [pick(row, "first_name"), pick(row, "last_name")]
     .filter(Boolean)
     .join(" ")
@@ -551,11 +581,14 @@ async function importRow(
       emails,
       linkedin_url: linkedin ?? undefined,
       twitter_url: twitter ?? undefined,
+      phones,
     },
+    { default_country: defaultCountry },
   );
   const linkedinKey = personLookup.normalized.linkedin_url;
   const twitterKey = personLookup.normalized.twitter_url;
-  if (emails.length || linkedinKey || twitterKey) {
+  const phoneKeys = personLookup.normalized.phones;
+  if (emails.length || linkedinKey || twitterKey || phoneKeys.length) {
     personId = personLookup.person_record_id;
     let personIsFresh = false;
     if (!personId) {
@@ -574,6 +607,22 @@ async function importRow(
           isFresh: true,
         });
         cache.set(cacheKey("people", "email_addresses", e.trim().toLowerCase()), personId);
+      }
+      for (const p of phones) {
+        const normalized = normalizePhoneNumber(p, defaultCountry);
+        if (!normalized) continue;
+        await addMultiValue(lix, batcher, {
+          object_slug: "people",
+          record_id: personId,
+          attribute_slug: "phone_numbers",
+          attribute_type: "phone-number",
+          attribute_config: { default_country: defaultCountry },
+          value: p,
+          source,
+          provenance,
+          isFresh: true,
+        });
+        cache.set(cacheKey("people", "phone_numbers", normalized), personId);
       }
       if (linkedinKey) {
         await setSingleValue(lix, batcher, {
@@ -750,6 +799,11 @@ export type ImportCsvArgs = {
   // `csv:<basename>`).
   source: string;
 
+  // ISO country code (e.g. "US") used to parse locally-formatted phone
+  // numbers into E.164. Without it, "(415) 555-1234" stays as digits-only
+  // and won't dedupe against "+14155551234".
+  default_country?: string;
+
   // Optional progress callbacks. The SDK never writes to process.stderr —
   // these hooks let CLI consumers report progress in their own form.
   onStart?: (info: { total: number; detected: DetectedColumns }) => void;
@@ -765,11 +819,11 @@ export type ImportCsvResult = {
 };
 
 // Import a CSV string into the workspace. Creates one person per email /
-// LinkedIn URL / Twitter URL, one company per domain (or per name when no
-// domain is available), and one deal per row that has `deal_name` / `deal`.
-// All writes are batched into multi-row INSERTs and flushed adaptively
-// (once-at-end for small CSVs, every-N-rows for large CSVs) so file size
-// and memory stay bounded.
+// LinkedIn URL / Twitter URL / phone number, one company per domain (or per
+// name when no domain is available), and one deal per row that has
+// `deal_name` / `deal`. All writes are batched into multi-row INSERTs and
+// flushed adaptively (once-at-end for small CSVs, every-N-rows for large
+// CSVs) so file size and memory stay bounded.
 export async function importCsv(
   workspace: Workspace,
   args: ImportCsvArgs,
@@ -794,7 +848,16 @@ export async function importCsv(
       : Number.POSITIVE_INFINITY;
 
   for (let i = 0; i < rows.length; i++) {
-    await importRow(lix, batcher, cache, rows[i]!, args.source, i + 1, stats);
+    await importRow(
+      lix,
+      batcher,
+      cache,
+      rows[i]!,
+      args.source,
+      i + 1,
+      stats,
+      args.default_country,
+    );
     if ((i + 1) % flushEvery === 0) {
       await batcher.flush();
     }

--- a/packages/sdk/src/workspace/seeds.ts
+++ b/packages/sdk/src/workspace/seeds.ts
@@ -37,6 +37,7 @@ const ATTRIBUTES: AttributeSeed[] = [
   // people
   { object_slug: "people", attribute_slug: "name", title: "Name", attribute_type: "personal-name", is_multivalued: false, is_unique: false },
   { object_slug: "people", attribute_slug: "email_addresses", title: "Email addresses", attribute_type: "email-address", is_multivalued: true, is_unique: true },
+  { object_slug: "people", attribute_slug: "phone_numbers", title: "Phone numbers", attribute_type: "phone-number", is_multivalued: true, is_unique: true },
   { object_slug: "people", attribute_slug: "job_title", title: "Job title", attribute_type: "text", is_multivalued: false, is_unique: false },
   { object_slug: "people", attribute_slug: "linkedin_url", title: "LinkedIn", attribute_type: "url", is_multivalued: false, is_unique: false },
   { object_slug: "people", attribute_slug: "twitter_url", title: "Twitter / X", attribute_type: "url", is_multivalued: false, is_unique: false },


### PR DESCRIPTION
## Summary

Fixes #84 — `acrm import csv` used to silently skip rows that only had a phone number, dropping 84% of one user's macOS Contacts import. Phone is now the fourth identifier in the dedup cascade, parsed to E.164 via `libphonenumber-js`.

- **New columns recognized**: `phone | mobile | cell | telephone | tel`, with optional `_number` suffix, optional `_N` index, and the same `work_` / `personal_` / `home_` prefixes that already work for email. Multiple values per cell split on `,` or `;`.
- **Cascade**: email → linkedin → twitter → **phone** (phone last, per the issue's request).
- **`--default-country <iso>`** flag, defaulting to `US`, controls how locally-formatted numbers are parsed. `(415) 555-1234`, `1-415-555-1234`, and `+1 (415) 555-1234` all dedupe to `+14155551234`. `+44 20 7946 0958` parses correctly regardless of the default.
- **New schema attribute** `people.phone_numbers` (multivalued + unique, type `phone-number`). New workspaces seed it automatically; existing `.acrm` files pick it up at their next `acrm init`.
- **SDK surface**: new `phone-number` `AttributeType`, `normalizePhoneNumber(input, defaultCountry?)` helper backed by `libphonenumber-js/min` (~75 KB), and `phones` / `phone` fields on `PersonIdentifiers`. `resolvePersonByIdentifiers` / `normalizeIdentifiers` accept `{ default_country }` so the cascade is shared between `acrm import csv` and `acrm import transcript`.
- Adds `libphonenumber-js` as an SDK dependency.

## Test plan

- [x] `npm test` — 149 CLI tests + 5 SDK tests pass
- [x] New `import-csv.test.ts` covers: phone-only rows create people, local + E.164 dedup under default country, `+`-prefixed non-US numbers parse independently, `work_phone_N` / `personal_phone` multi-value splitting, email-wins-over-phone cascade
- [x] Extended `resolve-person.test.ts` with phone-cascade and country-code parsing cases
- [ ] Manual smoke: import a real macOS Contacts CSV with mixed phone formats and confirm dedup behaviour
- [ ] Manual smoke: `acrm import csv contacts.csv --default-country=GB` against a UK address book

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add phone numbers as first-class identifiers for `acrm import csv`
> - CSV import now recognizes phone-related column headers, splits multi-value cells, normalizes inputs to E.164 via `libphonenumber-js`, and deduplicates across rows.
> - Person resolution in [`resolve-person.ts`](https://github.com/cluster-software/agent-crm/pull/88/files#diff-6b260f816d27486f6618d4dea337ec8c5b16dc09a4954d24bbf4867a6331237f) extends the lookup cascade to try `phone_numbers` after email/LinkedIn/Twitter.
> - New `phone-number` attribute type added to [`values.ts`](https://github.com/cluster-software/agent-crm/pull/88/files#diff-034666d14509c4654b3827d57e70192b06566786d79c6e7936568304b0961db7) with encoding, unique-key normalization, and a digits-only fallback when E.164 parsing fails.
> - A `--default-country <iso>` CLI option (default `US`) is added to `acrm import csv` to drive local phone parsing.
> - New workspaces receive a unique multivalued `people.phone_numbers` seed attribute via [`seeds.ts`](https://github.com/cluster-software/agent-crm/pull/88/files#diff-e4ce857ac7ed9f022d6d03e8ee46e137426655be361db110ec330791dfe8ab77).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 527963a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->