### PR TITLE
chore: add changeset for codex skill recognition fix

### DIFF
--- a/.changeset/fix-codex-skill-recognition.md
+++ b/.changeset/fix-codex-skill-recognition.md
@@ -1,0 +1,10 @@
+---
+"@agent-crm/cli": patch
+---
+
+Fix Codex skill recognition: four bundled skills (`acrm-query`, `post-call`,
+`prep-call`, `setup-transcripts`) were missing the `name:` field in their
+SKILL.md frontmatter. Codex requires both `name` and `description` and
+silently skipped these skills at session start. Add `name:` to all four —
+existing installs re-sync on next `acrm skills install` / npm postinstall
+because the source file hashes changed.


### PR DESCRIPTION
## Summary
Follow-up to #92, which merged before the changeset was added.

Adds a `patch` changeset for `@agent-crm/cli` so the Codex skill recognition fix gets a proper version bump and CHANGELOG entry.

## Test plan
- [ ] Changesets release workflow picks up the new file and proposes a version bump PR

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add changeset for `@agent-crm/cli` patch fixing missing skill `name` fields
> Adds a changeset file declaring a patch release for `@agent-crm/cli`. Four bundled skills were missing a `name` field; the fix updates these skills and triggers a resync on install.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d1649c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->