### PR TITLE
fix(cli): import-post SKILL.md valid YAML so Codex stops skipping it

### DIFF
--- a/.changeset/fix-import-post-yaml.md
+++ b/.changeset/fix-import-post-yaml.md
@@ -1,0 +1,8 @@
+---
+"@agent-crm/cli": patch
+---
+
+Fix `import-post` SKILL.md: the description contained `Phrasings:` mid-string,
+which YAML parses as a nested mapping key. Codex enforces YAML strictly and
+was skipping the skill with `mapping values are not allowed in this context`.
+Replace the colon with an em dash so the frontmatter parses everywhere.

--- a/packages/cli/skills/import-post.md
+++ b/packages/cli/skills/import-post.md
@@ -1,6 +1,6 @@
 ---
 name: import-post
-description: Import a LinkedIn or X post into the .acrm workspace by URL. Triggers when the user shares a LinkedIn post URL (linkedin.com/posts/..., linkedin.com/feed/update/urn:li:activity:...) or an X/Twitter status URL (x.com/<handle>/status/<id>, twitter.com/...) and wants to track the post or its author. Phrasings: "import this post", "save this LinkedIn post", "track this tweet", "add this person from their post", or just a bare post URL in chat.
+description: Import a LinkedIn or X post into the .acrm workspace by URL. Triggers when the user shares a LinkedIn post URL (linkedin.com/posts/..., linkedin.com/feed/update/urn:li:activity:...) or an X/Twitter status URL (x.com/<handle>/status/<id>, twitter.com/...) and wants to track the post or its author. Phrasings — "import this post", "save this LinkedIn post", "track this tweet", "add this person from their post", or just a bare post URL in chat.
 ---
 
 # import-post


### PR DESCRIPTION
## Summary
Codex was logging at every session start:

\`\`\`
⚠ /Users/.../.codex/skills/import-post/SKILL.md: invalid YAML: mapping values are not allowed in this context at line 2 column 321
\`\`\`

The description string contained \`Phrasings: "import this post"\` — YAML interprets \`: \` (colon-space) as a nested mapping key, which broke the frontmatter. Claude Code's parser is lenient and ignored it; Codex enforces YAML strictly.

Fix: replace the colon with an em dash (\`Phrasings —\`), matching the style of other skills. All 9 SKILL.md files now round-trip through `yaml.safe_load`.

## Test plan
- [x] `python3 -c "import yaml,re,glob; ..."` parses all 9 files without error
- [ ] On next session start, Codex no longer logs the warning
- [ ] \`import-post\` skill appears in Codex's skill list

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix invalid YAML in `import-post.md` frontmatter so Codex parses the skill
> Replaces a bare colon after `Phrasings` in the YAML frontmatter of [import-post.md](https://github.com/cluster-software/agent-crm/pull/95/files#diff-1460df5d368b3f2fbdc2ca222b0c8dd532dc6bb4048359ec1f7b45ba77dcaa72) with an em dash, which was causing YAML parsers to treat the value as a mapping key and skip the skill entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c319a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->