### PR TITLE
fix(cli): add name frontmatter so Codex recognizes acrm skills

### DIFF
--- a/packages/cli/skills/acrm-query.md
+++ b/packages/cli/skills/acrm-query.md
@@ -1,4 +1,5 @@
 ---
+name: acrm-query
 description: Cheat-sheet for querying the .acrm workspace with `acrm execute`. Read this before writing any SQL against acrm. acrm uses an EAV schema — there is no `people` / `companies` / `transcripts` table.
 ---
 

--- a/packages/cli/skills/post-call.md
+++ b/packages/cli/skills/post-call.md
@@ -1,4 +1,5 @@
 ---
+name: post-call
 description: After a meeting, pull its transcript from whichever provider you have connected (Granola, manual paste/file, etc.) and import it into the .acrm workspace as a `transcripts` record linked to the attendees. Provider-agnostic.
 ---
 

--- a/packages/cli/skills/prep-call.md
+++ b/packages/cli/skills/prep-call.md
@@ -1,4 +1,5 @@
 ---
+name: prep-call
 description: Prep for a call with a person in your .acrm workspace. Pulls the person's record, their company, and any deals; fetches the LinkedIn profile (cached); produces a one-pager with discovery questions.
 ---
 

--- a/packages/cli/skills/setup-transcripts.md
+++ b/packages/cli/skills/setup-transcripts.md
@@ -1,4 +1,5 @@
 ---
+name: setup-transcripts
 description: Connect a meeting transcription provider (Granola, Otter, Fireflies, Fathom, Zoom export, manual paste, etc.) so /post-call can pull transcripts into the .acrm workspace. Provider-agnostic — pick which one to use, or connect more than one.
 ---
 


### PR DESCRIPTION
## Summary
Codex requires both `name` and `description` in SKILL.md frontmatter (per [OpenAI's docs](https://developers.openai.com/codex/skills) — their bundled skills follow this). Four of our nine bundled skills only had `description:`, so Codex silently skipped them at session start.

Added `name:` to:
- `acrm-query.md`
- `post-call.md`
- `prep-call.md`
- `setup-transcripts.md`

The other 5 already had `name:` and were working.

The skills-installer compares source hashes, so existing installs will re-sync on next `acrm skills install` / npm postinstall now that file contents changed.

Fixes #90

## Test plan
- [ ] `npm run build` succeeds
- [ ] `acrm skills install` re-installs the 4 changed skills (hash mismatch triggers update)
- [ ] In a fresh Codex session, the 4 previously-missing skills appear in the skill list

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `name` frontmatter to acrm skill files so Codex recognizes them
> Adds a `name` field to the YAML front matter of four skill markdown files ([acrm-query.md](https://github.com/cluster-software/agent-crm/pull/92/files#diff-edba32b0a9890db22290a97050af2f98a64bacfb307063cc60376f7984819910), [post-call.md](https://github.com/cluster-software/agent-crm/pull/92/files#diff-e37b6db417ebbfc7d2a203736a8f2e44b1208088ecfeb68a0291d2cead4bdb74), [prep-call.md](https://github.com/cluster-software/agent-crm/pull/92/files#diff-498fcc9db50cb0e43563d5e8aa2096ac4e1f74ff4be8beb50ed77d29786a9b16), [setup-transcripts.md](https://github.com/cluster-software/agent-crm/pull/92/files#diff-32784af4dc130ce80c5dc469aa7fd1c060e03cf8dd9376e0618ff6e07662a77a)) so Codex can identify and load these skills by name.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b1a4d15.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->