### PR TITLE
Add local multi-output signals

### DIFF
--- a/.changeset/local-multi-output-signals.md
+++ b/.changeset/local-multi-output-signals.md
@@ -1,0 +1,6 @@
+---
+"@agent-crm/sdk": patch
+"@agent-crm/cli": minor
+---
+
+Add local multi-output signals with CLI commands, import-time background runs, per-field provenance, and a hotel contact-path example.

--- a/examples/signals/hotel_contact_path.md
+++ b/examples/signals/hotel_contact_path.md
@@ -1,0 +1,81 @@
+---
+slug: hotel_contact_path
+title: Hotel Contact Path
+object: companies
+---
+
+```json acrm-signal
+{
+  "outputs": [
+    {
+      "key": "operator_status",
+      "attribute": "operator_status",
+      "title": "Operator status",
+      "type": "status",
+      "options": [
+        "owner_identified:Owner identified",
+        "operator_identified:Operator identified",
+        "property_contact_only:Property contact only",
+        "unclear:Unclear"
+      ]
+    },
+    {
+      "key": "operator_name",
+      "attribute": "operator_name",
+      "title": "Operator name",
+      "type": "text"
+    },
+    {
+      "key": "operator_role",
+      "attribute": "operator_role",
+      "title": "Operator role",
+      "type": "select",
+      "options": [
+        "owner:Owner",
+        "family_owner:Family owner",
+        "proprietor:Proprietor",
+        "general_manager:General manager",
+        "managing_director:Managing director",
+        "operating_entity:Operating entity",
+        "property_contact:Property contact",
+        "unclear:Unclear"
+      ]
+    },
+    {
+      "key": "outreach_path",
+      "attribute": "outreach_path",
+      "title": "Outreach path",
+      "type": "text"
+    }
+  ]
+}
+```
+
+Find a practical outreach path to a real hotelier or operator for this hotel.
+
+Prioritize non-LinkedIn public sources:
+
+1. The hotel's own imprint, legal notice, privacy policy, footer, team, press, or contact pages.
+2. Local press articles that name owners, proprietors, general managers, managing directors, or family operators.
+3. Tourism board, chamber of commerce, hospitality association, destination marketing, or awards pages.
+4. OTA/review pages only when they clearly name management or ownership.
+
+Classify `operator_status` as:
+
+- `owner_identified`: a person, family, or owning entity is identified.
+- `operator_identified`: an operating company, GM, managing director, proprietor, or manager is identified, but ownership is not clear.
+- `property_contact_only`: only a generic property channel is available.
+- `unclear`: evidence is too weak or conflicting.
+
+Classify `operator_role` as:
+
+- `owner`: a named individual owner is identified.
+- `family_owner`: a named family ownership/operator group is identified.
+- `proprietor`: a proprietor/innkeeper is identified.
+- `general_manager`: a GM or hotel manager is the best named operator contact.
+- `managing_director`: a managing director, Geschäftsführer, or equivalent officer is identified.
+- `operating_entity`: only an operating company/entity is identified.
+- `property_contact`: only a generic property contact route is available.
+- `unclear`: evidence is too weak or conflicting.
+
+For `outreach_path`, prefer a direct email or named contact route. If only a contact form or phone number is available, state that plainly. Include citations for each factual claim whenever possible.

--- a/examples/signals/hotel_contact_path.md
+++ b/examples/signals/hotel_contact_path.md
@@ -42,6 +42,12 @@ object: companies
       ]
     },
     {
+      "key": "handelsregisternummer",
+      "attribute": "handelsregisternummer",
+      "title": "Handelsregisternummer",
+      "type": "text"
+    },
+    {
       "key": "outreach_path",
       "attribute": "outreach_path",
       "title": "Outreach path",
@@ -78,4 +84,8 @@ Classify `operator_role` as:
 - `property_contact`: only a generic property contact route is available.
 - `unclear`: evidence is too weak or conflicting.
 
-For `outreach_path`, prefer a direct email or named contact route. If only a contact form or phone number is available, state that plainly. Include citations for each factual claim whenever possible.
+For `operator_name`, return exactly one name. Prefer a person over a family, and a family over an operating entity. If there are multiple plausible people, choose the best operator/contact and put the rest in reasoning, not in the field value.
+
+For `handelsregisternummer`, return only the registration number itself, such as `HRB 158326` or the local equivalent. Put registry jurisdiction, country, source context, and caveats in reasoning, not in the field value. Use `n/a` if no registration number is found.
+
+For `outreach_path`, return only one contact detail: an email address, phone number, contact form URL, or direct booking/contact URL. Do not include labels, explanation, names, addresses, or extra prose in the field value. Put context in reasoning instead. Include citations for each factual claim whenever possible.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3547,10 +3547,10 @@
     },
     "packages/cli": {
       "name": "@agent-crm/cli",
-      "version": "0.14.0",
+      "version": "0.15.1",
       "hasInstallScript": true,
       "dependencies": {
-        "@agent-crm/sdk": "0.3.0",
+        "@agent-crm/sdk": "0.4.0",
         "@lix-js/sdk": "0.6.0-preview.3",
         "better-sqlite3": "^12.9.0",
         "commander": "^12.1.0"
@@ -3564,7 +3564,7 @@
     },
     "packages/sdk": {
       "name": "@agent-crm/sdk",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@lix-js/sdk": "0.6.0-preview.3",
         "better-sqlite3": "^12.9.0",

--- a/packages/cli/skills/create-signals.md
+++ b/packages/cli/skills/create-signals.md
@@ -1,0 +1,92 @@
+---
+name: create-signals
+description: Create or edit Agent CRM local signal definitions. Use when the user wants a new signal, signal bundle, enrichment field, web-researched CRM column, or help testing `acrm signals list|sync|run`.
+---
+
+Agent CRM signals are local research tasks that fill normal CRM fields.
+
+## Create a signal
+
+1. Add a Markdown file at `<workspace-dir>/signals/<slug>.md`.
+2. Use frontmatter with `slug`, `title`, and `object`.
+3. Add one fenced `json acrm-signal` block declaring all outputs.
+4. Write the prompt instructions below the block.
+
+Template:
+
+```md
+---
+slug: hotel_contact_path
+title: Hotel Contact Path
+object: companies
+---
+
+\`\`\`json acrm-signal
+{
+  "outputs": [
+    {
+      "key": "operator_status",
+      "attribute": "operator_status",
+      "title": "Operator status",
+      "type": "status",
+      "options": [
+        "owner_identified:Owner identified",
+        "operator_identified:Operator identified",
+        "property_contact_only:Property contact only",
+        "unclear:Unclear"
+      ]
+    },
+    {
+      "key": "outreach_path",
+      "attribute": "outreach_path",
+      "title": "Outreach path",
+      "type": "text"
+    }
+  ]
+}
+\`\`\`
+
+Find the best public outreach path. Prioritize first-party pages, imprint/legal
+notice pages, contact pages, local press, associations, directories, and award
+pages. Cite every factual claim.
+```
+
+## Rules
+
+- Use one signal bundle for one research task, even when it fills multiple fields.
+- `object` must be `people` or `companies`.
+- Supported output types: `text`, `number`, `url`, `date`, `timestamp`, `status`, `select`.
+- Do not create booleans. Model yes/no as `status` or `select`.
+- Keep `attribute` slugs lowercase snake_case.
+- Do not target core fields such as company `name`, `domains`, `linkedin_url`, or person `name`, `email_addresses`, `company`.
+- Put user-visible rationale in each field's `reasoning`; never ask for hidden chain-of-thought.
+- Prompt for cited public evidence. The runner stores citations, confidence, reasoning, notes, and uncited status in `provenance_json`.
+
+## Test it
+
+From the workspace directory:
+
+```sh
+acrm signals list
+acrm signals sync
+acrm signals run --missing --signal <slug> --object companies --record-id <id> --concurrency 1
+```
+
+Imports run missing-only signals in the background unless the user passes
+`--no-signals`.
+
+To inspect results, query `acrm_value`:
+
+```sh
+acrm execute 'SELECT attribute_slug, value_json, source, provenance_json
+FROM acrm_value
+WHERE object_slug = $1
+  AND record_id = $2
+  AND source = $3
+  AND active_until IS NULL' \
+'["companies","<record_id>","signal:<slug>"]'
+```
+
+Signal definitions are local files in `signals/`; the definitions themselves
+are not stored in `.acrm`. Synced attributes and generated values are stored in
+`.acrm`.

--- a/packages/cli/src/bin/acrm.ts
+++ b/packages/cli/src/bin/acrm.ts
@@ -5,6 +5,7 @@ import { registerInit } from "../commands/init.js";
 import { registerExecute } from "../commands/execute.js";
 import { registerRecords } from "../commands/records.js";
 import { registerSchema } from "../commands/schema.js";
+import { registerSignals } from "../commands/signals.js";
 import { registerImport, getOrCreateImportCommand } from "../commands/import.js";
 import { attachLinkedinSubcommand } from "../commands/import-linkedin.js";
 import { attachXSubcommand } from "../commands/import-x.js";
@@ -116,6 +117,7 @@ attachTranscriptSubcommand(getOrCreateImportCommand(program));
 registerExecute(program);
 registerRecords(program);
 registerSchema(program);
+registerSignals(program);
 registerSkills(program);
 registerAuth(program);
 

--- a/packages/cli/src/commands/import-csv.test.ts
+++ b/packages/cli/src/commands/import-csv.test.ts
@@ -38,6 +38,46 @@ describe("importCsv phone identifier", () => {
     await lix.close();
   });
 
+  it("returns touched people and companies for post-import signal runs", async () => {
+    const lix = await openTestWorkspace();
+    const csv = "name,email,company,domain\nAlice Signal,alice@hotel.example,Hotel Signal,hotel.example\n";
+    const result = await importCsv(Workspace.fromLix(lix), {
+      csvText: csv,
+      source: "csv:test",
+      default_country: "US",
+    });
+    expect(result.touched_records.map((record) => record.object_slug).sort()).toEqual([
+      "companies",
+      "people",
+    ]);
+    await lix.close();
+  });
+
+  it("dedupes repeated company domains while importing rows concurrently", async () => {
+    const lix = await openTestWorkspace();
+    const csv =
+      "name,email,company,domain\n" +
+      Array.from(
+        { length: 20 },
+        (_, i) => `Hotel Person ${i},person${i}@hotel.example,Hotel Concurrent,hotel.example`,
+      ).join("\n") +
+      "\n";
+    const result = await importCsv(Workspace.fromLix(lix), {
+      csvText: csv,
+      source: "csv:test",
+      default_country: "US",
+      concurrency: 10,
+    });
+    expect(result.stats.companies_created).toBe(1);
+    expect(result.stats.people_created).toBe(20);
+    const companies = await exec(
+      lix,
+      "SELECT COUNT(*) AS n FROM acrm_record WHERE object_slug = 'companies'",
+    );
+    expect(companies.rows[0]?.n).toBe(1);
+    await lix.close();
+  });
+
   it("dedupes locally-formatted and +-prefixed phones under default_country=US", async () => {
     const lix = await openTestWorkspace();
     const csv =

--- a/packages/cli/src/commands/import-linkedin.ts
+++ b/packages/cli/src/commands/import-linkedin.ts
@@ -10,10 +10,12 @@ import {
 import { resolveWorkspacePath } from "../workspace-resolve.js";
 import { fail, ok, setJsonMode } from "../output/json.js";
 import { loadDotenv } from "../lib/dotenv.js";
+import { type BackgroundSignalRun, startMissingSignalsForRecords } from "../signals.js";
 
 type Opts = {
   refresh?: boolean;
   cache?: boolean; // commander negation: --no-cache → cache=false
+  signals?: boolean;
 };
 
 export function attachLinkedinSubcommand(parent: Command): void {
@@ -24,6 +26,7 @@ export function attachLinkedinSubcommand(parent: Command): void {
     )
     .option("--refresh", "bypass cache and re-fetch from Apify")
     .option("--no-cache", "do not write the response to cache")
+    .option("--no-signals", "skip local signals after importing records")
     .action(async (urlOrSlug: string, opts: Opts) => {
       const root = parent.parent?.opts() as
         | { workspace?: string; json?: boolean }
@@ -34,8 +37,12 @@ export function attachLinkedinSubcommand(parent: Command): void {
           workspace: root?.workspace,
           refresh: opts.refresh,
           noCache: opts.cache === false,
+          noSignals: opts.signals === false,
         });
-        const json: LinkedinImportResult = {
+        const json: LinkedinImportResult & {
+          signals_background?: BackgroundSignalRun;
+          signals_warning?: string;
+        } = {
           ...result,
           cache_path: result.cache_path
             ? path.relative(process.cwd(), result.cache_path)
@@ -52,8 +59,8 @@ export function attachLinkedinSubcommand(parent: Command): void {
 
 async function runImportLinkedin(
   urlOrSlug: string,
-  opts: { workspace?: string; refresh?: boolean; noCache?: boolean },
-): Promise<LinkedinImportResult> {
+  opts: { workspace?: string; refresh?: boolean; noCache?: boolean; noSignals?: boolean },
+): Promise<LinkedinImportResult & { signals_background?: BackgroundSignalRun; signals_warning?: string }> {
   const workspaceFile = resolveWorkspacePath(opts.workspace);
   const workspaceDir = path.dirname(workspaceFile);
   loadDotenv(workspaceDir);
@@ -71,16 +78,34 @@ async function runImportLinkedin(
 
   const cacheDir = path.join(workspaceDir, ".cache", "linkedin");
 
+  let result: LinkedinImportResult | null = null;
   const ws = await Workspace.open(workspaceFile);
+  let records: Array<{ object_slug: "people" | "companies"; record_id: string }> = [];
   try {
-    return await importLinkedinProfile(ws, {
+    result = await importLinkedinProfile(ws, {
       urlOrSlug,
       token,
       cacheDir,
       refresh: opts.refresh,
       noCache: opts.noCache,
     });
+    if (!opts.noSignals) {
+      records = [
+        { object_slug: "people" as const, record_id: result.person_record_id },
+        ...(result.company_record_id
+          ? [{ object_slug: "companies" as const, record_id: result.company_record_id }]
+          : []),
+      ];
+    }
   } finally {
     await ws.close();
   }
+  if (!result) throw new AcrmError("LinkedIn import did not return a result", ERR.UNHANDLED);
+  if (opts.noSignals) return result;
+  const signalRun = startMissingSignalsForRecords(workspaceFile, records);
+  return {
+    ...result,
+    ...(signalRun?.background ? { signals_background: signalRun.background } : {}),
+    ...(signalRun?.warning ? { signals_warning: signalRun.warning } : {}),
+  };
 }

--- a/packages/cli/src/commands/import-post.ts
+++ b/packages/cli/src/commands/import-post.ts
@@ -6,14 +6,17 @@ import {
   Workspace,
   importPost,
   normalizePostUrl,
+  type PostImportResult,
 } from "@agent-crm/sdk";
 import { resolveWorkspacePath } from "../workspace-resolve.js";
 import { fail, ok, setJsonMode } from "../output/json.js";
 import { loadDotenv } from "../lib/dotenv.js";
+import { type BackgroundSignalRun, startMissingSignalsForRecords } from "../signals.js";
 
 type Opts = {
   refresh?: boolean;
   cache?: boolean;
+  signals?: boolean;
 };
 
 export function attachPostSubcommand(parent: Command): void {
@@ -24,6 +27,7 @@ export function attachPostSubcommand(parent: Command): void {
     )
     .option("--refresh", "bypass cache and re-fetch from Apify")
     .option("--no-cache", "do not write the response to cache")
+    .option("--no-signals", "skip local signals after importing records")
     .addHelpText(
       "after",
       `
@@ -57,6 +61,7 @@ repeat runs free.
           workspace: root?.workspace,
           refresh: opts.refresh,
           noCache: opts.cache === false,
+          noSignals: opts.signals === false,
         });
         ok({
           ...result,
@@ -79,8 +84,8 @@ repeat runs free.
 
 async function runImportPost(
   rawUrl: string,
-  opts: { workspace?: string; refresh?: boolean; noCache?: boolean },
-) {
+  opts: { workspace?: string; refresh?: boolean; noCache?: boolean; noSignals?: boolean },
+): Promise<PostImportResult & { signals_background?: BackgroundSignalRun; signals_warning?: string }> {
   const sniffed = normalizePostUrl(rawUrl);
   if (!sniffed) {
     throw new AcrmError(
@@ -116,9 +121,11 @@ async function runImportPost(
     platform === "linkedin" ? "linkedin" : "x",
   );
 
+  let result: PostImportResult | null = null;
+  let records: Array<{ object_slug: "people" | "companies"; record_id: string }> = [];
   const ws = await Workspace.open(workspaceFile);
   try {
-    return await importPost(ws, {
+    result = await importPost(ws, {
       rawUrl,
       token,
       postCacheDir,
@@ -126,7 +133,23 @@ async function runImportPost(
       refresh: opts.refresh,
       noCache: opts.noCache,
     });
+    if (!opts.noSignals) {
+      records = [
+        { object_slug: "people" as const, record_id: result.person_record_id },
+        ...(result.company_record_id
+          ? [{ object_slug: "companies" as const, record_id: result.company_record_id }]
+          : []),
+      ];
+    }
   } finally {
     await ws.close();
   }
+  if (!result) throw new AcrmError("Post import did not return a result", ERR.UNHANDLED);
+  if (opts.noSignals) return result;
+  const signalRun = startMissingSignalsForRecords(workspaceFile, records);
+  return {
+    ...result,
+    ...(signalRun?.background ? { signals_background: signalRun.background } : {}),
+    ...(signalRun?.warning ? { signals_warning: signalRun.warning } : {}),
+  };
 }

--- a/packages/cli/src/commands/import-x.ts
+++ b/packages/cli/src/commands/import-x.ts
@@ -10,10 +10,12 @@ import {
 import { resolveWorkspacePath } from "../workspace-resolve.js";
 import { fail, ok, setJsonMode } from "../output/json.js";
 import { loadDotenv } from "../lib/dotenv.js";
+import { type BackgroundSignalRun, startMissingSignalsForRecords } from "../signals.js";
 
 type Opts = {
   refresh?: boolean;
   cache?: boolean;
+  signals?: boolean;
 };
 
 export function attachXSubcommand(parent: Command): void {
@@ -24,6 +26,7 @@ export function attachXSubcommand(parent: Command): void {
     )
     .option("--refresh", "bypass cache and re-fetch from Apify")
     .option("--no-cache", "do not write the response to cache")
+    .option("--no-signals", "skip local signals after importing records")
     .action(async (handleOrUrl: string, opts: Opts) => {
       const root = parent.parent?.opts() as
         | { workspace?: string; json?: boolean }
@@ -34,6 +37,7 @@ export function attachXSubcommand(parent: Command): void {
           workspace: root?.workspace,
           refresh: opts.refresh,
           noCache: opts.cache === false,
+          noSignals: opts.signals === false,
         });
         ok({
           ...result,
@@ -51,8 +55,8 @@ export function attachXSubcommand(parent: Command): void {
 
 async function runImportX(
   handleOrUrl: string,
-  opts: { workspace?: string; refresh?: boolean; noCache?: boolean },
-): Promise<XImportResult> {
+  opts: { workspace?: string; refresh?: boolean; noCache?: boolean; noSignals?: boolean },
+): Promise<XImportResult & { signals_background?: BackgroundSignalRun; signals_warning?: string }> {
   const workspaceFile = resolveWorkspacePath(opts.workspace);
   const workspaceDir = path.dirname(workspaceFile);
   loadDotenv(workspaceDir);
@@ -70,16 +74,29 @@ async function runImportX(
 
   const cacheDir = path.join(workspaceDir, ".cache", "x");
 
+  let result: XImportResult | null = null;
+  let records: Array<{ object_slug: "people"; record_id: string }> = [];
   const ws = await Workspace.open(workspaceFile);
   try {
-    return await importXProfile(ws, {
+    result = await importXProfile(ws, {
       handleOrUrl,
       token,
       cacheDir,
       refresh: opts.refresh,
       noCache: opts.noCache,
     });
+    if (!opts.noSignals) {
+      records = [{ object_slug: "people", record_id: result.person_record_id }];
+    }
   } finally {
     await ws.close();
   }
+  if (!result) throw new AcrmError("X import did not return a result", ERR.UNHANDLED);
+  if (opts.noSignals) return result;
+  const signalRun = startMissingSignalsForRecords(workspaceFile, records);
+  return {
+    ...result,
+    ...(signalRun?.background ? { signals_background: signalRun.background } : {}),
+    ...(signalRun?.warning ? { signals_warning: signalRun.warning } : {}),
+  };
 }

--- a/packages/cli/src/commands/import.ts
+++ b/packages/cli/src/commands/import.ts
@@ -9,6 +9,7 @@ import {
 } from "@agent-crm/sdk";
 import { resolveWorkspacePath } from "../workspace-resolve.js";
 import { fail, isJson, ok, setJsonMode } from "../output/json.js";
+import { startMissingSignalsForRecords } from "../signals.js";
 
 // Exposed so other import subcommands (e.g. `import linkedin`, `import x`)
 // can attach themselves to the same `import` parent without redefining it.
@@ -35,6 +36,7 @@ export function registerImport(program: Command): void {
       "ISO country code (e.g. US, GB, DE) used to parse locally-formatted phone numbers into E.164. Numbers that already include '+<dial-code>' are unaffected.",
       "US",
     )
+    .option("--no-signals", "skip local signals after importing records")
     .addHelpText(
       "after",
       `
@@ -82,7 +84,7 @@ Identity:
 `,
     )
     .action(
-      async (csvPath: string, options: { defaultCountry?: string }) => {
+      async (csvPath: string, options: { defaultCountry?: string; signals?: boolean }) => {
         const root = program.opts() as { json?: boolean; workspace?: string };
         setJsonMode(root.json);
         let ws: Workspace | null = null;
@@ -170,7 +172,29 @@ Identity:
           await ws.close();
           ws = null;
 
-          ok({ ...result.stats });
+          const signalRun =
+            options.signals === false
+              ? null
+              : startMissingSignalsForRecords(
+                  resolveWorkspacePath(root.workspace),
+                  result.touched_records,
+                );
+          if (signalRun?.warning && !isJson()) {
+            process.stderr.write(`warning: signals skipped: ${signalRun.warning}\n`);
+          }
+          if (signalRun?.background && !isJson()) {
+            for (const job of signalRun.background.jobs) {
+              process.stderr.write(
+                `signals running in background for ${job.object_slug} (${job.record_ids.length} records), log: ${job.log_path}\n`,
+              );
+            }
+          }
+
+          ok({
+            ...result.stats,
+            ...(signalRun?.background ? { signals_background: signalRun.background } : {}),
+            ...(signalRun?.warning ? { signals_warning: signalRun.warning } : {}),
+          });
         } catch (e) {
           if (ws) {
             try {

--- a/packages/cli/src/commands/signals.ts
+++ b/packages/cli/src/commands/signals.ts
@@ -107,6 +107,19 @@ export function registerSignals(program: Command): void {
     .option("--record-id <id>", "run against one record_id; repeatable", collect, [] as string[])
     .option("--limit <n>", "maximum record-signal runs")
     .option("--concurrency <n>", "number of runner processes at a time", "1")
+    .addHelpText(
+      "after",
+      `
+Environment:
+  SIGNAL_RUNS_MODEL       Claude model passed to the default signal runner (default: sonnet)
+  ACRM_SIGNAL_RUNNER      JSON string array override for the full runner command
+
+Default runner:
+  Uses claude -p with WebSearch and WebFetch. Bash is exposed only for commands
+  starting with agent-browser via Claude Code's allowed tool pattern:
+  Bash(agent-browser:*)
+`,
+    )
     .action(
       async (opts: {
         missing?: boolean;

--- a/packages/cli/src/commands/signals.ts
+++ b/packages/cli/src/commands/signals.ts
@@ -1,0 +1,170 @@
+import path from "node:path";
+import type { Command } from "commander";
+import {
+  AcrmError,
+  ERR,
+  Workspace,
+  ensureSignalAttributes,
+  finishSignalJob,
+  loadSignalDefinitions,
+  runSignals,
+  type SignalObjectSlug,
+} from "@agent-crm/sdk";
+import { fail, ok, setJsonMode } from "../output/json.js";
+import { signalsDirForWorkspace } from "../signals.js";
+import { resolveWorkspacePath } from "../workspace-resolve.js";
+
+function collect(value: string, previous: string[]): string[] {
+  return [...(previous ?? []), value];
+}
+
+function parseObject(value: string | undefined): SignalObjectSlug | undefined {
+  if (!value) return undefined;
+  if (value === "people" || value === "companies") return value;
+  throw new AcrmError(
+    `invalid --object: ${value} (expected people or companies)`,
+    ERR.INVALID_INPUT,
+  );
+}
+
+function parsePositiveInt(value: string | undefined, fallback?: number): number | undefined {
+  if (value === undefined) return fallback;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1) {
+    throw new AcrmError(`expected positive integer, got: ${value}`, ERR.INVALID_INPUT);
+  }
+  return n;
+}
+
+function handleError(e: unknown): never {
+  if (e instanceof AcrmError) fail(e.message, e.code, e.hint);
+  else fail(e instanceof Error ? e.message : String(e), ERR.UNHANDLED);
+  process.exit(1);
+}
+
+export function registerSignals(program: Command): void {
+  const signals = program
+    .command("signals")
+    .description(
+      "list, sync, and run local multi-output signal definitions from <workspace>/signals/*.md.",
+    );
+
+  signals
+    .command("list")
+    .description("list signal definitions for the current workspace")
+    .action(async () => {
+      const root = program.opts() as { json?: boolean; workspace?: string };
+      setJsonMode(root.json);
+      try {
+        const workspaceFile = resolveWorkspacePath(root.workspace);
+        const definitions = await loadSignalDefinitions(
+          signalsDirForWorkspace(workspaceFile),
+        );
+        ok({
+          count: definitions.length,
+          signals: definitions.map((definition) => ({
+            slug: definition.slug,
+            title: definition.title,
+            object_slug: definition.object_slug,
+            path: path.relative(process.cwd(), definition.path),
+            outputs: definition.outputs,
+          })),
+        });
+      } catch (e) {
+        handleError(e);
+      }
+    });
+
+  signals
+    .command("sync")
+    .description("create or update CRM attributes declared by signal outputs")
+    .action(async () => {
+      const root = program.opts() as { json?: boolean; workspace?: string };
+      setJsonMode(root.json);
+      let ws: Workspace | null = null;
+      try {
+        const workspaceFile = resolveWorkspacePath(root.workspace);
+        const definitions = await loadSignalDefinitions(
+          signalsDirForWorkspace(workspaceFile),
+        );
+        ws = await Workspace.open(workspaceFile);
+        const result = await ensureSignalAttributes(ws, definitions);
+        ok(result);
+      } catch (e) {
+        handleError(e);
+      } finally {
+        await ws?.close().catch(() => undefined);
+      }
+    });
+
+  signals
+    .command("run")
+    .description("run local signal bundles against people or companies")
+    .option("--missing", "fill only missing output fields (default)")
+    .option("--force", "refresh all output fields, even when current values exist")
+    .option("--signal <slug>", "run only a specific signal; repeatable", collect, [] as string[])
+    .option("--object <people|companies>", "restrict records by object")
+    .option("--record-id <id>", "run against one record_id; repeatable", collect, [] as string[])
+    .option("--limit <n>", "maximum record-signal runs")
+    .option("--concurrency <n>", "number of runner processes at a time", "1")
+    .action(
+      async (opts: {
+        missing?: boolean;
+        force?: boolean;
+        signal?: string[];
+        object?: string;
+        recordId?: string[];
+        limit?: string;
+        concurrency?: string;
+      }) => {
+        const root = program.opts() as { json?: boolean; workspace?: string };
+        setJsonMode(root.json);
+        let ws: Workspace | null = null;
+        let workspaceFile: string | undefined;
+        try {
+          const object_slug = parseObject(opts.object);
+          const record_ids = opts.recordId ?? [];
+          if (record_ids.length > 0 && !object_slug) {
+            throw new AcrmError(
+              "--object is required when --record-id is provided",
+              ERR.INVALID_INPUT,
+            );
+          }
+          workspaceFile = resolveWorkspacePath(root.workspace);
+          ws = await Workspace.open(workspaceFile);
+          const result = await runSignals(ws, {
+            signalsDir: signalsDirForWorkspace(workspaceFile),
+            mode: opts.force ? "force" : "missing",
+            signalSlugs: opts.signal?.length ? opts.signal : undefined,
+            object_slug,
+            record_ids: record_ids.length ? record_ids : undefined,
+            limit: parsePositiveInt(opts.limit),
+            concurrency: parsePositiveInt(opts.concurrency, 1),
+          });
+          await finishEnvSignalJob(workspaceFile, result.runs_failed > 0 ? "failed" : "succeeded");
+          ok(result);
+        } catch (e) {
+          if (workspaceFile) {
+            await finishEnvSignalJob(
+              workspaceFile,
+              "failed",
+              e instanceof Error ? e.message : String(e),
+            ).catch(() => undefined);
+          }
+          handleError(e);
+        } finally {
+          await ws?.close().catch(() => undefined);
+        }
+      },
+    );
+}
+
+async function finishEnvSignalJob(
+  workspaceFile: string,
+  status: "succeeded" | "failed",
+  error?: string,
+): Promise<void> {
+  const jobId = process.env.ACRM_SIGNAL_JOB_ID;
+  if (!jobId) return;
+  await finishSignalJob(workspaceFile, jobId, status, error).catch(() => undefined);
+}

--- a/packages/cli/src/signals.ts
+++ b/packages/cli/src/signals.ts
@@ -1,0 +1,173 @@
+import { spawn } from "node:child_process";
+import { closeSync, mkdirSync, openSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { writeSignalJobStateSync, type SignalObjectSlug, type SignalRecordRef } from "@agent-crm/sdk";
+
+export type ImportSignalResult =
+  | { background: BackgroundSignalRun; warning?: never }
+  | { background?: never; warning: string };
+
+export type BackgroundSignalRun = {
+  started: true;
+  jobs: BackgroundSignalJob[];
+};
+
+export type BackgroundSignalJob = {
+  object_slug: SignalObjectSlug;
+  record_ids: string[];
+  pid: number;
+  log_path: string;
+};
+
+const DEFAULT_BACKGROUND_SIGNAL_CONCURRENCY = 10;
+const MAX_IMPORT_SIGNAL_RECORDS = 1000;
+
+export function signalsDirForWorkspace(workspaceFile: string): string {
+  return path.join(path.dirname(workspaceFile), "signals");
+}
+
+export function startMissingSignalsForRecords(
+  workspaceFile: string,
+  records: SignalRecordRef[],
+): ImportSignalResult | null {
+  if (records.length === 0) return null;
+  if (!hasSignalFiles(signalsDirForWorkspace(workspaceFile))) return null;
+  try {
+    const jobs = startBackgroundJobs(workspaceFile, capImportSignalRecords(records));
+    if (jobs.length === 0) return null;
+    return { background: { started: true, jobs } };
+  } catch (e) {
+    return {
+      warning: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+function capImportSignalRecords(records: SignalRecordRef[]): SignalRecordRef[] {
+  // TODO: use a job manifest file so import-time signals can scale beyond
+  // 1,000 touched records without huge argv payloads or long local runs.
+  return uniqueSignalRecords(records).slice(0, MAX_IMPORT_SIGNAL_RECORDS);
+}
+
+function uniqueSignalRecords(records: SignalRecordRef[]): SignalRecordRef[] {
+  const seen = new Set<string>();
+  const out: SignalRecordRef[] = [];
+  for (const record of records) {
+    const key = `${record.object_slug}:${record.record_id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(record);
+  }
+  return out;
+}
+
+function hasSignalFiles(signalsDir: string): boolean {
+  try {
+    return readdirSync(signalsDir).some((name) => name.endsWith(".md"));
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw e;
+  }
+}
+
+function startBackgroundJobs(
+  workspaceFile: string,
+  records: SignalRecordRef[],
+): BackgroundSignalJob[] {
+  const grouped = groupRecordIds(records);
+  const jobs: BackgroundSignalJob[] = [];
+  for (const [object_slug, record_ids] of grouped) {
+    const jobId = `import-${object_slug}-${Date.now()}`;
+    const log_path = createLogPath(workspaceFile, jobId);
+    const fd = openSync(log_path, "a");
+    try {
+      const child = spawn(process.execPath, signalRunArgs(workspaceFile, object_slug, record_ids), {
+        cwd: path.dirname(workspaceFile),
+        detached: true,
+        env: {
+          ...process.env,
+          ACRM_SIGNAL_JOB_ID: jobId,
+          ACRM_SIGNAL_LOG_PATH: log_path,
+        },
+        shell: false,
+        stdio: ["ignore", fd, fd],
+      });
+      child.unref();
+      const now = new Date().toISOString();
+      writeSignalJobStateSync(workspaceFile, {
+        id: jobId,
+        status: "running",
+        source: "cli",
+        object_slug,
+        record_ids,
+        signalSlugs: [],
+        log_path,
+        started_at: now,
+        updated_at: now,
+        pid: child.pid ?? 0,
+      });
+      jobs.push({
+        object_slug,
+        record_ids,
+        pid: child.pid ?? 0,
+        log_path,
+      });
+    } finally {
+      closeSync(fd);
+    }
+  }
+  return jobs;
+}
+
+function groupRecordIds(records: SignalRecordRef[]): Map<SignalObjectSlug, string[]> {
+  const grouped = new Map<SignalObjectSlug, string[]>();
+  const seen = new Set<string>();
+  for (const record of records) {
+    const key = `${record.object_slug}:${record.record_id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const current = grouped.get(record.object_slug) ?? [];
+    current.push(record.record_id);
+    grouped.set(record.object_slug, current);
+  }
+  return grouped;
+}
+
+function signalRunArgs(
+  workspaceFile: string,
+  object_slug: SignalObjectSlug,
+  record_ids: string[],
+): string[] {
+  const entrypoint = process.argv[1];
+  if (!entrypoint) {
+    throw new Error("Could not find current acrm CLI entrypoint for background signals");
+  }
+  return [
+    entrypoint,
+    "-w",
+    workspaceFile,
+    "--json",
+    "signals",
+    "run",
+    "--missing",
+    "--object",
+    object_slug,
+    "--concurrency",
+    String(backgroundSignalConcurrency()),
+    ...record_ids.flatMap((record_id) => ["--record-id", record_id]),
+  ];
+}
+
+function backgroundSignalConcurrency(): number {
+  const raw = process.env.ACRM_SIGNAL_CONCURRENCY;
+  if (!raw) return DEFAULT_BACKGROUND_SIGNAL_CONCURRENCY;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) return DEFAULT_BACKGROUND_SIGNAL_CONCURRENCY;
+  return value;
+}
+
+function createLogPath(workspaceFile: string, jobId: string): string {
+  const dir = path.join(path.dirname(workspaceFile), ".cache", "signals");
+  mkdirSync(dir, { recursive: true });
+  return path.join(dir, `${jobId}.log`);
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -40,3 +40,5 @@ export * from "./operations/import-transcript.js";
 export * from "./operations/import-x.js";
 export * from "./operations/records.js";
 export * from "./operations/schema.js";
+export * from "./operations/signal-jobs.js";
+export * from "./operations/signals.js";

--- a/packages/sdk/src/operations/import-csv.ts
+++ b/packages/sdk/src/operations/import-csv.ts
@@ -13,7 +13,10 @@ import {
   type AttributeConfig,
   type AttributeType,
 } from "../domain/values.js";
-import { resolvePersonByIdentifiers } from "../domain/resolve-person.js";
+import {
+  normalizeIdentifiers,
+  resolvePersonByIdentifiers,
+} from "../domain/resolve-person.js";
 import { generateUuid } from "../lib/ids.js";
 import { nowIso } from "../lib/time.js";
 import { loadAttribute } from "../workspace/catalog.js";
@@ -21,6 +24,9 @@ import type { Workspace } from "../workspace.js";
 
 type CsvRow = Record<string, string>;
 type LookupCache = Map<string, string>;
+
+const DEFAULT_IMPORT_CONCURRENCY = 10;
+const IMPORT_CONCURRENCY_ENV = "ACRM_IMPORT_CONCURRENCY";
 
 function parseCsv(text: string): CsvRow[] {
   const rows: string[][] = [];
@@ -168,21 +174,26 @@ class WriteBatcher {
   private records: PendingRecord[] = [];
   private values: PendingValue[] = [];
   private enqueuedMulti = new Set<string>();
+  private mutex = new AsyncMutex();
 
   constructor(private lix: Lix) {}
 
-  enqueueRecord(r: PendingRecord) {
-    this.records.push(r);
+  async enqueueRecord(r: PendingRecord): Promise<void> {
+    await this.mutex.runExclusive(() => {
+      this.records.push(r);
+    });
   }
 
-  enqueueValue(v: PendingValue): boolean {
-    if (v.normalized_key) {
-      const k = `${v.record_id}\x00${v.attribute_slug}\x00${v.normalized_key}`;
-      if (this.enqueuedMulti.has(k)) return false;
-      this.enqueuedMulti.add(k);
-    }
-    this.values.push(v);
-    return true;
+  async enqueueValue(v: PendingValue): Promise<boolean> {
+    return await this.mutex.runExclusive(() => {
+      if (v.normalized_key) {
+        const k = `${v.record_id}\x00${v.attribute_slug}\x00${v.normalized_key}`;
+        if (this.enqueuedMulti.has(k)) return false;
+        this.enqueuedMulti.add(k);
+      }
+      this.values.push(v);
+      return true;
+    });
   }
 
   get size(): number {
@@ -190,9 +201,11 @@ class WriteBatcher {
   }
 
   async flush(): Promise<void> {
-    if (this.records.length) await this.flushRecords();
-    if (this.values.length) await this.flushValues();
-    this.enqueuedMulti.clear();
+    await this.mutex.runExclusive(async () => {
+      if (this.records.length) await this.flushRecords();
+      if (this.values.length) await this.flushValues();
+      this.enqueuedMulti.clear();
+    });
   }
 
   private async flushRecords(): Promise<void> {
@@ -246,12 +259,57 @@ class WriteBatcher {
   }
 }
 
+class AsyncMutex {
+  private current: Promise<void> = Promise.resolve();
+
+  async runExclusive<T>(fn: () => T | Promise<T>): Promise<T> {
+    let release!: () => void;
+    const previous = this.current;
+    this.current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
+  }
+}
+
+class KeyedLocks {
+  private locks = new Map<string, AsyncMutex>();
+
+  async runExclusive<T>(
+    keys: string[],
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    const unique = Array.from(new Set(keys)).sort();
+    let run = fn;
+    for (let i = unique.length - 1; i >= 0; i--) {
+      const key = unique[i]!;
+      const next = run;
+      run = () => this.lockFor(key).runExclusive(next);
+    }
+    return await run();
+  }
+
+  private lockFor(key: string): AsyncMutex {
+    let lock = this.locks.get(key);
+    if (!lock) {
+      lock = new AsyncMutex();
+      this.locks.set(key, lock);
+    }
+    return lock;
+  }
+}
+
 async function insertRecord(
   batcher: WriteBatcher,
   object_slug: string,
   record_id: string,
 ): Promise<void> {
-  batcher.enqueueRecord({ object_slug, record_id });
+  await batcher.enqueueRecord({ object_slug, record_id });
 }
 
 async function setSingleValue(
@@ -280,7 +338,7 @@ async function setSingleValue(
     );
   }
   const id = await generateUuid(lix);
-  batcher.enqueueValue(prepareValueInsert(id, { ...args, value_json }));
+  await batcher.enqueueValue(prepareValueInsert(id, { ...args, value_json }));
 }
 
 async function addMultiValue(
@@ -312,7 +370,7 @@ async function addMultiValue(
     if (exists.rows.length) return;
   }
   const id = await generateUuid(lix);
-  batcher.enqueueValue(prepareValueInsert(id, { ...args, value_json }));
+  await batcher.enqueueValue(prepareValueInsert(id, { ...args, value_json }));
 }
 
 export type ImportCsvStats = {
@@ -322,6 +380,11 @@ export type ImportCsvStats = {
   deals_created: number;
   people_skipped_no_identifier: number;
   warnings?: string[];
+};
+
+export type ImportCsvTouchedRecord = {
+  object_slug: "people" | "companies";
+  record_id: string;
 };
 
 const DOMAIN_HEADERS = ["domain", "website", "company_domain"] as const;
@@ -488,8 +551,9 @@ async function importRow(
   rowIndex: number,
   stats: ImportCsvStats,
   defaultCountry: string | undefined,
-): Promise<void> {
+): Promise<ImportCsvTouchedRecord[]> {
   const provenance = { row: rowIndex };
+  const touched: ImportCsvTouchedRecord[] = [];
 
   const emails = collectEmails(row);
   const primaryEmail = emails[0] ?? null;
@@ -571,6 +635,9 @@ async function importRow(
       cache.set(cacheKey("companies", "name__ci", companyName.trim().toLowerCase()), companyId);
       stats.companies_created++;
     }
+  }
+  if (companyId) {
+    touched.push({ object_slug: "companies", record_id: companyId });
   }
 
   // person
@@ -692,6 +759,9 @@ async function importRow(
   } else {
     stats.people_skipped_no_identifier++;
   }
+  if (personId) {
+    touched.push({ object_slug: "people", record_id: personId });
+  }
 
   // deal (optional)
   const dealName = pick(row, "deal_name", "deal");
@@ -790,6 +860,83 @@ async function importRow(
     }
     stats.deals_created++;
   }
+  return touched;
+}
+
+function rowLockKeys(
+  row: CsvRow,
+  defaultCountry: string | undefined,
+): string[] {
+  const keys: string[] = [];
+  const emails = collectEmails(row);
+  const primaryEmail = emails[0] ?? null;
+  const phones = collectPhones(row, defaultCountry);
+  const linkedin = findLinkedin(row);
+  const twitter = findTwitter(row);
+  const normalized = normalizeIdentifiers(
+    {
+      emails,
+      linkedin_url: linkedin ?? undefined,
+      twitter_url: twitter ?? undefined,
+      phones,
+    },
+    { default_country: defaultCountry },
+  );
+
+  for (const email of normalized.emails) keys.push(`people:email:${email}`);
+  if (normalized.linkedin_url) keys.push(`people:linkedin:${normalized.linkedin_url}`);
+  if (normalized.twitter_url) keys.push(`people:twitter:${normalized.twitter_url}`);
+  for (const phone of normalized.phones) keys.push(`people:phone:${phone}`);
+
+  const companyName = pick(row, "company", "company_name", "organization");
+  const domainRaw = pick(row, "domain", "website", "company_domain");
+  let companyDomain: string | null = null;
+  if (domainRaw) {
+    const norm = normalizeDomain(domainRaw);
+    if (looksLikeDomain(norm)) companyDomain = norm;
+  }
+  if (!companyDomain && primaryEmail) {
+    const fromEmail = domainFromEmail(primaryEmail);
+    if (fromEmail && looksLikeDomain(fromEmail)) companyDomain = fromEmail;
+  }
+  if (companyDomain) {
+    keys.push(`companies:domain:${companyDomain}`);
+  } else if (companyName) {
+    keys.push(`companies:name:${companyName.trim().toLowerCase()}`);
+  }
+  return keys;
+}
+
+function importConcurrency(args: ImportCsvArgs): number {
+  return normalizePositiveInt(
+    args.concurrency ?? process.env[IMPORT_CONCURRENCY_ENV],
+    DEFAULT_IMPORT_CONCURRENCY,
+  );
+}
+
+function normalizePositiveInt(value: unknown, fallback: number): number {
+  if (value === undefined || value === null || value === "") return fallback;
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 1) return fallback;
+  return Math.floor(n);
+}
+
+async function runWithConcurrency(
+  total: number,
+  concurrency: number,
+  worker: (index: number) => Promise<void>,
+): Promise<void> {
+  let next = 0;
+  const workers = Array.from(
+    { length: Math.min(Math.max(1, concurrency), Math.max(1, total)) },
+    async () => {
+      while (next < total) {
+        const index = next++;
+        await worker(index);
+      }
+    },
+  );
+  await Promise.all(workers);
 }
 
 export type ImportCsvArgs = {
@@ -810,12 +957,16 @@ export type ImportCsvArgs = {
   onProgress?: (info: { current: number; total: number; stats: ImportCsvStats }) => void;
   onBeforeFinalFlush?: (info: { pending_count: number }) => void;
   onAfterFinalFlush?: (info: { duration_ms: number }) => void;
+
+  // Defaults to 10. Can also be set with ACRM_IMPORT_CONCURRENCY.
+  concurrency?: number;
 };
 
 export type ImportCsvResult = {
   stats: ImportCsvStats;
   warnings: string[];
   pending_at_final_flush: number;
+  touched_records: ImportCsvTouchedRecord[];
 };
 
 // Import a CSV string into the workspace. Creates one person per email /
@@ -842,27 +993,40 @@ export async function importCsv(
   };
   const cache: LookupCache = new Map();
   const batcher = new WriteBatcher(lix);
+  const rowLocks = new KeyedLocks();
+  const touchedRecords = new Map<string, ImportCsvTouchedRecord>();
   const flushEvery =
     rows.length > LARGE_CSV_THRESHOLD
       ? LARGE_CSV_FLUSH_EVERY_ROWS
       : Number.POSITIVE_INFINITY;
+  const concurrency = importConcurrency(args);
+  let completed = 0;
 
-  for (let i = 0; i < rows.length; i++) {
-    await importRow(
-      lix,
-      batcher,
-      cache,
-      rows[i]!,
-      args.source,
-      i + 1,
-      stats,
-      args.default_country,
+  await runWithConcurrency(rows.length, concurrency, async (i) => {
+    const row = rows[i]!;
+    const touched = await rowLocks.runExclusive(
+      rowLockKeys(row, args.default_country),
+      () =>
+        importRow(
+          lix,
+          batcher,
+          cache,
+          row,
+          args.source,
+          i + 1,
+          stats,
+          args.default_country,
+        ),
     );
-    if ((i + 1) % flushEvery === 0) {
+    for (const record of touched) {
+      touchedRecords.set(`${record.object_slug}:${record.record_id}`, record);
+    }
+    completed++;
+    if (completed % flushEvery === 0) {
       await batcher.flush();
     }
-    args.onProgress?.({ current: i + 1, total: rows.length, stats });
-  }
+    args.onProgress?.({ current: completed, total: rows.length, stats });
+  });
 
   const pendingAtFlush = batcher.size;
   args.onBeforeFinalFlush?.({ pending_count: pendingAtFlush });
@@ -877,5 +1041,6 @@ export async function importCsv(
     stats,
     warnings,
     pending_at_final_flush: pendingAtFlush,
+    touched_records: Array.from(touchedRecords.values()),
   };
 }

--- a/packages/sdk/src/operations/signal-jobs.ts
+++ b/packages/sdk/src/operations/signal-jobs.ts
@@ -1,0 +1,143 @@
+import { mkdir, readdir, readFile, rename, writeFile } from "node:fs/promises";
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import type { SignalObjectSlug } from "./signals.js";
+
+export type SignalJobStatus = "running" | "succeeded" | "failed";
+
+export type SignalRunJobState = {
+  id: string;
+  status: SignalJobStatus;
+  source: "cli" | "app";
+  object_slug?: SignalObjectSlug;
+  record_ids: string[];
+  signalSlugs: string[];
+  log_path: string;
+  started_at: string;
+  updated_at: string;
+  completed_at?: string;
+  pid?: number;
+  error?: string;
+};
+
+export function signalJobsDirForWorkspace(workspaceFile: string): string {
+  return path.join(path.dirname(workspaceFile), ".cache", "signals", "jobs");
+}
+
+export async function writeSignalJobState(
+  workspaceFile: string,
+  job: SignalRunJobState,
+): Promise<void> {
+  const file = signalJobPath(workspaceFile, job.id);
+  await mkdir(path.dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.tmp`;
+  await writeFile(tmp, `${JSON.stringify(job, null, 2)}\n`, "utf8");
+  await rename(tmp, file);
+}
+
+export function writeSignalJobStateSync(
+  workspaceFile: string,
+  job: SignalRunJobState,
+): void {
+  const file = signalJobPath(workspaceFile, job.id);
+  mkdirSync(path.dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify(job, null, 2)}\n`, "utf8");
+  renameSync(tmp, file);
+}
+
+export async function finishSignalJob(
+  workspaceFile: string,
+  id: string,
+  status: Exclude<SignalJobStatus, "running">,
+  error?: string,
+): Promise<void> {
+  const existing = await readSignalJobState(workspaceFile, id);
+  if (!existing) return;
+  const now = new Date().toISOString();
+  await writeSignalJobState(workspaceFile, {
+    ...existing,
+    status,
+    updated_at: now,
+    completed_at: now,
+    ...(error ? { error } : {}),
+  });
+}
+
+export async function listRunningSignalJobs(workspaceFile: string): Promise<SignalRunJobState[]> {
+  const jobs = await listSignalJobStates(workspaceFile);
+  const running: SignalRunJobState[] = [];
+  for (const job of jobs) {
+    if (job.status !== "running") continue;
+    if (!isProcessAlive(job.pid)) {
+      await finishSignalJob(
+        workspaceFile,
+        job.id,
+        "failed",
+        "Signal job process is no longer running.",
+      ).catch(() => undefined);
+      continue;
+    }
+    running.push(job);
+  }
+  return running.sort((a, b) => a.started_at.localeCompare(b.started_at));
+}
+
+async function listSignalJobStates(workspaceFile: string): Promise<SignalRunJobState[]> {
+  const dir = signalJobsDirForWorkspace(workspaceFile);
+  let names: string[];
+  try {
+    names = await readdir(dir);
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw e;
+  }
+  const jobs: SignalRunJobState[] = [];
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    const file = path.join(dir, name);
+    try {
+      const parsed = JSON.parse(await readFile(file, "utf8")) as SignalRunJobState;
+      if (parsed?.id && parsed?.status && Array.isArray(parsed.record_ids)) {
+        jobs.push(parsed);
+      }
+    } catch {
+      // Ignore partial/corrupt job files; they should not break workspace loading.
+    }
+  }
+  return jobs;
+}
+
+async function readSignalJobState(
+  workspaceFile: string,
+  id: string,
+): Promise<SignalRunJobState | null> {
+  try {
+    const parsed = JSON.parse(
+      await readFile(signalJobPath(workspaceFile, id), "utf8"),
+    ) as SignalRunJobState;
+    return parsed?.id ? parsed : null;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw e;
+  }
+}
+
+function signalJobPath(workspaceFile: string, id: string): string {
+  return path.join(signalJobsDirForWorkspace(workspaceFile), `${safeJobId(id)}.json`);
+}
+
+function safeJobId(id: string): string {
+  return id.replace(/[^a-zA-Z0-9_.-]/g, "_");
+}
+
+function isProcessAlive(pid: number | undefined): boolean {
+  if (!pid || pid < 1) return true;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code === "EPERM";
+  }
+}

--- a/packages/sdk/src/operations/signals.test.ts
+++ b/packages/sdk/src/operations/signals.test.ts
@@ -394,6 +394,7 @@ console.log(JSON.stringify({
 console.log(JSON.stringify({
   type: "result",
   subtype: "success",
+  num_turns: 3,
   structured_output: {
     outputs: [
       {
@@ -432,6 +433,7 @@ console.log(JSON.stringify({
         mode: "force",
       });
       expect(result.runs_succeeded).toBe(1);
+      expect(result.statuses[0]?.num_turns).toBe(3);
       const args = JSON.parse(await readFile(argsPath, "utf8")) as string[];
       expect(args).toContain("--output-format");
       expect(args).toContain("stream-json");
@@ -439,8 +441,9 @@ console.log(JSON.stringify({
       expect(args).toContain("--model");
       expect(args[args.indexOf("--model") + 1]).toBe("sonnet");
       expect(args).toContain("--tools");
-      expect(args).toContain("WebSearch,WebFetch");
+      expect(args).toContain("WebSearch,WebFetch,Bash");
       expect(args).toContain("--allowedTools");
+      expect(args).toContain("WebSearch,WebFetch,Bash(agent-browser:*)");
       expect(args).toContain("--json-schema");
       const schema = JSON.parse(args[args.indexOf("--json-schema") + 1]!) as Record<string, unknown>;
       expect(JSON.stringify(schema)).toContain("operator_status");
@@ -527,7 +530,7 @@ console.log(JSON.stringify({
         claudePath,
         `#!/usr/bin/env node
 console.log(JSON.stringify({ type: "assistant", message: { content: [{ type: "thinking", thinking: "private scratchpad should not be logged", signature: "sig" }] } }));
-console.log(JSON.stringify({ type: "result", result: "partial claude stdout before failure" }));
+console.log(JSON.stringify({ type: "result", num_turns: 4, result: "partial claude stdout before failure" }));
 console.error("runner stderr: web search quota exhausted for test");
 process.exit(17);
 `,
@@ -548,6 +551,8 @@ process.exit(17);
       });
       expect(result.runs_failed).toBe(1);
       expect(result.failures[0]?.message).toBe("signal runner exited with code 17");
+      expect(result.failures[0]?.num_turns).toBe(4);
+      expect(result.statuses[0]?.num_turns).toBe(4);
       expect(result.failures[0]?.stdout_excerpt).toContain("partial claude stdout");
       expect(result.failures[0]?.stdout_excerpt).not.toContain("private scratchpad");
       expect(result.failures[0]?.stderr_excerpt).toContain("web search quota exhausted");

--- a/packages/sdk/src/operations/signals.test.ts
+++ b/packages/sdk/src/operations/signals.test.ts
@@ -1,0 +1,693 @@
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { openLix, type Lix } from "@lix-js/sdk";
+import { createBetterSqlite3Backend } from "@lix-js/sdk/sqlite";
+import { describe, expect, it } from "vitest";
+import { exec } from "../db/execute.js";
+import { createRecord } from "./records.js";
+import {
+  loadSignalDefinitions,
+  runSignals,
+  type SignalRunner,
+} from "./signals.js";
+import { seedAttributes, seedObjects } from "../workspace/seeds.js";
+import { registerAllSchemas } from "../workspace/schemas/index.js";
+import { Workspace } from "../workspace.js";
+
+async function openTestWorkspace(): Promise<Lix> {
+  const lix = await openLix({
+    backend: createBetterSqlite3Backend({ path: ":memory:" }),
+  });
+  await registerAllSchemas(lix);
+  await seedObjects(lix);
+  await seedAttributes(lix);
+  return lix;
+}
+
+async function withSignalsDir(
+  body: string,
+): Promise<{ dir: string; cleanup: () => Promise<void> }> {
+  const root = await mkdtemp(path.join(tmpdir(), "acrm-signals-"));
+  const dir = path.join(root, "signals");
+  await mkdir(dir);
+  await writeFile(path.join(dir, "hotel_contact_path.md"), body, "utf8");
+  return {
+    dir,
+    cleanup: () => rm(root, { recursive: true, force: true }),
+  };
+}
+
+const hotelSignal = `---
+slug: hotel_contact_path
+title: Hotel Contact Path
+object: companies
+---
+
+\`\`\`json acrm-signal
+{
+  "outputs": [
+    {
+      "key": "operator_status",
+      "attribute": "operator_status",
+      "title": "Operator status",
+      "type": "status",
+      "options": ["owner_identified:Owner identified", "unclear:Unclear"]
+    },
+    {
+      "key": "operator_name",
+      "attribute": "operator_name",
+      "title": "Operator name",
+      "type": "text"
+    }
+  ]
+}
+\`\`\`
+
+Search the hotel website imprint and local press for the operator.
+`;
+
+describe("signals", () => {
+  it("parses a multi-output signal definition", async () => {
+    const { dir, cleanup } = await withSignalsDir(hotelSignal);
+    try {
+      const definitions = await loadSignalDefinitions(dir);
+      expect(definitions).toHaveLength(1);
+      expect(definitions[0]?.slug).toBe("hotel_contact_path");
+      expect(definitions[0]?.object_slug).toBe("companies");
+      expect(definitions[0]?.outputs.map((output) => output.key)).toEqual([
+        "operator_status",
+        "operator_name",
+      ]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("syncs attributes, runs once, and stores per-field provenance", async () => {
+    const lix = await openTestWorkspace();
+    const { dir, cleanup } = await withSignalsDir(hotelSignal);
+    try {
+      const company = await createRecord(Workspace.fromLix(lix), {
+        object_slug: "companies",
+        fields: ["name=Hotel Felix", "domains=hotelfelix.example"],
+      });
+      let calls = 0;
+      const runner: SignalRunner = async (prompt) => {
+        calls++;
+        expect(prompt).toContain("operator_status");
+        expect(prompt).toContain("Hotel Felix");
+        expect(prompt).toContain("Output must be raw JSON parseable by JSON.parse");
+        expect(prompt).toContain("operator_name (text): value must be a non-empty JSON string.");
+        expect(prompt).toContain("Use WebSearch to discover public sources and WebFetch to verify pages");
+        expect(prompt).toContain("Never cite training data");
+        return JSON.stringify({
+          outputs: [
+            {
+              key: "operator_status",
+              value: "owner_identified",
+              confidence: "high",
+              citations: [
+                {
+                  url: "https://hotelfelix.example/imprint",
+                  title: "Imprint",
+                },
+              ],
+              reasoning: "The imprint names Felix Hotels GmbH as the operator.",
+            },
+            {
+              key: "operator_name",
+              value: "Felix Hotels GmbH",
+              confidence: "high",
+              citations: [],
+              reasoning: "The legal notice lists this entity.",
+            },
+          ],
+        });
+      };
+
+      const result = await runSignals(Workspace.fromLix(lix), {
+        signalsDir: dir,
+        records: [{ object_slug: "companies", record_id: company.record_id }],
+        mode: "missing",
+        runner,
+      });
+
+      expect(calls).toBe(1);
+      expect(result.values_written).toBe(2);
+      expect(result.statuses).toEqual([
+        {
+          object_slug: "companies",
+          record_id: company.record_id,
+          signal_slug: "hotel_contact_path",
+          status: "succeeded",
+          values_written: 2,
+        },
+      ]);
+      const values = await exec(
+        lix,
+        `SELECT attribute_slug, value_json, source, provenance_json
+           FROM acrm_value
+          WHERE object_slug = 'companies'
+            AND record_id = $1
+            AND attribute_slug IN ('operator_status', 'operator_name')
+            AND active_until IS NULL
+          ORDER BY attribute_slug`,
+        [company.record_id],
+      );
+      expect(values.rows).toHaveLength(2);
+      const byAttr = new Map(
+        values.rows.map((row) => [row.attribute_slug as string, row]),
+      );
+      expect(JSON.parse(byAttr.get("operator_status")!.value_json as string)).toEqual({
+        id: "owner_identified",
+        title: "Owner identified",
+      });
+      const provenance = JSON.parse(
+        byAttr.get("operator_name")!.provenance_json as string,
+      ) as Record<string, unknown>;
+      expect(byAttr.get("operator_name")!.source).toBe("signal:hotel_contact_path");
+      expect(provenance.reasoning).toBe("The legal notice lists this entity.");
+      expect(provenance.uncited).toBe(true);
+    } finally {
+      await cleanup();
+      await lix.close();
+    }
+  });
+
+  it("does not rerun missing-only signals when outputs already exist", async () => {
+    const lix = await openTestWorkspace();
+    const { dir, cleanup } = await withSignalsDir(hotelSignal);
+    try {
+      const company = await createRecord(Workspace.fromLix(lix), {
+        object_slug: "companies",
+        fields: ["name=Hotel Existing"],
+      });
+      const firstRunner: SignalRunner = async () =>
+        JSON.stringify({
+          outputs: [
+            {
+              key: "operator_status",
+              value: "unclear",
+              confidence: "low",
+              citations: [],
+              reasoning: "No non-obvious source was found.",
+            },
+            {
+              key: "operator_name",
+              value: "Unknown",
+              confidence: "low",
+              citations: [],
+              reasoning: "No operator was named in public sources.",
+            },
+          ],
+        });
+      await runSignals(Workspace.fromLix(lix), {
+        signalsDir: dir,
+        records: [{ object_slug: "companies", record_id: company.record_id }],
+        mode: "missing",
+        runner: firstRunner,
+      });
+
+      const second = await runSignals(Workspace.fromLix(lix), {
+        signalsDir: dir,
+        records: [{ object_slug: "companies", record_id: company.record_id }],
+        mode: "missing",
+        runner: async () => {
+          throw new Error("should not run");
+        },
+      });
+
+      expect(second.runs_attempted).toBe(0);
+      expect(second.skipped).toBe(1);
+      expect(second.statuses).toEqual([
+        {
+          object_slug: "companies",
+          record_id: company.record_id,
+          signal_slug: "hotel_contact_path",
+          status: "skipped",
+        },
+      ]);
+    } finally {
+      await cleanup();
+      await lix.close();
+    }
+  });
+
+  it("rejects signal outputs that target core CRM fields", async () => {
+    const coreFieldSignal = `---
+slug: bad_core_signal
+title: Bad Core Signal
+object: companies
+---
+
+\`\`\`json acrm-signal
+{
+  "outputs": [
+    {
+      "key": "company_name",
+      "attribute": "name",
+      "title": "Company name",
+      "type": "text"
+    }
+  ]
+}
+\`\`\`
+
+Find the company name.
+`;
+    const lix = await openTestWorkspace();
+    const { dir, cleanup } = await withSignalsDir(coreFieldSignal);
+    try {
+      const company = await createRecord(Workspace.fromLix(lix), {
+        object_slug: "companies",
+        fields: ["name=Hotel Protected"],
+      });
+      await expect(
+        runSignals(Workspace.fromLix(lix), {
+          signalsDir: dir,
+          records: [{ object_slug: "companies", record_id: company.record_id }],
+          mode: "force",
+          runner: async () => {
+            throw new Error("should not run");
+          },
+        }),
+      ).rejects.toThrow(/targets core field companies\.name/);
+    } finally {
+      await cleanup();
+      await lix.close();
+    }
+  });
+
+  it("records a failure when a runner returns an unknown output key", async () => {
+    const lix = await openTestWorkspace();
+    const { dir, cleanup } = await withSignalsDir(hotelSignal);
+    try {
+      const company = await createRecord(Workspace.fromLix(lix), {
+        object_slug: "companies",
+        fields: ["name=Hotel Bad Output"],
+      });
+      const result = await runSignals(Workspace.fromLix(lix), {
+        signalsDir: dir,
+        records: [{ object_slug: "companies", record_id: company.record_id }],
+        mode: "force",
+        runner: async () =>
+          JSON.stringify({
+            outputs: [
+              {
+                key: "not_declared",
+                value: "oops",
+                confidence: "low",
+                citations: [],
+                reasoning: "This key is not in the signal definition.",
+              },
+            ],
+          }),
+      });
+      expect(result.runs_failed).toBe(1);
+      expect(result.statuses[0]?.status).toBe("failed");
+      expect(result.failures[0]?.message).toMatch(/unknown output key/);
+    } finally {
+      await cleanup();
+      await lix.close();
+    }
+  });
+
+  it("records a failure when a runner returns a value with the wrong declared type", async () => {
+    const typedSignal = `---
+slug: typed_signal
+title: Typed Signal
+object: companies
+---
+
+\`\`\`json acrm-signal
+{
+  "outputs": [
+    {
+      "key": "employee_count",
+      "attribute": "employee_count",
+      "title": "Employee count",
+      "type": "number"
+    }
+  ]
+}
+\`\`\`
+
+Find the number of employees.
+`;
+    const lix = await openTestWorkspace();
+    const { dir, cleanup } = await withSignalsDir(typedSignal);
+    try {
+      const company = await createRecord(Workspace.fromLix(lix), {
+        object_slug: "companies",
+        fields: ["name=Hotel Wrong Type"],
+      });
+      const result = await runSignals(Workspace.fromLix(lix), {
+        signalsDir: dir,
+        records: [{ object_slug: "companies", record_id: company.record_id }],
+        mode: "force",
+        runner: async (prompt) => {
+          expect(prompt).toContain("employee_count (number): value must be a finite JSON number");
+          return JSON.stringify({
+            outputs: [
+              {
+                key: "employee_count",
+                value: "42",
+                confidence: "high",
+                citations: [],
+                reasoning: "The source says there are 42 employees.",
+              },
+            ],
+          });
+        },
+      });
+      expect(result.runs_failed).toBe(1);
+      expect(result.values_written).toBe(0);
+      expect(result.failures[0]?.message).toMatch(/invalid number value/);
+      expect(result.failures[0]?.stdout_excerpt).toContain("employee_count");
+    } finally {
+      await cleanup();
+      await lix.close();
+    }
+  });
+
+  it("allows web tools, attaches a JSON schema, and passes the configured Claude model", async () => {
+    const lix = await openTestWorkspace();
+    const { dir, cleanup } = await withSignalsDir(hotelSignal);
+    const binDir = await mkdtemp(path.join(tmpdir(), "acrm-claude-bin-"));
+    const argsPath = path.join(binDir, "args.json");
+    const claudePath = path.join(binDir, "claude");
+    const previousPath = process.env.PATH;
+    const previousRunner = process.env.ACRM_SIGNAL_RUNNER;
+    const previousSignalRunsModel = process.env.SIGNAL_RUNS_MODEL;
+    const previousArgsPath = process.env.ACRM_TEST_CLAUDE_ARGS;
+    try {
+      await writeFile(
+        claudePath,
+        `#!/usr/bin/env node
+const fs = require("node:fs");
+fs.writeFileSync(process.env.ACRM_TEST_CLAUDE_ARGS, JSON.stringify(process.argv.slice(2)));
+console.log(JSON.stringify({
+  type: "assistant",
+  message: { content: [{ type: "text", text: "Searching public hotel pages..." }] }
+}));
+console.log(JSON.stringify({
+  type: "result",
+  subtype: "success",
+  structured_output: {
+    outputs: [
+      {
+        key: "operator_status",
+        value: "owner_identified",
+        confidence: "high",
+        citations: [{ url: "https://example.test/imprint", title: "Imprint" }],
+        reasoning: "The fetched imprint identifies the operator."
+      },
+      {
+        key: "operator_name",
+        value: "Example Hotels GmbH",
+        confidence: "high",
+        citations: [{ url: "https://example.test/imprint", title: "Imprint" }],
+        reasoning: "The fetched imprint names the operating entity."
+      }
+    ]
+  }
+}));
+`,
+        "utf8",
+      );
+      await chmod(claudePath, 0o755);
+      process.env.PATH = `${binDir}:${previousPath ?? ""}`;
+      process.env.ACRM_TEST_CLAUDE_ARGS = argsPath;
+      delete process.env.ACRM_SIGNAL_RUNNER;
+      delete process.env.SIGNAL_RUNS_MODEL;
+
+      const company = await createRecord(Workspace.fromLix(lix), {
+        object_slug: "companies",
+        fields: ["name=Hotel Default Runner"],
+      });
+      const result = await runSignals(Workspace.fromLix(lix), {
+        signalsDir: dir,
+        records: [{ object_slug: "companies", record_id: company.record_id }],
+        mode: "force",
+      });
+      expect(result.runs_succeeded).toBe(1);
+      const args = JSON.parse(await readFile(argsPath, "utf8")) as string[];
+      expect(args).toContain("--output-format");
+      expect(args).toContain("stream-json");
+      expect(args).toContain("--verbose");
+      expect(args).toContain("--model");
+      expect(args[args.indexOf("--model") + 1]).toBe("sonnet");
+      expect(args).toContain("--tools");
+      expect(args).toContain("WebSearch,WebFetch");
+      expect(args).toContain("--allowedTools");
+      expect(args).toContain("--json-schema");
+      const schema = JSON.parse(args[args.indexOf("--json-schema") + 1]!) as Record<string, unknown>;
+      expect(JSON.stringify(schema)).toContain("operator_status");
+
+      process.env.SIGNAL_RUNS_MODEL = "opus";
+      const overrideCompany = await createRecord(Workspace.fromLix(lix), {
+        object_slug: "companies",
+        fields: ["name=Hotel Model Override"],
+      });
+      const overrideResult = await runSignals(Workspace.fromLix(lix), {
+        signalsDir: dir,
+        records: [{ object_slug: "companies", record_id: overrideCompany.record_id }],
+        mode: "force",
+      });
+      expect(overrideResult.runs_succeeded).toBe(1);
+      const overrideArgs = JSON.parse(await readFile(argsPath, "utf8")) as string[];
+      expect(overrideArgs[overrideArgs.indexOf("--model") + 1]).toBe("opus");
+    } finally {
+      process.env.PATH = previousPath;
+      if (previousRunner === undefined) delete process.env.ACRM_SIGNAL_RUNNER;
+      else process.env.ACRM_SIGNAL_RUNNER = previousRunner;
+      if (previousSignalRunsModel === undefined) delete process.env.SIGNAL_RUNS_MODEL;
+      else process.env.SIGNAL_RUNS_MODEL = previousSignalRunsModel;
+      if (previousArgsPath === undefined) delete process.env.ACRM_TEST_CLAUDE_ARGS;
+      else process.env.ACRM_TEST_CLAUDE_ARGS = previousArgsPath;
+      await cleanup();
+      await rm(binDir, { recursive: true, force: true });
+      await lix.close();
+    }
+  });
+
+  it("parses Claude JSON output wrappers with structured_output", async () => {
+    const lix = await openTestWorkspace();
+    const { dir, cleanup } = await withSignalsDir(hotelSignal);
+    try {
+      const company = await createRecord(Workspace.fromLix(lix), {
+        object_slug: "companies",
+        fields: ["name=Hotel Wrapper"],
+      });
+      const result = await runSignals(Workspace.fromLix(lix), {
+        signalsDir: dir,
+        records: [{ object_slug: "companies", record_id: company.record_id }],
+        mode: "force",
+        runner: async () =>
+          JSON.stringify({
+            type: "result",
+            structured_output: {
+              outputs: [
+                {
+                  key: "operator_status",
+                  value: "owner_identified",
+                  confidence: "high",
+                  citations: [{ url: "https://example.test/imprint" }],
+                  reasoning: "The fetched imprint identifies the operator.",
+                },
+                {
+                  key: "operator_name",
+                  value: "Example Hotels GmbH",
+                  confidence: "high",
+                  citations: [{ url: "https://example.test/imprint" }],
+                  reasoning: "The fetched imprint names the operating entity.",
+                },
+              ],
+            },
+          }),
+      });
+      expect(result.runs_succeeded).toBe(1);
+      expect(result.values_written).toBe(2);
+    } finally {
+      await cleanup();
+      await lix.close();
+    }
+  });
+
+  it("includes runner stderr excerpts in failures", async () => {
+    const lix = await openTestWorkspace();
+    const { dir, cleanup } = await withSignalsDir(hotelSignal);
+    const binDir = await mkdtemp(path.join(tmpdir(), "acrm-claude-fail-bin-"));
+    const claudePath = path.join(binDir, "claude");
+    const previousPath = process.env.PATH;
+    const previousRunner = process.env.ACRM_SIGNAL_RUNNER;
+    try {
+      await writeFile(
+        claudePath,
+        `#!/usr/bin/env node
+console.log(JSON.stringify({ type: "assistant", message: { content: [{ type: "thinking", thinking: "private scratchpad should not be logged", signature: "sig" }] } }));
+console.log(JSON.stringify({ type: "result", result: "partial claude stdout before failure" }));
+console.error("runner stderr: web search quota exhausted for test");
+process.exit(17);
+`,
+        "utf8",
+      );
+      await chmod(claudePath, 0o755);
+      process.env.PATH = `${binDir}:${previousPath ?? ""}`;
+      delete process.env.ACRM_SIGNAL_RUNNER;
+
+      const company = await createRecord(Workspace.fromLix(lix), {
+        object_slug: "companies",
+        fields: ["name=Hotel Runner Failure"],
+      });
+      const result = await runSignals(Workspace.fromLix(lix), {
+        signalsDir: dir,
+        records: [{ object_slug: "companies", record_id: company.record_id }],
+        mode: "force",
+      });
+      expect(result.runs_failed).toBe(1);
+      expect(result.failures[0]?.message).toBe("signal runner exited with code 17");
+      expect(result.failures[0]?.stdout_excerpt).toContain("partial claude stdout");
+      expect(result.failures[0]?.stdout_excerpt).not.toContain("private scratchpad");
+      expect(result.failures[0]?.stderr_excerpt).toContain("web search quota exhausted");
+    } finally {
+      process.env.PATH = previousPath;
+      if (previousRunner === undefined) delete process.env.ACRM_SIGNAL_RUNNER;
+      else process.env.ACRM_SIGNAL_RUNNER = previousRunner;
+      await cleanup();
+      await rm(binDir, { recursive: true, force: true });
+      await lix.close();
+    }
+  });
+
+  it("migrates signal-owned text outputs to enum outputs and retires removed outputs", async () => {
+    const oldSignal = `---
+slug: hotel_contact_path
+title: Hotel Contact Path
+object: companies
+---
+
+\`\`\`json acrm-signal
+{
+  "outputs": [
+    {
+      "key": "operator_role",
+      "attribute": "operator_role",
+      "title": "Operator role",
+      "type": "text"
+    },
+    {
+      "key": "operator_source_notes",
+      "attribute": "operator_source_notes",
+      "title": "Operator source notes",
+      "type": "text"
+    }
+  ]
+}
+\`\`\`
+
+Find the operator role.
+`;
+    const newSignal = `---
+slug: hotel_contact_path
+title: Hotel Contact Path
+object: companies
+---
+
+\`\`\`json acrm-signal
+{
+  "outputs": [
+    {
+      "key": "operator_role",
+      "attribute": "operator_role",
+      "title": "Operator role",
+      "type": "select",
+      "options": ["owner:Owner", "general_manager:General manager"]
+    }
+  ]
+}
+\`\`\`
+
+Classify the operator role.
+`;
+    const lix = await openTestWorkspace();
+    const { dir, cleanup } = await withSignalsDir(oldSignal);
+    try {
+      const company = await createRecord(Workspace.fromLix(lix), {
+        object_slug: "companies",
+        fields: ["name=Hotel Migration"],
+      });
+      await runSignals(Workspace.fromLix(lix), {
+        signalsDir: dir,
+        records: [{ object_slug: "companies", record_id: company.record_id }],
+        mode: "force",
+        runner: async () =>
+          JSON.stringify({
+            outputs: [
+              {
+                key: "operator_role",
+                value: "Owner-operators",
+                confidence: "medium",
+                citations: [],
+                reasoning: "The old signal returned role prose.",
+              },
+              {
+                key: "operator_source_notes",
+                value: "Old notes",
+                confidence: "medium",
+                citations: [],
+                reasoning: "The old signal returned notes.",
+              },
+            ],
+          }),
+      });
+
+      await writeFile(path.join(dir, "hotel_contact_path.md"), newSignal, "utf8");
+      const result = await runSignals(Workspace.fromLix(lix), {
+        signalsDir: dir,
+        records: [{ object_slug: "companies", record_id: company.record_id }],
+        mode: "missing",
+        runner: async () =>
+          JSON.stringify({
+            outputs: [
+              {
+                key: "operator_role",
+                value: "general_manager",
+                confidence: "high",
+                citations: [{ url: "https://example.test/team" }],
+                reasoning: "The current signal returns the enum option id.",
+              },
+            ],
+          }),
+      });
+
+      expect(result.runs_succeeded).toBe(1);
+      expect(result.values_written).toBe(1);
+      const attr = await exec(
+        lix,
+        "SELECT attribute_type FROM acrm_attribute WHERE object_slug = 'companies' AND attribute_slug = 'operator_role'",
+      );
+      expect(attr.rows[0]?.attribute_type).toBe("select");
+      const active = await exec(
+        lix,
+        `SELECT attribute_slug, value_json
+           FROM acrm_value
+          WHERE object_slug = 'companies'
+            AND record_id = $1
+            AND attribute_slug IN ('operator_role', 'operator_source_notes')
+            AND active_until IS NULL
+          ORDER BY attribute_slug`,
+        [company.record_id],
+      );
+      expect(active.rows.map((row) => row.attribute_slug)).toEqual(["operator_role"]);
+      expect(JSON.parse(active.rows[0]?.value_json as string)).toEqual({
+        id: "general_manager",
+        title: "General manager",
+      });
+    } finally {
+      await cleanup();
+      await lix.close();
+    }
+  });
+});

--- a/packages/sdk/src/operations/signals.ts
+++ b/packages/sdk/src/operations/signals.ts
@@ -72,6 +72,8 @@ export type SignalRunArgs = {
 export type SignalRunFailure = SignalRecordRef & {
   signal_slug: string;
   message: string;
+  num_turns?: number;
+  estimated_num_turns?: number;
   stdout_excerpt?: string;
   stderr_excerpt?: string;
 };
@@ -80,6 +82,8 @@ export type SignalRunStatus = SignalRecordRef & {
   signal_slug: string;
   status: "succeeded" | "failed" | "skipped";
   values_written?: number;
+  num_turns?: number;
+  estimated_num_turns?: number;
 };
 
 export type SignalRunResult = {
@@ -172,9 +176,9 @@ const DEFAULT_RUNNER = [
   "stream-json",
   "--verbose",
   "--tools",
-  "WebSearch,WebFetch",
+  "WebSearch,WebFetch,Bash",
   "--allowedTools",
-  "WebSearch,WebFetch",
+  "WebSearch,WebFetch,Bash(agent-browser:*)",
 ];
 const DEFAULT_SIGNAL_RUNS_MODEL = "sonnet";
 const DEFAULT_RUNNER_TIMEOUT_MS = 5 * 60 * 1000;
@@ -341,20 +345,21 @@ export async function runSignals(
         }
         result.runs_attempted++;
         try {
-          const written = await runOneSignal(
+          const run = await runOneSignal(
             workspace,
             definition,
             record,
             requested,
             args.runner ?? defaultRunner,
           );
-          result.values_written += written;
+          result.values_written += run.values_written;
           result.runs_succeeded++;
           result.statuses.push({
             ...record,
             signal_slug: definition.slug,
             status: "succeeded",
-            values_written: written,
+            values_written: run.values_written,
+            ...runnerTurnMetricFields(run),
           });
         } catch (e) {
           const failure = signalFailureFromError(e);
@@ -363,11 +368,13 @@ export async function runSignals(
             ...record,
             signal_slug: definition.slug,
             status: "failed",
+            ...runnerTurnMetricFields(failure),
           });
           result.failures.push({
             ...record,
             signal_slug: definition.slug,
             message: failure.message,
+            ...runnerTurnMetricFields(failure),
             ...(failure.stdout_excerpt ? { stdout_excerpt: failure.stdout_excerpt } : {}),
             ...(failure.stderr_excerpt ? { stderr_excerpt: failure.stderr_excerpt } : {}),
           });
@@ -852,7 +859,7 @@ async function runOneSignal(
   record: SignalRecordRef,
   requested: SignalOutputDefinition[],
   runner: SignalRunner,
-): Promise<number> {
+): Promise<{ values_written: number } & RunnerTurnMetrics> {
   const recordContext = await loadRecordContext(workspace, record);
   const prompt = buildRunnerPrompt(definition, record, requested, recordContext);
   const raw = await runner(prompt, {
@@ -860,6 +867,7 @@ async function runOneSignal(
     record,
     requested_outputs: requested.map((output) => output.key),
   });
+  const metrics = runnerTurnMetrics(raw);
   let outputs: ParsedRunnerOutput[];
   try {
     outputs = parseRunnerResponse(raw, definition);
@@ -896,7 +904,10 @@ async function runOneSignal(
     });
     written++;
   }
-  return written;
+  return {
+    values_written: written,
+    ...runnerTurnMetricFields(metrics),
+  };
 }
 
 async function loadRecordContext(
@@ -1077,26 +1088,74 @@ function parseRunnerPayload(raw: string): unknown {
   return unwrapClaudeJson(parseJson(extractJson(raw)));
 }
 
-function parseClaudeStreamResult(raw: string): unknown {
-  const objects = stripAnsi(raw)
+type RunnerTurnMetrics = {
+  num_turns?: number;
+  estimated_num_turns?: number;
+};
+
+function parseClaudeStreamObjects(raw: string): Record<string, unknown>[] {
+  return stripAnsi(raw)
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter((line) => line.startsWith("{"))
     .flatMap((line) => {
       try {
-        return [JSON.parse(line) as unknown];
+        const parsed = JSON.parse(line) as unknown;
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          return [parsed as Record<string, unknown>];
+        }
+        return [];
       } catch {
         return [];
       }
     });
+}
+
+function parseClaudeStreamResult(raw: string): unknown {
+  const objects = parseClaudeStreamObjects(raw);
   if (objects.length < 2) return undefined;
   for (const item of objects.slice().reverse()) {
-    if (item && typeof item === "object" && !Array.isArray(item)) {
-      const object = item as Record<string, unknown>;
-      if (object.type === "result") return object;
-    }
+    if (item.type === "result") return item;
   }
   return undefined;
+}
+
+function runnerTurnMetrics(raw: string): RunnerTurnMetrics {
+  const objects = parseClaudeStreamObjects(raw);
+  let num_turns: number | undefined;
+  let toolResultMessages = 0;
+  for (const item of objects) {
+    if (item.type === "result" && typeof item.num_turns === "number") {
+      num_turns = item.num_turns;
+    }
+    if (item.type === "user") {
+      const message = item.message;
+      if (!message || typeof message !== "object" || Array.isArray(message)) continue;
+      const content = (message as Record<string, unknown>).content;
+      if (!Array.isArray(content)) continue;
+      const hasToolResult = content.some((block) =>
+        block &&
+        typeof block === "object" &&
+        !Array.isArray(block) &&
+        (block as Record<string, unknown>).type === "tool_result",
+      );
+      if (hasToolResult) {
+        toolResultMessages++;
+      }
+    }
+  }
+  const estimated_num_turns =
+    num_turns === undefined && toolResultMessages > 0 ? toolResultMessages + 1 : undefined;
+  return runnerTurnMetricFields({ num_turns, estimated_num_turns });
+}
+
+function runnerTurnMetricFields(metrics: RunnerTurnMetrics): RunnerTurnMetrics {
+  return {
+    ...(metrics.num_turns !== undefined ? { num_turns: metrics.num_turns } : {}),
+    ...(metrics.estimated_num_turns !== undefined
+      ? { estimated_num_turns: metrics.estimated_num_turns }
+      : {}),
+  };
 }
 
 function unwrapClaudeJson(parsed: unknown): unknown {
@@ -1318,12 +1377,19 @@ function teeRunnerChunk(chunk: string): void {
 }
 
 class SignalRunnerProcessError extends Error {
+  num_turns?: number;
+  estimated_num_turns?: number;
   stdout_excerpt?: string;
   stderr_excerpt?: string;
 
   constructor(message: string, stdout: string, stderr: string) {
     super(message);
     this.name = "SignalRunnerProcessError";
+    const metrics = runnerTurnMetrics(stdout);
+    if (metrics.num_turns !== undefined) this.num_turns = metrics.num_turns;
+    if (metrics.estimated_num_turns !== undefined) {
+      this.estimated_num_turns = metrics.estimated_num_turns;
+    }
     const stdoutExcerpt = textExcerpt(stdout, RUNNER_STDOUT_EXCERPT_CHARS);
     if (stdoutExcerpt) this.stdout_excerpt = stdoutExcerpt;
     const excerpt = textExcerpt(stderr, RUNNER_STDERR_EXCERPT_CHARS);
@@ -1332,11 +1398,18 @@ class SignalRunnerProcessError extends Error {
 }
 
 class SignalRunnerOutputError extends Error {
+  num_turns?: number;
+  estimated_num_turns?: number;
   stdout_excerpt?: string;
 
   constructor(error: unknown, stdout: string) {
     super(error instanceof Error ? error.message : String(error));
     this.name = error instanceof Error ? error.name : "SignalRunnerOutputError";
+    const metrics = runnerTurnMetrics(stdout);
+    if (metrics.num_turns !== undefined) this.num_turns = metrics.num_turns;
+    if (metrics.estimated_num_turns !== undefined) {
+      this.estimated_num_turns = metrics.estimated_num_turns;
+    }
     const excerpt = textExcerpt(sanitizeRunnerOutputForLog(stdout), RUNNER_STDOUT_EXCERPT_CHARS);
     if (excerpt) this.stdout_excerpt = excerpt;
   }
@@ -1344,8 +1417,22 @@ class SignalRunnerOutputError extends Error {
 
 function signalFailureFromError(
   error: unknown,
-): { message: string; stdout_excerpt?: string; stderr_excerpt?: string } {
+): { message: string; stdout_excerpt?: string; stderr_excerpt?: string } & RunnerTurnMetrics {
   const message = error instanceof Error ? error.message : String(error);
+  const num_turns =
+    error &&
+    typeof error === "object" &&
+    "num_turns" in error &&
+    typeof (error as { num_turns?: unknown }).num_turns === "number"
+      ? (error as { num_turns: number }).num_turns
+      : undefined;
+  const estimated_num_turns =
+    error &&
+    typeof error === "object" &&
+    "estimated_num_turns" in error &&
+    typeof (error as { estimated_num_turns?: unknown }).estimated_num_turns === "number"
+      ? (error as { estimated_num_turns: number }).estimated_num_turns
+      : undefined;
   const stdout_excerpt =
     error &&
     typeof error === "object" &&
@@ -1360,14 +1447,12 @@ function signalFailureFromError(
     typeof (error as { stderr_excerpt?: unknown }).stderr_excerpt === "string"
       ? (error as { stderr_excerpt: string }).stderr_excerpt
       : undefined;
-  if (stdout_excerpt || stderr_excerpt) {
-    return {
-      message,
-      ...(stdout_excerpt ? { stdout_excerpt } : {}),
-      ...(stderr_excerpt ? { stderr_excerpt } : {}),
-    };
-  }
-  return { message };
+  return {
+    message,
+    ...runnerTurnMetricFields({ num_turns, estimated_num_turns }),
+    ...(stdout_excerpt ? { stdout_excerpt } : {}),
+    ...(stderr_excerpt ? { stderr_excerpt } : {}),
+  };
 }
 
 function normalizeCitations(raw: unknown): unknown[] {

--- a/packages/sdk/src/operations/signals.ts
+++ b/packages/sdk/src/operations/signals.ts
@@ -1,0 +1,1598 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { appendFileSync } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { exec } from "../db/execute.js";
+import type { AttributeConfig, AttributeType } from "../domain/values.js";
+import { AcrmError, ERR } from "../lib/errors.js";
+import { nowIso } from "../lib/time.js";
+import {
+  addAttribute,
+  type AddAttributeResult,
+} from "./schema.js";
+import { setSingleValue } from "../db/upsert.js";
+import { loadAttribute } from "../workspace/catalog.js";
+import type { Workspace } from "../workspace.js";
+
+export type SignalObjectSlug = "people" | "companies";
+export type SignalRunMode = "missing" | "force";
+
+export type SignalOption = {
+  id: string;
+  title: string;
+};
+
+export type SignalOutputDefinition = {
+  key: string;
+  attribute: string;
+  title: string;
+  type: SignalAttributeType;
+  options?: SignalOption[];
+};
+
+export type SignalDefinition = {
+  slug: string;
+  title: string;
+  object_slug: SignalObjectSlug;
+  outputs: SignalOutputDefinition[];
+  prompt: string;
+  definition_hash: string;
+  path: string;
+};
+
+export type SignalRunnerContext = {
+  signal: SignalDefinition;
+  record: SignalRecordRef;
+  requested_outputs: string[];
+};
+
+export type SignalRunner = (
+  prompt: string,
+  context: SignalRunnerContext,
+) => Promise<string>;
+
+export type SignalRecordRef = {
+  object_slug: SignalObjectSlug;
+  record_id: string;
+};
+
+export type SignalRunArgs = {
+  signalsDir: string;
+  signalSlugs?: string[];
+  object_slug?: SignalObjectSlug;
+  record_ids?: string[];
+  records?: SignalRecordRef[];
+  mode?: SignalRunMode;
+  limit?: number;
+  concurrency?: number;
+  runner?: SignalRunner;
+};
+
+export type SignalRunFailure = SignalRecordRef & {
+  signal_slug: string;
+  message: string;
+  stdout_excerpt?: string;
+  stderr_excerpt?: string;
+};
+
+export type SignalRunStatus = SignalRecordRef & {
+  signal_slug: string;
+  status: "succeeded" | "failed" | "skipped";
+  values_written?: number;
+};
+
+export type SignalRunResult = {
+  definitions: number;
+  records_considered: number;
+  runs_attempted: number;
+  runs_succeeded: number;
+  runs_failed: number;
+  values_written: number;
+  skipped: number;
+  failures: SignalRunFailure[];
+  statuses: SignalRunStatus[];
+};
+
+export type SignalSyncResult = {
+  definitions: number;
+  attributes_created: number;
+  attributes_updated: number;
+  created: AddAttributeResult[];
+  updated: Array<{
+    object_slug: SignalObjectSlug;
+    attribute_slug: string;
+    options_added: string[];
+    type_changed_from?: string;
+    type_changed_to?: string;
+    retired?: boolean;
+  }>;
+};
+
+type SignalAttributeType = Extract<
+  AttributeType,
+  "text" | "number" | "url" | "date" | "timestamp" | "status" | "select"
+>;
+
+type Frontmatter = Record<string, string>;
+
+type RecordContextValue = {
+  attribute_slug: string;
+  title: string;
+  type: string;
+  value: unknown;
+};
+
+type ParsedRunnerOutput = {
+  key: string;
+  value: unknown;
+  confidence: string;
+  citations: unknown[];
+  reasoning: string;
+  notes?: string;
+};
+
+const SIGNAL_OBJECTS = new Set<string>(["people", "companies"]);
+const SUPPORTED_TYPES = new Set<string>([
+  "text",
+  "number",
+  "url",
+  "date",
+  "timestamp",
+  "status",
+  "select",
+]);
+const SLUG_RE = /^[a-z][a-z0-9_]*$/;
+const CORE_SIGNAL_BLOCKED_ATTRIBUTES: Record<SignalObjectSlug, Set<string>> = {
+  companies: new Set([
+    "name",
+    "domains",
+    "description",
+    "linkedin_url",
+    "team",
+    "associated_deals",
+  ]),
+  people: new Set([
+    "name",
+    "email_addresses",
+    "phone_numbers",
+    "job_title",
+    "linkedin_url",
+    "twitter_url",
+    "company",
+    "associated_deals",
+    "associated_posts",
+    "associated_transcripts",
+  ]),
+};
+const DEFAULT_RUNNER = [
+  "claude",
+  "-p",
+  "--output-format",
+  "stream-json",
+  "--verbose",
+  "--tools",
+  "WebSearch,WebFetch",
+  "--allowedTools",
+  "WebSearch,WebFetch",
+];
+const DEFAULT_SIGNAL_RUNS_MODEL = "sonnet";
+const DEFAULT_RUNNER_TIMEOUT_MS = 5 * 60 * 1000;
+const RUNNER_STDOUT_EXCERPT_CHARS = 4000;
+const RUNNER_STDERR_EXCERPT_CHARS = 1200;
+
+export async function loadSignalDefinitions(
+  signalsDir: string,
+): Promise<SignalDefinition[]> {
+  const entries = await readdir(signalsDir, { withFileTypes: true }).catch((e) => {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw e;
+  });
+  const definitions: SignalDefinition[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+    const filePath = path.join(signalsDir, entry.name);
+    const content = await readFile(filePath, "utf8");
+    definitions.push(parseSignalDefinition(filePath, content));
+  }
+  return definitions.sort((a, b) => a.slug.localeCompare(b.slug));
+}
+
+export async function ensureSignalAttributes(
+  workspace: Workspace,
+  definitions: SignalDefinition[],
+): Promise<SignalSyncResult> {
+  const result: SignalSyncResult = {
+    definitions: definitions.length,
+    attributes_created: 0,
+    attributes_updated: 0,
+    created: [],
+    updated: [],
+  };
+
+  for (const definition of definitions) {
+    const retired = await retireRemovedSignalValues(workspace, definition);
+    for (const attribute_slug of retired) {
+      result.updated.push({
+        object_slug: definition.object_slug,
+        attribute_slug,
+        options_added: [],
+        retired: true,
+      });
+    }
+    for (const output of definition.outputs) {
+      assertOutputDoesNotTargetCoreField(definition, output);
+      const existing = await loadAttribute(
+        workspace.lix,
+        definition.object_slug,
+        output.attribute,
+      );
+      const config = configForOutput(output);
+      if (!existing) {
+        const created = await addAttribute(workspace, {
+          object_slug: definition.object_slug,
+          attribute_slug: output.attribute,
+          attribute_type: output.type,
+          title: output.title,
+          is_multivalued: false,
+          is_unique: false,
+          config,
+        });
+        result.created.push(created);
+        result.attributes_created++;
+        continue;
+      }
+
+      if (existing.is_multivalued) {
+        throw new AcrmError(
+          `signal ${definition.slug} output ${output.key} targets multivalued attribute ${definition.object_slug}.${output.attribute}; signal outputs must be single-valued`,
+          ERR.INVALID_INPUT,
+        );
+      }
+      if (existing.attribute_type !== output.type) {
+        await changeSignalAttributeType(workspace, definition, output, existing.attribute_type);
+        result.updated.push({
+          object_slug: definition.object_slug,
+          attribute_slug: output.attribute,
+          options_added: output.options?.map((option) => option.id) ?? [],
+          type_changed_from: existing.attribute_type,
+          type_changed_to: output.type,
+        });
+        result.attributes_updated++;
+        continue;
+      }
+
+      const added = await ensureOptions(
+        workspace,
+        definition.object_slug,
+        output,
+        existing.config,
+      );
+      if (added.length > 0) {
+        result.updated.push({
+          object_slug: definition.object_slug,
+          attribute_slug: output.attribute,
+          options_added: added,
+        });
+        result.attributes_updated++;
+      }
+    }
+  }
+
+  return result;
+}
+
+function assertOutputDoesNotTargetCoreField(
+  definition: SignalDefinition,
+  output: SignalOutputDefinition,
+): void {
+  if (!CORE_SIGNAL_BLOCKED_ATTRIBUTES[definition.object_slug].has(output.attribute)) return;
+  throw new AcrmError(
+    `signal ${definition.slug} output ${output.key} targets core field ${definition.object_slug}.${output.attribute}; choose a dedicated signal attribute instead`,
+    ERR.INVALID_INPUT,
+  );
+}
+
+export async function runSignals(
+  workspace: Workspace,
+  args: SignalRunArgs,
+): Promise<SignalRunResult> {
+  const mode = args.mode ?? "missing";
+  const definitions = filterDefinitions(
+    await loadSignalDefinitions(args.signalsDir),
+    args,
+  );
+  await ensureSignalAttributes(workspace, definitions);
+
+  const records = await selectRecords(workspace, definitions, args);
+  const result: SignalRunResult = {
+    definitions: definitions.length,
+    records_considered: records.length,
+    runs_attempted: 0,
+    runs_succeeded: 0,
+    runs_failed: 0,
+    values_written: 0,
+    skipped: 0,
+    failures: [],
+    statuses: [],
+  };
+
+  const tasks: Array<() => Promise<void>> = [];
+  for (const definition of definitions) {
+    const matching = records.filter(
+      (record) => record.object_slug === definition.object_slug,
+    );
+    for (const record of matching) {
+      tasks.push(async () => {
+        const active = await activeAttributesForOutputs(
+          workspace,
+          record,
+          definition.outputs,
+        );
+        const requested = requestedOutputs(definition, active, mode);
+        if (requested.length === 0) {
+          result.skipped++;
+          result.statuses.push({
+            ...record,
+            signal_slug: definition.slug,
+            status: "skipped",
+          });
+          return;
+        }
+        result.runs_attempted++;
+        try {
+          const written = await runOneSignal(
+            workspace,
+            definition,
+            record,
+            requested,
+            args.runner ?? defaultRunner,
+          );
+          result.values_written += written;
+          result.runs_succeeded++;
+          result.statuses.push({
+            ...record,
+            signal_slug: definition.slug,
+            status: "succeeded",
+            values_written: written,
+          });
+        } catch (e) {
+          const failure = signalFailureFromError(e);
+          result.runs_failed++;
+          result.statuses.push({
+            ...record,
+            signal_slug: definition.slug,
+            status: "failed",
+          });
+          result.failures.push({
+            ...record,
+            signal_slug: definition.slug,
+            message: failure.message,
+            ...(failure.stdout_excerpt ? { stdout_excerpt: failure.stdout_excerpt } : {}),
+            ...(failure.stderr_excerpt ? { stderr_excerpt: failure.stderr_excerpt } : {}),
+          });
+        }
+      });
+      if (args.limit && tasks.length >= args.limit) break;
+    }
+    if (args.limit && tasks.length >= args.limit) break;
+  }
+
+  await runWithConcurrency(tasks, normalizePositiveInt(args.concurrency, 1));
+  return result;
+}
+
+function parseSignalDefinition(
+  filePath: string,
+  content: string,
+): SignalDefinition {
+  const frontmatter = parseFrontmatter(content, filePath);
+  const body = stripFrontmatter(content);
+  const block = parseSignalBlock(body, filePath);
+  const slug = requireSlug(frontmatter.slug, "slug", filePath);
+  const title = requireString(frontmatter.title, "title", filePath);
+  const object = requireSlug(frontmatter.object, "object", filePath);
+  if (!SIGNAL_OBJECTS.has(object)) {
+    throw new AcrmError(
+      `invalid signal object in ${filePath}: ${object} (expected people or companies)`,
+      ERR.INVALID_INPUT,
+    );
+  }
+  const outputs = parseOutputs(block.outputs, filePath);
+  const prompt = body.replace(block.raw, "").trim();
+  if (!prompt) {
+    throw new AcrmError(
+      `signal ${slug} in ${filePath} is missing prompt instructions`,
+      ERR.INVALID_INPUT,
+    );
+  }
+  return {
+    slug,
+    title,
+    object_slug: object as SignalObjectSlug,
+    outputs,
+    prompt,
+    definition_hash: createHash("sha256").update(content).digest("hex"),
+    path: filePath,
+  };
+}
+
+function parseFrontmatter(content: string, filePath: string): Frontmatter {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) {
+    throw new AcrmError(
+      `signal file ${filePath} is missing frontmatter`,
+      ERR.INVALID_INPUT,
+    );
+  }
+  const result: Frontmatter = {};
+  for (const line of match[1]!.split(/\r?\n/)) {
+    const kv = line.match(/^([a-zA-Z_][a-zA-Z0-9_-]*):\s*(.*)$/);
+    if (!kv) continue;
+    let value = kv[2]!.trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    result[kv[1]!] = value;
+  }
+  return result;
+}
+
+function stripFrontmatter(content: string): string {
+  return content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "");
+}
+
+function parseSignalBlock(
+  body: string,
+  filePath: string,
+): { raw: string; outputs: unknown } {
+  const match = body.match(/```json\s+acrm-signal\s*\r?\n([\s\S]*?)\r?\n```/);
+  if (!match) {
+    throw new AcrmError(
+      `signal file ${filePath} is missing a \`\`\`json acrm-signal fenced block`,
+      ERR.INVALID_INPUT,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(match[1]!);
+  } catch (e) {
+    throw new AcrmError(
+      `invalid acrm-signal JSON in ${filePath}: ${e instanceof Error ? e.message : String(e)}`,
+      ERR.INVALID_INPUT,
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new AcrmError(
+      `invalid acrm-signal block in ${filePath}: expected object`,
+      ERR.INVALID_INPUT,
+    );
+  }
+  return {
+    raw: match[0],
+    outputs: (parsed as Record<string, unknown>).outputs,
+  };
+}
+
+function parseOutputs(value: unknown, filePath: string): SignalOutputDefinition[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new AcrmError(
+      `signal file ${filePath} must declare at least one output`,
+      ERR.INVALID_INPUT,
+    );
+  }
+  const seenKeys = new Set<string>();
+  const seenAttrs = new Set<string>();
+  return value.map((raw, index) => {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      throw new AcrmError(
+        `invalid output #${index + 1} in ${filePath}: expected object`,
+        ERR.INVALID_INPUT,
+      );
+    }
+    const item = raw as Record<string, unknown>;
+    const key = requireSlug(asString(item.key), "output.key", filePath);
+    const attribute = requireSlug(
+      asString(item.attribute),
+      "output.attribute",
+      filePath,
+    );
+    const title = requireString(asString(item.title), "output.title", filePath);
+    const type = requireString(asString(item.type), "output.type", filePath);
+    if (!SUPPORTED_TYPES.has(type)) {
+      throw new AcrmError(
+        `invalid output type in ${filePath}: ${type}`,
+        ERR.INVALID_INPUT,
+      );
+    }
+    if (seenKeys.has(key)) {
+      throw new AcrmError(`duplicate output key in ${filePath}: ${key}`, ERR.INVALID_INPUT);
+    }
+    if (seenAttrs.has(attribute)) {
+      throw new AcrmError(
+        `duplicate output attribute in ${filePath}: ${attribute}`,
+        ERR.INVALID_INPUT,
+      );
+    }
+    seenKeys.add(key);
+    seenAttrs.add(attribute);
+    const output: SignalOutputDefinition = {
+      key,
+      attribute,
+      title,
+      type: type as SignalAttributeType,
+    };
+    const options = parseOptions(item.options, filePath, key, type);
+    if (options) output.options = options;
+    return output;
+  });
+}
+
+function parseOptions(
+  raw: unknown,
+  filePath: string,
+  key: string,
+  type: string,
+): SignalOption[] | undefined {
+  if (type !== "status" && type !== "select") {
+    if (raw !== undefined) {
+      throw new AcrmError(
+        `options are only valid for status/select output ${key} in ${filePath}`,
+        ERR.INVALID_INPUT,
+      );
+    }
+    return undefined;
+  }
+  if (!Array.isArray(raw) || raw.length === 0) {
+    throw new AcrmError(
+      `status/select output ${key} in ${filePath} requires options`,
+      ERR.INVALID_INPUT,
+    );
+  }
+  const seen = new Set<string>();
+  return raw.map((option) => {
+    let parsed: SignalOption;
+    if (typeof option === "string") {
+      const index = option.indexOf(":");
+      const id = (index < 0 ? option : option.slice(0, index)).trim();
+      const title = index < 0 ? titleCase(id) : option.slice(index + 1).trim();
+      parsed = { id, title: title || titleCase(id) };
+    } else if (option && typeof option === "object" && !Array.isArray(option)) {
+      const item = option as Record<string, unknown>;
+      parsed = {
+        id: requireSlug(asString(item.id), "option.id", filePath),
+        title: requireString(asString(item.title), "option.title", filePath),
+      };
+    } else {
+      throw new AcrmError(
+        `invalid option for output ${key} in ${filePath}`,
+        ERR.INVALID_INPUT,
+      );
+    }
+    if (!SLUG_RE.test(parsed.id)) {
+      throw new AcrmError(
+        `invalid option id for output ${key} in ${filePath}: ${parsed.id}`,
+        ERR.INVALID_INPUT,
+      );
+    }
+    if (seen.has(parsed.id)) {
+      throw new AcrmError(
+        `duplicate option id for output ${key} in ${filePath}: ${parsed.id}`,
+        ERR.INVALID_INPUT,
+      );
+    }
+    seen.add(parsed.id);
+    return parsed;
+  });
+}
+
+function requireSlug(value: string | undefined, label: string, filePath: string): string {
+  const raw = requireString(value, label, filePath);
+  if (!SLUG_RE.test(raw)) {
+    throw new AcrmError(
+      `invalid ${label} in ${filePath}: ${raw}`,
+      ERR.INVALID_INPUT,
+    );
+  }
+  return raw;
+}
+
+function requireString(
+  value: string | undefined,
+  label: string,
+  filePath: string,
+): string {
+  if (!value || !value.trim()) {
+    throw new AcrmError(`missing ${label} in ${filePath}`, ERR.INVALID_INPUT);
+  }
+  return value.trim();
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function titleCase(slug: string): string {
+  return slug
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part[0]!.toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function configForOutput(output: SignalOutputDefinition): AttributeConfig | null {
+  if (output.type !== "status" && output.type !== "select") return null;
+  return { options: output.options ?? [] };
+}
+
+async function ensureOptions(
+  workspace: Workspace,
+  object_slug: SignalObjectSlug,
+  output: SignalOutputDefinition,
+  currentConfig: AttributeConfig | undefined,
+): Promise<string[]> {
+  if (output.type !== "status" && output.type !== "select") return [];
+  const desired = output.options ?? [];
+  const current = Array.isArray(currentConfig?.options)
+    ? (currentConfig.options as SignalOption[])
+    : [];
+  const currentIds = new Set(current.map((option) => option.id));
+  const missing = desired.filter((option) => !currentIds.has(option.id));
+  if (missing.length === 0) return [];
+  const nextConfig = {
+    ...(currentConfig ?? {}),
+    options: [...current, ...missing],
+  };
+  await exec(
+    workspace.lix,
+    "UPDATE acrm_attribute SET config_json = $1 WHERE object_slug = $2 AND attribute_slug = $3",
+    [JSON.stringify(nextConfig), object_slug, output.attribute],
+  );
+  return missing.map((option) => option.id);
+}
+
+async function changeSignalAttributeType(
+  workspace: Workspace,
+  definition: SignalDefinition,
+  output: SignalOutputDefinition,
+  currentType: AttributeType,
+): Promise<void> {
+  const signalSource = `signal:${definition.slug}`;
+  const active = await exec(
+    workspace.lix,
+    `SELECT source
+       FROM acrm_value
+      WHERE object_slug = $1
+        AND attribute_slug = $2
+        AND active_until IS NULL`,
+    [definition.object_slug, output.attribute],
+  );
+  const hasUserValues = active.rows.some((row) => row.source !== signalSource);
+  if (hasUserValues) {
+    throw new AcrmError(
+      `signal ${definition.slug} output ${output.key} wants ${definition.object_slug}.${output.attribute} to be ${output.type}, but it is ${currentType} and has non-signal values`,
+      ERR.INVALID_INPUT,
+    );
+  }
+
+  const now = nowIso();
+  await exec(
+    workspace.lix,
+    `UPDATE acrm_value
+        SET active_until = $1
+      WHERE object_slug = $2
+        AND attribute_slug = $3
+        AND source = $4
+        AND active_until IS NULL`,
+    [now, definition.object_slug, output.attribute, signalSource],
+  );
+  await exec(
+    workspace.lix,
+    `UPDATE acrm_attribute
+        SET title = $1,
+            attribute_type = $2,
+            config_json = $3
+      WHERE object_slug = $4
+        AND attribute_slug = $5`,
+    [
+      output.title,
+      output.type,
+      configForOutput(output) ? JSON.stringify(configForOutput(output)) : null,
+      definition.object_slug,
+      output.attribute,
+    ],
+  );
+}
+
+async function retireRemovedSignalValues(
+  workspace: Workspace,
+  definition: SignalDefinition,
+): Promise<string[]> {
+  const desired = new Set(definition.outputs.map((output) => output.attribute));
+  const signalSource = `signal:${definition.slug}`;
+  const active = await exec(
+    workspace.lix,
+    `SELECT DISTINCT attribute_slug
+       FROM acrm_value
+      WHERE object_slug = $1
+        AND source = $2
+        AND active_until IS NULL`,
+    [definition.object_slug, signalSource],
+  );
+  const removed = active.rows
+    .map((row) => String(row.attribute_slug))
+    .filter((attribute_slug) => !desired.has(attribute_slug));
+  if (removed.length === 0) return [];
+
+  const placeholders = removed.map((_, index) => `$${index + 4}`).join(", ");
+  await exec(
+    workspace.lix,
+    `UPDATE acrm_value
+        SET active_until = $1
+      WHERE object_slug = $2
+        AND source = $3
+        AND active_until IS NULL
+        AND attribute_slug IN (${placeholders})`,
+    [nowIso(), definition.object_slug, signalSource, ...removed],
+  );
+  return removed;
+}
+
+function filterDefinitions(
+  definitions: SignalDefinition[],
+  args: SignalRunArgs,
+): SignalDefinition[] {
+  const slugs = args.signalSlugs ? new Set(args.signalSlugs) : null;
+  return definitions.filter((definition) => {
+    if (slugs && !slugs.has(definition.slug)) return false;
+    if (args.object_slug && definition.object_slug !== args.object_slug) return false;
+    return true;
+  });
+}
+
+async function selectRecords(
+  workspace: Workspace,
+  definitions: SignalDefinition[],
+  args: SignalRunArgs,
+): Promise<SignalRecordRef[]> {
+  if (args.records) {
+    return uniqueRecords(
+      args.records.filter((record) => {
+        if (args.object_slug && record.object_slug !== args.object_slug) return false;
+        return SIGNAL_OBJECTS.has(record.object_slug);
+      }),
+    );
+  }
+  if (args.record_ids && args.record_ids.length > 0) {
+    if (!args.object_slug) {
+      throw new AcrmError(
+        "object_slug is required when selecting signal records by record_id",
+        ERR.INVALID_INPUT,
+      );
+    }
+    return uniqueRecords(
+      args.record_ids.map((record_id) => ({
+        object_slug: args.object_slug!,
+        record_id,
+      })),
+    );
+  }
+
+  const objects = new Set(definitions.map((definition) => definition.object_slug));
+  const records: SignalRecordRef[] = [];
+  for (const object_slug of objects) {
+    const r = await exec(
+      workspace.lix,
+      "SELECT record_id FROM acrm_record WHERE object_slug = $1 ORDER BY record_id DESC",
+      [object_slug],
+    );
+    for (const row of r.rows) {
+      records.push({
+        object_slug,
+        record_id: String(row.record_id),
+      });
+    }
+  }
+  return records;
+}
+
+function uniqueRecords(records: SignalRecordRef[]): SignalRecordRef[] {
+  const seen = new Set<string>();
+  const out: SignalRecordRef[] = [];
+  for (const record of records) {
+    const key = `${record.object_slug}:${record.record_id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(record);
+  }
+  return out;
+}
+
+async function activeAttributesForOutputs(
+  workspace: Workspace,
+  record: SignalRecordRef,
+  outputs: SignalOutputDefinition[],
+): Promise<Set<string>> {
+  if (outputs.length === 0) return new Set();
+  const placeholders = outputs.map((_, index) => `$${index + 3}`).join(", ");
+  const r = await exec(
+    workspace.lix,
+    `SELECT attribute_slug
+       FROM acrm_value
+      WHERE object_slug = $1
+        AND record_id = $2
+        AND active_until IS NULL
+        AND attribute_slug IN (${placeholders})
+      ORDER BY active_from DESC`,
+    [record.object_slug, record.record_id, ...outputs.map((output) => output.attribute)],
+  );
+  const active = new Set<string>();
+  for (const row of r.rows) {
+    const attr = String(row.attribute_slug);
+    active.add(attr);
+  }
+  return active;
+}
+
+function requestedOutputs(
+  definition: SignalDefinition,
+  active: Set<string>,
+  mode: SignalRunMode,
+): SignalOutputDefinition[] {
+  if (mode === "force") return definition.outputs;
+  return definition.outputs.filter((output) => !active.has(output.attribute));
+}
+
+async function runOneSignal(
+  workspace: Workspace,
+  definition: SignalDefinition,
+  record: SignalRecordRef,
+  requested: SignalOutputDefinition[],
+  runner: SignalRunner,
+): Promise<number> {
+  const recordContext = await loadRecordContext(workspace, record);
+  const prompt = buildRunnerPrompt(definition, record, requested, recordContext);
+  const raw = await runner(prompt, {
+    signal: definition,
+    record,
+    requested_outputs: requested.map((output) => output.key),
+  });
+  let outputs: ParsedRunnerOutput[];
+  try {
+    outputs = parseRunnerResponse(raw, definition);
+    validateRunnerOutputs(outputs, definition);
+  } catch (e) {
+    throw new SignalRunnerOutputError(e, raw);
+  }
+  const requestedKeys = new Set(requested.map((output) => output.key));
+  const outputByKey = new Map(definition.outputs.map((output) => [output.key, output]));
+  const ran_at = nowIso();
+  let written = 0;
+
+  for (const output of outputs) {
+    if (!requestedKeys.has(output.key)) continue;
+    const definitionOutput = outputByKey.get(output.key)!;
+    await setSingleValue(workspace.lix, {
+      object_slug: definition.object_slug,
+      record_id: record.record_id,
+      attribute_slug: definitionOutput.attribute,
+      attribute_type: definitionOutput.type,
+      value: output.value,
+      source: `signal:${definition.slug}`,
+      provenance: {
+        signal_slug: definition.slug,
+        output_key: output.key,
+        ran_at,
+        definition_hash: definition.definition_hash,
+        confidence: output.confidence,
+        citations: output.citations,
+        reasoning: output.reasoning,
+        ...(output.notes ? { notes: output.notes } : {}),
+        uncited: output.citations.length === 0,
+      },
+    });
+    written++;
+  }
+  return written;
+}
+
+async function loadRecordContext(
+  workspace: Workspace,
+  record: SignalRecordRef,
+): Promise<RecordContextValue[]> {
+  const r = await exec(
+    workspace.lix,
+    `SELECT v.attribute_slug, v.value_json, a.title, a.attribute_type
+       FROM acrm_value v
+       JOIN acrm_attribute a
+         ON a.object_slug = v.object_slug
+        AND a.attribute_slug = v.attribute_slug
+      WHERE v.object_slug = $1
+        AND v.record_id = $2
+        AND v.active_until IS NULL
+      ORDER BY v.attribute_slug, v.active_from DESC`,
+    [record.object_slug, record.record_id],
+  );
+  return r.rows.map((row) => ({
+    attribute_slug: String(row.attribute_slug),
+    title: String(row.title ?? row.attribute_slug),
+    type: String(row.attribute_type),
+    value: parseJson(row.value_json),
+  }));
+}
+
+function buildRunnerPrompt(
+  definition: SignalDefinition,
+  record: SignalRecordRef,
+  requested: SignalOutputDefinition[],
+  recordContext: RecordContextValue[],
+): string {
+  return `You are filling an Agent CRM local signal.
+
+Signal:
+${JSON.stringify(
+  {
+    slug: definition.slug,
+    title: definition.title,
+    object: definition.object_slug,
+  },
+  null,
+  2,
+)}
+
+Record:
+${JSON.stringify({ ...record, values: recordContext }, null, 2)}
+
+Requested outputs:
+${JSON.stringify(
+  requested.map((output) => ({
+    key: output.key,
+    attribute: output.attribute,
+    title: output.title,
+    type: output.type,
+    options: output.options,
+  })),
+  null,
+  2,
+)}
+
+Value type rules:
+${requested.map(outputTypeRule).join("\n")}
+
+Instructions:
+${definition.prompt}
+
+Return ONLY one valid JSON object with this exact shape:
+{
+  "outputs": [
+    {
+      "key": "<one requested key>",
+      "value": "<typed value>",
+      "confidence": "low|medium|high",
+      "citations": [{"url":"https://...", "title":"...", "quote":"short supporting quote"}],
+      "reasoning": "Concise public rationale for why this value is supported.",
+      "notes": "Optional extra context."
+    }
+  ]
+}
+
+Rules:
+- Output must be raw JSON parseable by JSON.parse. No prose, markdown, code fences, comments, or trailing commas.
+- Every returned output.key must exactly match one requested key.
+- Every returned output.value must match that key's declared type rule above.
+- confidence must be exactly one of: "low", "medium", "high".
+- Use WebSearch to discover public sources and WebFetch to verify pages before citing them.
+- Never cite training data, memory, inferred page contents, or a URL you did not fetch or otherwise verify in this run.
+- Do not include hidden chain-of-thought; reasoning must be a concise auditable explanation.
+- Return no output for a key when the evidence is too weak to choose a value.
+- Citations may be empty only when no source is available; uncited values will be marked in CRM provenance.
+- Do not invent records, companies, people, or outreach channels.`;
+}
+
+function outputTypeRule(output: SignalOutputDefinition): string {
+  const prefix = `- ${output.key} (${output.type}):`;
+  switch (output.type) {
+    case "text":
+      return `${prefix} value must be a non-empty JSON string.`;
+    case "number":
+      return `${prefix} value must be a finite JSON number, not a quoted string.`;
+    case "url":
+      return `${prefix} value must be a non-empty absolute http(s) URL string.`;
+    case "date":
+      return `${prefix} value must be a string in YYYY-MM-DD format.`;
+    case "timestamp":
+      return `${prefix} value must be an ISO-8601 timestamp string with timezone, e.g. 2026-05-20T14:30:00Z.`;
+    case "status":
+    case "select":
+      return `${prefix} value must be one of these option ids as a JSON string: ${(output.options ?? []).map((option) => option.id).join(", ")}.`;
+  }
+}
+
+function parseRunnerResponse(
+  raw: string,
+  definition: SignalDefinition,
+): ParsedRunnerOutput[] {
+  const parsed = parseRunnerPayload(raw);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new AcrmError(
+      `signal ${definition.slug} returned invalid JSON object. Output excerpt: ${outputExcerpt(raw)}`,
+      ERR.INVALID_INPUT,
+    );
+  }
+  const outputs = (parsed as Record<string, unknown>).outputs;
+  if (!Array.isArray(outputs)) {
+    throw new AcrmError(
+      `signal ${definition.slug} response missing outputs[]`,
+      ERR.INVALID_INPUT,
+    );
+  }
+  return outputs.map((rawOutput, index) => {
+    if (!rawOutput || typeof rawOutput !== "object" || Array.isArray(rawOutput)) {
+      throw new AcrmError(
+        `signal ${definition.slug} output #${index + 1} is not an object`,
+        ERR.INVALID_INPUT,
+      );
+    }
+    const item = rawOutput as Record<string, unknown>;
+    const key = typeof item.key === "string" ? item.key : "";
+    const confidence = typeof item.confidence === "string" ? item.confidence.trim() : "";
+    const reasoning = typeof item.reasoning === "string" ? item.reasoning.trim() : "";
+    if (!key || !reasoning) {
+      throw new AcrmError(
+        `signal ${definition.slug} output #${index + 1} requires key and reasoning`,
+        ERR.INVALID_INPUT,
+      );
+    }
+    if (!isConfidence(confidence)) {
+      throw new AcrmError(
+        `signal ${definition.slug} output ${key} has invalid confidence: ${String(item.confidence)} (expected low, medium, or high)`,
+        ERR.INVALID_INPUT,
+      );
+    }
+    if (!("value" in item) || item.value === null || item.value === undefined || item.value === "") {
+      throw new AcrmError(
+        `signal ${definition.slug} output ${key} is missing value`,
+        ERR.INVALID_INPUT,
+      );
+    }
+    return {
+      key,
+      value: item.value,
+      confidence,
+      citations: normalizeCitations(item.citations),
+      reasoning,
+      ...(typeof item.notes === "string" && item.notes.trim()
+        ? { notes: item.notes.trim() }
+        : {}),
+    };
+  });
+}
+
+function parseRunnerPayload(raw: string): unknown {
+  const streamResult = parseClaudeStreamResult(raw);
+  if (streamResult !== undefined) return unwrapClaudeJson(streamResult);
+  return unwrapClaudeJson(parseJson(extractJson(raw)));
+}
+
+function parseClaudeStreamResult(raw: string): unknown {
+  const objects = stripAnsi(raw)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("{"))
+    .flatMap((line) => {
+      try {
+        return [JSON.parse(line) as unknown];
+      } catch {
+        return [];
+      }
+    });
+  if (objects.length < 2) return undefined;
+  for (const item of objects.slice().reverse()) {
+    if (item && typeof item === "object" && !Array.isArray(item)) {
+      const object = item as Record<string, unknown>;
+      if (object.type === "result") return object;
+    }
+  }
+  return undefined;
+}
+
+function unwrapClaudeJson(parsed: unknown): unknown {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return parsed;
+  const item = parsed as Record<string, unknown>;
+  if (item.structured_output !== undefined) return item.structured_output;
+  if (typeof item.result === "string") {
+    return parseJson(extractJson(item.result));
+  }
+  return parsed;
+}
+
+function validateRunnerOutputs(
+  outputs: ParsedRunnerOutput[],
+  definition: SignalDefinition,
+): void {
+  const byKey = new Map(definition.outputs.map((output) => [output.key, output]));
+  for (const output of outputs) {
+    const defined = byKey.get(output.key);
+    if (!defined) {
+      throw new AcrmError(
+        `signal ${definition.slug} returned unknown output key: ${output.key}`,
+        ERR.INVALID_INPUT,
+      );
+    }
+    validateOutputValue(output, defined, definition.slug);
+  }
+}
+
+function validateOutputValue(
+  output: ParsedRunnerOutput,
+  definitionOutput: SignalOutputDefinition,
+  signalSlug: string,
+): void {
+  const failType = (expected: string): never => {
+    throw new AcrmError(
+      `signal ${signalSlug} returned invalid ${definitionOutput.type} value for ${output.key}: ${String(output.value)} (expected ${expected})`,
+      ERR.INVALID_INPUT,
+    );
+  };
+  switch (definitionOutput.type) {
+    case "text":
+      if (typeof output.value !== "string" || !output.value.trim()) {
+        failType("a non-empty string");
+      }
+      return;
+    case "number":
+      if (typeof output.value !== "number" || !Number.isFinite(output.value)) {
+        failType("a finite JSON number");
+      }
+      return;
+    case "url":
+      if (typeof output.value !== "string" || !isHttpUrl(output.value)) {
+        failType("an absolute http(s) URL string");
+      }
+      return;
+    case "date":
+      if (typeof output.value !== "string" || !isIsoDate(output.value)) {
+        failType("YYYY-MM-DD");
+      }
+      return;
+    case "timestamp":
+      if (typeof output.value !== "string" || !isIsoTimestamp(output.value)) {
+        failType("an ISO-8601 timestamp string with timezone");
+      }
+      return;
+    case "status":
+    case "select": {
+      const raw = typeof output.value === "string" ? output.value : "";
+      const optionIds = new Set((definitionOutput.options ?? []).map((option) => option.id));
+      if (!raw || !optionIds.has(raw)) {
+        failType(`one of: ${(definitionOutput.options ?? []).map((option) => option.id).join(", ")}`);
+      }
+      return;
+    }
+  }
+}
+
+function isConfidence(value: string): boolean {
+  return value === "low" || value === "medium" || value === "high";
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value.trim());
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function isIsoDate(value: string): boolean {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
+}
+
+function isIsoTimestamp(value: string): boolean {
+  return (
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/.test(value) &&
+    Number.isFinite(Date.parse(value))
+  );
+}
+
+function extractJson(raw: string): string {
+  const trimmed = stripAnsi(raw).trim();
+  if (trimmed.startsWith("{")) return trimmed;
+  const fenced = trimmed.match(/```(?:json)?\s*\r?\n([\s\S]*?)\r?\n```/);
+  if (fenced) return fenced[1]!.trim();
+  const firstBrace = trimmed.indexOf("{");
+  const lastBrace = trimmed.lastIndexOf("}");
+  if (firstBrace >= 0 && lastBrace > firstBrace) {
+    return trimmed.slice(firstBrace, lastBrace + 1);
+  }
+  return trimmed;
+}
+
+function outputExcerpt(raw: string): string {
+  const text = stripAnsi(raw).replace(/\s+/g, " ").trim();
+  if (!text) return "(empty stdout)";
+  return JSON.stringify(text.length > 300 ? `${text.slice(0, 300)}…` : text);
+}
+
+function stripAnsi(raw: string): string {
+  return raw.replace(/\u001b\[[0-9;]*m/g, "");
+}
+
+function textExcerpt(raw: string, limit: number): string {
+  const text = stripAnsi(raw).replace(/\s+/g, " ").trim();
+  if (!text) return "";
+  return text.length > limit ? `${text.slice(0, limit)}…` : text;
+}
+
+function sanitizeRunnerOutputForLog(raw: string): string {
+  return stripAnsi(raw)
+    .split(/\r?\n/)
+    .flatMap((line) => {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("{")) return line ? [line] : [];
+      try {
+        const sanitized = sanitizeClaudeStreamObject(JSON.parse(trimmed) as unknown);
+        return sanitized ? [JSON.stringify(sanitized)] : [];
+      } catch {
+        return [line];
+      }
+    })
+    .join("\n");
+}
+
+function sanitizeRunnerOutputChunk(
+  previousRemainder: string,
+  chunk: string,
+): { text: string; remainder: string } {
+  const combined = previousRemainder + chunk;
+  const lines = combined.split(/\n/);
+  const hasCompleteLine = combined.endsWith("\n");
+  const remainder = hasCompleteLine ? "" : (lines.pop() ?? "");
+  const complete = hasCompleteLine ? lines : lines;
+  const text = sanitizeRunnerOutputForLog(complete.join("\n"));
+  return {
+    text: text ? `${text}\n` : "",
+    remainder,
+  };
+}
+
+function sanitizeClaudeStreamObject(value: unknown): unknown | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+  const item = value as Record<string, unknown>;
+  if (item.type !== "assistant") return value;
+  const message = item.message;
+  if (!message || typeof message !== "object" || Array.isArray(message)) return value;
+  const messageObject = message as Record<string, unknown>;
+  const content = messageObject.content;
+  if (!Array.isArray(content)) return value;
+  const safeContent = content
+    .filter((block) => !isThinkingBlock(block))
+    .map((block) => stripSignature(block));
+  if (safeContent.length === 0) return null;
+  return {
+    ...item,
+    message: {
+      ...messageObject,
+      content: safeContent,
+    },
+  };
+}
+
+function isThinkingBlock(block: unknown): boolean {
+  if (!block || typeof block !== "object" || Array.isArray(block)) return false;
+  const type = (block as Record<string, unknown>).type;
+  return type === "thinking" || type === "redacted_thinking";
+}
+
+function stripSignature(block: unknown): unknown {
+  if (!block || typeof block !== "object" || Array.isArray(block)) return block;
+  const { signature: _signature, ...rest } = block as Record<string, unknown>;
+  return rest;
+}
+
+function teeRunnerChunk(chunk: string): void {
+  const logPath = process.env.ACRM_SIGNAL_LOG_PATH;
+  if (!logPath) {
+    process.stderr.write(chunk);
+    return;
+  }
+  try {
+    appendFileSync(logPath, chunk, "utf8");
+  } catch {
+    // Best-effort diagnostics should never fail the signal run itself.
+  }
+}
+
+class SignalRunnerProcessError extends Error {
+  stdout_excerpt?: string;
+  stderr_excerpt?: string;
+
+  constructor(message: string, stdout: string, stderr: string) {
+    super(message);
+    this.name = "SignalRunnerProcessError";
+    const stdoutExcerpt = textExcerpt(stdout, RUNNER_STDOUT_EXCERPT_CHARS);
+    if (stdoutExcerpt) this.stdout_excerpt = stdoutExcerpt;
+    const excerpt = textExcerpt(stderr, RUNNER_STDERR_EXCERPT_CHARS);
+    if (excerpt) this.stderr_excerpt = excerpt;
+  }
+}
+
+class SignalRunnerOutputError extends Error {
+  stdout_excerpt?: string;
+
+  constructor(error: unknown, stdout: string) {
+    super(error instanceof Error ? error.message : String(error));
+    this.name = error instanceof Error ? error.name : "SignalRunnerOutputError";
+    const excerpt = textExcerpt(sanitizeRunnerOutputForLog(stdout), RUNNER_STDOUT_EXCERPT_CHARS);
+    if (excerpt) this.stdout_excerpt = excerpt;
+  }
+}
+
+function signalFailureFromError(
+  error: unknown,
+): { message: string; stdout_excerpt?: string; stderr_excerpt?: string } {
+  const message = error instanceof Error ? error.message : String(error);
+  const stdout_excerpt =
+    error &&
+    typeof error === "object" &&
+    "stdout_excerpt" in error &&
+    typeof (error as { stdout_excerpt?: unknown }).stdout_excerpt === "string"
+      ? (error as { stdout_excerpt: string }).stdout_excerpt
+      : undefined;
+  const stderr_excerpt =
+    error &&
+    typeof error === "object" &&
+    "stderr_excerpt" in error &&
+    typeof (error as { stderr_excerpt?: unknown }).stderr_excerpt === "string"
+      ? (error as { stderr_excerpt: string }).stderr_excerpt
+      : undefined;
+  if (stdout_excerpt || stderr_excerpt) {
+    return {
+      message,
+      ...(stdout_excerpt ? { stdout_excerpt } : {}),
+      ...(stderr_excerpt ? { stderr_excerpt } : {}),
+    };
+  }
+  return { message };
+}
+
+function normalizeCitations(raw: unknown): unknown[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((citation) => {
+    if (typeof citation === "string") return citation.trim().length > 0;
+    return citation && typeof citation === "object" && !Array.isArray(citation);
+  });
+}
+
+function parseJson(raw: unknown): unknown {
+  if (typeof raw !== "string") return raw;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+async function defaultRunner(
+  prompt: string,
+  context: SignalRunnerContext,
+): Promise<string> {
+  const command = runnerCommandFromEnv();
+  if (!process.env.ACRM_SIGNAL_RUNNER) {
+    command.push(
+      "--json-schema",
+      JSON.stringify(signalResponseSchema(context.signal, context.requested_outputs)),
+    );
+  }
+  return runCommand([...command, prompt]);
+}
+
+function runnerCommandFromEnv(): string[] {
+  const raw = process.env.ACRM_SIGNAL_RUNNER;
+  if (!raw) {
+    return [
+      ...DEFAULT_RUNNER,
+      "--model",
+      signalRunsModelFromEnv(),
+    ];
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new AcrmError(
+      `ACRM_SIGNAL_RUNNER must be a JSON string array: ${e instanceof Error ? e.message : String(e)}`,
+      ERR.INVALID_INPUT,
+    );
+  }
+  if (
+    !Array.isArray(parsed) ||
+    parsed.length === 0 ||
+    !parsed.every((part) => typeof part === "string" && part.length > 0)
+  ) {
+    throw new AcrmError(
+      "ACRM_SIGNAL_RUNNER must be a non-empty JSON string array",
+      ERR.INVALID_INPUT,
+    );
+  }
+  return parsed as string[];
+}
+
+function signalRunsModelFromEnv(): string {
+  const raw = process.env.SIGNAL_RUNS_MODEL?.trim();
+  return raw || DEFAULT_SIGNAL_RUNS_MODEL;
+}
+
+function signalResponseSchema(
+  definition: SignalDefinition,
+  requestedKeys: string[],
+): Record<string, unknown> {
+  const requested = new Set(requestedKeys);
+  const outputs = definition.outputs.filter((output) => requested.has(output.key));
+  return {
+    type: "object",
+    additionalProperties: false,
+    required: ["outputs"],
+    properties: {
+      outputs: {
+        type: "array",
+        items: {
+          anyOf: outputs.map((output) => outputSchema(output)),
+        },
+      },
+    },
+  };
+}
+
+function outputSchema(output: SignalOutputDefinition): Record<string, unknown> {
+  return {
+    type: "object",
+    additionalProperties: false,
+    required: ["key", "value", "confidence", "citations", "reasoning"],
+    properties: {
+      key: { enum: [output.key] },
+      value: valueSchema(output),
+      confidence: { enum: ["low", "medium", "high"] },
+      citations: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: true,
+          required: ["url"],
+          properties: {
+            url: { type: "string", minLength: 1 },
+            title: { type: "string" },
+            quote: { type: "string" },
+          },
+        },
+      },
+      reasoning: { type: "string", minLength: 1 },
+      notes: { type: "string" },
+    },
+  };
+}
+
+function valueSchema(output: SignalOutputDefinition): Record<string, unknown> {
+  switch (output.type) {
+    case "number":
+      return { type: "number" };
+    case "url":
+      return { type: "string", pattern: "^https?://" };
+    case "date":
+      return { type: "string", pattern: "^\\d{4}-\\d{2}-\\d{2}$" };
+    case "timestamp":
+      return {
+        type: "string",
+        pattern: "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$",
+      };
+    case "status":
+    case "select":
+      return { enum: (output.options ?? []).map((option) => option.id) };
+    case "text":
+      return { type: "string", minLength: 1 };
+  }
+}
+
+async function runCommand(command: string[]): Promise<string> {
+  const [bin, ...args] = command;
+  if (!bin) throw new AcrmError("empty signal runner command", ERR.INVALID_INPUT);
+  return await new Promise((resolve, reject) => {
+    const child = spawn(bin, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      shell: false,
+      env: process.env,
+    });
+    let stdout = "";
+    let stdoutLog = "";
+    let stdoutLogRemainder = "";
+    let stderr = "";
+    const flushStdoutLog = () => {
+      const text = sanitizeRunnerOutputForLog(stdoutLogRemainder);
+      stdoutLogRemainder = "";
+      if (!text) return;
+      const line = `${text}\n`;
+      stdoutLog += line;
+      teeRunnerChunk(line);
+    };
+    const timer = setTimeout(() => {
+      flushStdoutLog();
+      child.kill();
+      reject(
+        new SignalRunnerProcessError(
+          `signal runner timed out after ${DEFAULT_RUNNER_TIMEOUT_MS}ms`,
+          stdoutLog,
+          stderr,
+        ),
+      );
+    }, DEFAULT_RUNNER_TIMEOUT_MS);
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+      const sanitized = sanitizeRunnerOutputChunk(stdoutLogRemainder, chunk);
+      stdoutLogRemainder = sanitized.remainder;
+      if (sanitized.text) {
+        stdoutLog += sanitized.text;
+        teeRunnerChunk(sanitized.text);
+      }
+    });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+      teeRunnerChunk(chunk);
+    });
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      flushStdoutLog();
+      reject(new SignalRunnerProcessError(error.message, stdoutLog, stderr));
+    });
+    child.on("exit", (code) => {
+      clearTimeout(timer);
+      flushStdoutLog();
+      if (code === 0) {
+        resolve(stdout);
+      } else {
+        reject(
+          new SignalRunnerProcessError(
+            `signal runner exited with code ${code}`,
+            stdoutLog,
+            stderr,
+          ),
+        );
+      }
+    });
+  });
+}
+
+async function runWithConcurrency(
+  tasks: Array<() => Promise<void>>,
+  concurrency: number,
+): Promise<void> {
+  let next = 0;
+  const workers = Array.from({ length: Math.max(1, concurrency) }, async () => {
+    while (next < tasks.length) {
+      const task = tasks[next++]!;
+      await task();
+    }
+  });
+  await Promise.all(workers);
+}
+
+function normalizePositiveInt(value: unknown, fallback: number): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n) || n < 1) return fallback;
+  return Math.floor(n);
+}


### PR DESCRIPTION
## Summary
- Adds local multi-output signal definitions from `<workspace>/signals/*.md` with `acrm signals list|sync|run`.
- Runs one local Claude research task per record/signal bundle and writes each output into normal `acrm_value` rows with per-field provenance.
- Starts missing-only signal jobs after CSV, LinkedIn, X, and post imports, with background logs/job state in `.cache/signals`.
- Adds the `hotel_contact_path` company-level example signal and caps import-triggered signal records at 1,000 with a TODO for manifest-based scaling.
- Adds bundled `create-signals` skill so agents know how to author, sync, run, and verify signal definitions.
- Adds a Changeset for publishing the SDK patch + CLI minor release needed by the companion app PR.

## Notes
- Default runner is `claude -p --output-format stream-json --verbose` with `WebSearch`/`WebFetch` allowed.
- `SIGNAL_RUNS_MODEL` controls the default `--model` value; `ACRM_SIGNAL_RUNNER` can still override the full command.
- Signal definitions themselves remain local files and are not stored in `.acrm`; synced attributes and signal values/provenance are stored in `.acrm`.

## Verification
- `npm run build`
- `npm test`
- `npm run build --workspace @agent-crm/cli`

## Screenshots

**Signals calculating**

<img src="https://cluster-software.s3.amazonaws.com/agent-crm/signals-pr-2026-05-20/zz_signals_calculating.png" width="50%" />

**Sources + reasoning popover**

<img src="https://cluster-software.s3.amazonaws.com/agent-crm/signals-pr-2026-05-20/zz_sources.png" width="50%" />

**Failed signal rerun**

<img src="https://cluster-software.s3.amazonaws.com/agent-crm/signals-pr-2026-05-20/zz_failed.png" width="50%" />

**Signals settings**

<img src="https://cluster-software.s3.amazonaws.com/agent-crm/signals-pr-2026-05-20/zz_signals_settings.png" width="50%" />


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add local multi-output signals with background runs and per-field provenance to the CLI
> - Adds a new `signals` CLI command group with `list`, `sync`, and `run` subcommands in [signals.ts](https://github.com/cluster-software/agent-crm/pull/97/files#diff-070eb43179a337dafdca156bd389dc508f97f34e7210ca38d53fc7a0a0e81f6f); `signals run` supports filtering by slug/object/record IDs, missing-only or force modes, and concurrency controls.
> - Implements the full signal execution framework in [signals.ts](https://github.com/cluster-software/agent-crm/pull/97/files#diff-4a6b884b7d3a5ff8345c1e80d1ca4da085014abed9bd52ca2e9521994da3cd0e): parses Markdown signal definitions, syncs CRM attributes, invokes an external LLM runner (default: Claude), validates structured outputs, and writes values with per-field provenance (confidence, citations, reasoning).
> - `import csv`, `import linkedin`, `import post`, and `import x` commands now accept `--no-signals`; by default they trigger background signal runs for touched records via detached child processes, returning `signals_background` and `signals_warning` fields in JSON output.
> - Background signal jobs are managed by [signals.ts](https://github.com/cluster-software/agent-crm/pull/97/files#diff-c53c01560f408a271561da0035fda06065e97a4e1202e57461dd3d075ffeafa0): records are deduplicated, capped at 1000, grouped by object, spawned as detached processes with log files under `.cache/signals`, and tracked with persisted job state via [signal-jobs.ts](https://github.com/cluster-software/agent-crm/pull/97/files#diff-f6cafd403d368a0913679d398231795a2b9515bd8e109bb7ced54430198d9861).
> - `importCsv` in [import-csv.ts](https://github.com/cluster-software/agent-crm/pull/97/files#diff-2b9f23217756a85b688b5b20c1f5e89ee0693ffb6e5e92f0fe5673d2e83a7f07) now processes rows in parallel (default concurrency 10, configurable via `ACRM_IMPORT_CONCURRENCY`) with per-identifier keyed locking to prevent races, and returns `touched_records` for downstream signal triggering.
> - Risk: concurrent CSV import with mutex-based locking is a significant behavioral change to `WriteBatcher`; any caller relying on synchronous enqueue ordering should verify compatibility.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ae2900.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->