### PR TITLE
Add /acrm-onboarding skill and `acrm import gmail`

### DIFF
--- a/.changeset/acrm-onboarding-skill.md
+++ b/.changeset/acrm-onboarding-skill.md
@@ -1,0 +1,27 @@
+---
+"@agent-crm/cli": minor
+"@agent-crm/sdk": minor
+---
+
+Add `/acrm-onboarding` skill and `acrm import gmail` command.
+
+New users can now run `/acrm-onboarding` and pick a data source (Gmail / CSV /
+LinkedIn or X profile) to populate a fresh workspace. The Gmail path shells
+out to the [`gws` CLI](https://github.com/googleworkspace/cli), pulls People
+API `connections` plus auto-created `otherContacts` (every email
+correspondent Google has saved), and upserts them as `people` + `companies`
+deduped by email and email-domain — matching `acrm import csv` semantics.
+
+acrm ships with its own bundled Google OAuth Desktop client, so the end-user
+flow is just `npm install -g @googleworkspace/cli` + `acrm import gmail` →
+one browser pop-up to consent → done. No GCP project, no gcloud install, no
+Cloud Console clicks. Power users who prefer their own OAuth client can set
+`ACRM_GOOGLE_CLIENT_ID` + `ACRM_GOOGLE_CLIENT_SECRET` to override.
+
+- SDK: `importGoogleContacts(workspace, { contacts, default_country? })`
+  accepts an iterable of `GoogleContact` and upserts via the existing dedup
+  cascade. New `resolveGoogleClientCredentials()` + `buildClientSecretJson()`
+  helpers expose the bundled OAuth client (with env-var override).
+- CLI: `acrm import gmail [--no-other-contacts] [--default-country <iso>]`.
+  Auto-bootstraps `~/.config/gws/client_secret.json` on first run, then
+  drives `gws auth login -s people` itself if not authed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3547,10 +3547,10 @@
     },
     "packages/cli": {
       "name": "@agent-crm/cli",
-      "version": "0.14.0",
+      "version": "0.15.2",
       "hasInstallScript": true,
       "dependencies": {
-        "@agent-crm/sdk": "0.3.0",
+        "@agent-crm/sdk": "0.4.0",
         "@lix-js/sdk": "0.6.0-preview.3",
         "better-sqlite3": "^12.9.0",
         "commander": "^12.1.0"
@@ -3564,7 +3564,7 @@
     },
     "packages/sdk": {
       "name": "@agent-crm/sdk",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@lix-js/sdk": "0.6.0-preview.3",
         "better-sqlite3": "^12.9.0",

--- a/packages/cli/skills/acrm-onboarding.md
+++ b/packages/cli/skills/acrm-onboarding.md
@@ -1,0 +1,154 @@
+---
+name: acrm-onboarding
+description: Onboard a new Agent CRM user — initialize a `.acrm` workspace (if needed), then walk them through picking a first data source (Gmail / CSV / LinkedIn or X profile) and importing it. Trigger phrasings — "onboard me", "set up agent crm", "get started with acrm", "I'm new to acrm", or a bare `/acrm-onboarding`.
+---
+
+# acrm-onboarding
+
+The first-run flow for Agent CRM. Goal: in one conversation, take a user from "nothing" to "populated `.acrm` with their real contacts" so the rest of the skills (`/prep-call`, `/follow-up`, `/post-call`) have something to chew on.
+
+## Run
+
+### 1. Greet + workspace check
+
+Say:
+
+> Welcome to Agent CRM — the headless CRM for Claude. Let's get you set up.
+
+Then check whether a workspace already exists in this directory:
+
+```sh
+acrm execute "SELECT 1" --json
+```
+
+- If that succeeds, you're already inside a workspace — skip to step 2.
+- If it fails with `ACRM_ERROR_NO_WORKSPACE`, ask the user what to name their workspace (default: `pipeline.acrm`) and run:
+
+  ```sh
+  acrm init <name>.acrm
+  ```
+
+### 2. Pick a data source
+
+Use `AskUserQuestion` with this exact question and options (single-select, multipleChoice off):
+
+- **Question**: `What data source do you want to plug into?`
+- **Options**:
+  1. `Sync from Gmail` — pulls Google contacts (My Contacts + everyone you've ever emailed)
+  2. `Import a leads CSV` — load a file of leads
+  3. `Import a LinkedIn or X profile` — add one person at a time from a profile URL
+
+### 3. Run the branch they chose
+
+#### 3a. Gmail
+
+Powered by the [`gws` CLI](https://github.com/googleworkspace/cli). acrm
+ships with its own bundled Google OAuth client, so the user does **not**
+need a GCP project, does **not** need `gcloud`, and does **not** need to
+touch the Cloud Console. The flow is:
+
+1. Make sure `gws` is installed (one `npm install -g`).
+2. Run `acrm import gmail`.
+3. A browser opens; user clicks **Allow** to consent to acrm reading their
+   Google contacts.
+4. Import runs.
+
+##### Preflight
+
+```sh
+gws --version       # is the gws CLI installed?
+```
+
+##### A — Install `gws` (only if the preflight failed)
+
+```sh
+! npm install -g @googleworkspace/cli
+```
+
+##### B — Run the import
+
+```sh
+! acrm import gmail
+```
+
+The CLI handles everything:
+
+1. Writes acrm's bundled OAuth client into `~/.config/gws/client_secret.json`
+   on first run (idempotent — leaves an existing file alone).
+2. Probes `people.googleapis.com` to see if there's an active session.
+3. If not, spawns `gws auth login -s people`, which opens a browser for the
+   user to consent.
+4. Streams contacts from People API `connections` (the user's curated
+   address book) plus `otherContacts` (everyone Google has auto-saved
+   because the user emailed them) and upserts them as `people` +
+   `companies`, deduped by email and email-domain.
+
+JSON output reports counts:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "contacts_seen": 1247,
+    "people_created": 932,
+    "companies_created": 188,
+    "people_skipped_no_identifier": 127,
+    "included_other_contacts": true,
+    "duration_ms": 18421
+  }
+}
+```
+
+Pass `--no-other-contacts` for "My Contacts only" — skips the auto-saved
+bucket.
+
+##### Heads-ups
+
+- **"Google hasn't verified this app"** — until acrm completes Google's
+  OAuth verification, the consent screen shows this warning. Tell the user
+  to click **Continue → Allow**. One-time click; once we're verified, the
+  warning disappears.
+- **Bring-your-own OAuth client** — power users who'd rather use their own
+  GCP project can set `ACRM_GOOGLE_CLIENT_ID` + `ACRM_GOOGLE_CLIENT_SECRET`
+  in the environment. acrm uses those instead of the bundled credentials.
+
+#### 3b. CSV
+
+Ask the user for the path to the CSV. Then run:
+
+```sh
+acrm import csv <path>
+```
+
+If the user is in another country, pass `--default-country=<ISO>` (e.g. `GB`, `DE`) so locally-formatted phone numbers parse correctly. See `acrm import csv --help` for the full list of recognized column names.
+
+#### 3c. LinkedIn or X profile
+
+Ask the user for the URL (or `@handle` for X). Sniff the platform from the URL and run the right command:
+
+- LinkedIn profile URL (`linkedin.com/in/<slug>`) → `acrm import linkedin '<url>'`
+- X / Twitter profile (`x.com/<handle>`, `twitter.com/<handle>`, or bare `@handle`) → `acrm import x '<handle>'`
+
+Both require `APIFY_API_TOKEN` in `.env` next to the workspace. If missing, the CLI prints an exact fix — relay it to the user. After import, offer to add another profile (loop until they're done).
+
+### 4. Confirm + next step
+
+After the import succeeds, show a short summary tied to what they actually have:
+
+```sh
+acrm execute "SELECT object_slug, COUNT(*) AS n FROM acrm_record GROUP BY object_slug" --json
+```
+
+Then suggest the next concrete thing they can do, based on what got imported:
+
+- If `people` > 0 with at least one having a `linkedin_url`, suggest: `try /prep-call <name>` — pulls their LinkedIn and drafts discovery questions.
+- Recommend connecting a transcript provider so meetings flow in: `try /setup-transcripts` (enables `/post-call`).
+
+Keep the close short — one or two suggestions, not a feature dump.
+
+## Hard rules
+
+- **Never** fabricate a workspace path or skip the `acrm init` step. If no workspace exists, the user must explicitly name one.
+- **Never** silently run a destructive command. `acrm import gmail` is additive (idempotent upsert), so it's safe to re-run — say so if the user worries about duplicates.
+- **Don't** fabricate OAuth credentials or paper over auth errors. If `acrm import gmail` fails on OAuth, surface its exact `hint` field to the user — they own the consent flow.
+- **Don't** loop the AskUserQuestion. Pick one source per onboarding session — if they want to import another source after, they can re-invoke the skill or run the underlying command directly.

--- a/packages/cli/src/bin/acrm.ts
+++ b/packages/cli/src/bin/acrm.ts
@@ -9,6 +9,7 @@ import { registerImport, getOrCreateImportCommand } from "../commands/import.js"
 import { attachLinkedinSubcommand } from "../commands/import-linkedin.js";
 import { attachXSubcommand } from "../commands/import-x.js";
 import { attachPostSubcommand } from "../commands/import-post.js";
+import { attachGmailSubcommand } from "../commands/import-gmail.js";
 import { attachTranscriptSubcommand } from "../commands/import-transcript.js";
 import { registerSkills } from "../commands/skills.js";
 import { registerAuth } from "../commands/auth.js";
@@ -58,6 +59,7 @@ Data model:
 Typical flow:
   acrm init <name>.acrm           create a workspace
   acrm import csv ./leads.csv     load people + companies (and deals if columns present)
+  acrm import gmail               sync Google contacts via the gws CLI (https://github.com/googleworkspace/cli) — pulls People API connections + auto-created otherContacts
   acrm import linkedin <url>      add one person from a LinkedIn profile (creates person + company)
   acrm import x <handle>          add one person from an X/Twitter profile
   acrm import post <url>          add a LinkedIn or X **post** by URL — upserts the author as a person and stores the post (use when a user shares a post link they want to track)
@@ -112,6 +114,7 @@ registerImport(program);
 attachLinkedinSubcommand(getOrCreateImportCommand(program));
 attachXSubcommand(getOrCreateImportCommand(program));
 attachPostSubcommand(getOrCreateImportCommand(program));
+attachGmailSubcommand(getOrCreateImportCommand(program));
 attachTranscriptSubcommand(getOrCreateImportCommand(program));
 registerExecute(program);
 registerRecords(program);

--- a/packages/cli/src/commands/import-gmail.test.ts
+++ b/packages/cli/src/commands/import-gmail.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "vitest";
+import { openTestWorkspace } from "../test/open-test-lix.js";
+import {
+  exec,
+  importGoogleContacts,
+  Workspace,
+  type GoogleContact,
+} from "@agent-crm/sdk";
+
+async function rowsFor(
+  ws: Workspace,
+  object_slug: string,
+  attribute_slug: string,
+) {
+  const r = await exec(
+    ws.lix,
+    `SELECT record_id, normalized_key, value_json FROM acrm_value
+     WHERE object_slug = $1 AND attribute_slug = $2 AND active_until IS NULL
+     ORDER BY normalized_key`,
+    [object_slug, attribute_slug],
+  );
+  return r.rows.map((row) => ({
+    record_id: row.record_id as string,
+    normalized_key: (row.normalized_key as string | null) ?? null,
+    value_json: row.value_json,
+  }));
+}
+
+describe("importGoogleContacts", () => {
+  it("creates person + company from a connection with email + organization", async () => {
+    const lix = await openTestWorkspace();
+    const ws = Workspace.fromLix(lix);
+    const contacts: GoogleContact[] = [
+      {
+        resource_name: "people/c1",
+        origin: "connections",
+        display_name: "Jane Doe",
+        emails: ["jane@acme.com"],
+        organizations: [{ name: "Acme Corp", title: "VP Sales" }],
+      },
+    ];
+    const result = await importGoogleContacts(ws, { contacts });
+    expect(result.stats.people_created).toBe(1);
+    expect(result.stats.companies_created).toBe(1);
+    const emails = await rowsFor(ws, "people", "email_addresses");
+    expect(emails).toHaveLength(1);
+    expect(emails[0]?.normalized_key).toBe("jane@acme.com");
+    const domains = await rowsFor(ws, "companies", "domains");
+    expect(domains).toHaveLength(1);
+    expect(domains[0]?.normalized_key).toBe("acme.com");
+    const names = await rowsFor(ws, "people", "name");
+    expect(names).toHaveLength(1);
+    const titles = await rowsFor(ws, "people", "job_title");
+    expect(titles).toHaveLength(1);
+    await lix.close();
+  });
+
+  it("dedupes a contact that already exists via CSV by email", async () => {
+    const lix = await openTestWorkspace();
+    const ws = Workspace.fromLix(lix);
+    const first: GoogleContact[] = [
+      {
+        resource_name: "people/c1",
+        origin: "connections",
+        display_name: "Jane Doe",
+        emails: ["jane@acme.com"],
+      },
+    ];
+    await importGoogleContacts(ws, { contacts: first });
+    const result = await importGoogleContacts(ws, {
+      contacts: [
+        {
+          resource_name: "people/c1",
+          origin: "connections",
+          display_name: "Jane D.",
+          emails: ["jane@acme.com"],
+        },
+      ],
+    });
+    expect(result.stats.people_created).toBe(0);
+    const emails = await rowsFor(ws, "people", "email_addresses");
+    expect(emails).toHaveLength(1);
+    await lix.close();
+  });
+
+  it("skips a contact with only a display name (no identifier)", async () => {
+    const lix = await openTestWorkspace();
+    const ws = Workspace.fromLix(lix);
+    const result = await importGoogleContacts(ws, {
+      contacts: [
+        {
+          resource_name: "people/c-empty",
+          origin: "connections",
+          display_name: "Nameonly McNobody",
+        },
+      ],
+    });
+    expect(result.stats.people_created).toBe(0);
+    expect(result.stats.people_skipped_no_identifier).toBe(1);
+    await lix.close();
+  });
+
+  it("classifies linkedin + x URLs from the contact card", async () => {
+    const lix = await openTestWorkspace();
+    const ws = Workspace.fromLix(lix);
+    await importGoogleContacts(ws, {
+      contacts: [
+        {
+          resource_name: "people/c2",
+          origin: "connections",
+          display_name: "Linked Larry",
+          emails: ["larry@example.com"],
+          urls: [
+            "https://www.linkedin.com/in/larry",
+            "https://x.com/larry",
+            "https://example.com",
+          ],
+        },
+      ],
+    });
+    const li = await rowsFor(ws, "people", "linkedin_url");
+    expect(li).toHaveLength(1);
+    expect(li[0]?.normalized_key).toBe("linkedin.com/in/larry");
+    const x = await rowsFor(ws, "people", "twitter_url");
+    expect(x).toHaveLength(1);
+    expect(x[0]?.normalized_key).toBe("x.com/larry");
+    await lix.close();
+  });
+
+  it("links an existing person (matched by linkedin) to the company discovered on re-import", async () => {
+    const lix = await openTestWorkspace();
+    const ws = Workspace.fromLix(lix);
+
+    // First import: linkedin-only contact. No email → no company.
+    await importGoogleContacts(ws, {
+      contacts: [
+        {
+          resource_name: "people/linkedin-only",
+          origin: "connections",
+          display_name: "Jane Doe",
+          urls: ["https://www.linkedin.com/in/janedoe"],
+        },
+      ],
+    });
+    expect(
+      (await rowsFor(ws, "companies", "domains")).length,
+      "no company before second import",
+    ).toBe(0);
+    expect(
+      (await rowsFor(ws, "people", "company")).length,
+      "no person→company link before second import",
+    ).toBe(0);
+
+    // Second import: matches by linkedin URL. Now has email (→ company
+    // domain) and organization name. The existing person should gain a
+    // company ref even though personCreated === false.
+    const result = await importGoogleContacts(ws, {
+      contacts: [
+        {
+          resource_name: "people/enriched",
+          origin: "connections",
+          display_name: "Jane Doe",
+          emails: ["jane@acme.com"],
+          urls: ["https://www.linkedin.com/in/janedoe"],
+          organizations: [{ name: "Acme Corp", title: "VP Sales" }],
+        },
+      ],
+    });
+    expect(
+      result.stats.people_created,
+      "matched existing person via linkedin_url",
+    ).toBe(0);
+    expect(result.stats.companies_created).toBe(1);
+    const companyLinks = await rowsFor(ws, "people", "company");
+    expect(
+      companyLinks,
+      "fix: existing person now linked to the company",
+    ).toHaveLength(1);
+    await lix.close();
+  });
+
+  it("dedupes companies across two contacts that share a domain", async () => {
+    const lix = await openTestWorkspace();
+    const ws = Workspace.fromLix(lix);
+    const result = await importGoogleContacts(ws, {
+      contacts: [
+        {
+          resource_name: "people/c-a",
+          origin: "connections",
+          display_name: "Alice",
+          emails: ["alice@acme.com"],
+        },
+        {
+          resource_name: "people/c-b",
+          origin: "other_contacts",
+          display_name: "Bob",
+          emails: ["bob@acme.com"],
+        },
+      ],
+    });
+    expect(result.stats.people_created).toBe(2);
+    expect(result.stats.companies_created).toBe(1);
+    const domains = await rowsFor(ws, "companies", "domains");
+    expect(domains).toHaveLength(1);
+    expect(domains[0]?.normalized_key).toBe("acme.com");
+    await lix.close();
+  });
+});

--- a/packages/cli/src/commands/import-gmail.ts
+++ b/packages/cli/src/commands/import-gmail.ts
@@ -1,0 +1,128 @@
+import type { Command } from "commander";
+import {
+  AcrmError,
+  ERR,
+  Workspace,
+  importGoogleContacts,
+} from "@agent-crm/sdk";
+import { resolveWorkspacePath } from "../workspace-resolve.js";
+import { isJson, fail, ok, setJsonMode } from "../output/json.js";
+import {
+  checkGwsInstalled,
+  checkGwsAuthed,
+  streamGoogleContacts,
+} from "../lib/gws-contacts.js";
+import {
+  ensureBundledClientSecret,
+  runGwsAuthLogin,
+} from "../lib/gws-bootstrap.js";
+
+type Opts = {
+  otherContacts?: boolean; // commander negation: --no-other-contacts → false
+  defaultCountry?: string;
+};
+
+export function attachGmailSubcommand(parent: Command): void {
+  parent
+    .command("gmail")
+    .description(
+      "Sync Google contacts into the workspace via the `gws` CLI (https://github.com/googleworkspace/cli). Pulls People API connections by default, plus auto-created `otherContacts` (everyone you've ever emailed) unless --no-other-contacts is passed. Creates one person per primary email and one company per email domain (matching `import csv` dedup). Requires `gws` on PATH; handles OAuth bootstrap (writing the bundled client_secret.json and driving `gws auth login` if needed) on first run.",
+    )
+    .option(
+      "--no-other-contacts",
+      "skip the auto-created 'other contacts' bucket (My Contacts only)",
+    )
+    .option(
+      "--default-country <iso>",
+      "ISO country code (e.g. US, GB, DE) used to parse locally-formatted phone numbers into E.164",
+      "US",
+    )
+    .action(async (opts: Opts) => {
+      const root = parent.parent?.opts() as
+        | { workspace?: string; json?: boolean }
+        | undefined;
+      setJsonMode(root?.json);
+      let ws: Workspace | null = null;
+      try {
+        const workspaceFile = resolveWorkspacePath(root?.workspace);
+
+        // Step 1: gws binary must be on PATH.
+        const installed = await checkGwsInstalled();
+        if (!installed.ok) {
+          throw new AcrmError(
+            "the `gws` CLI is required to import from Gmail",
+            ERR.INVALID_INPUT,
+            "install it with:\n  npm install -g @googleworkspace/cli",
+          );
+        }
+
+        // Step 2: bundled OAuth client_secret.json — write it if missing so
+        // the user never has to create their own OAuth client.
+        const seeded = ensureBundledClientSecret();
+        if (seeded.wrote && !isJson()) {
+          process.stderr.write(
+            `wrote bundled OAuth client to ${seeded.path}\n`,
+          );
+        }
+
+        // Step 3: if not authed, drive `gws auth login -s people` ourselves
+        // so the user sees one browser pop-up rather than a CLI error.
+        const authed = await checkGwsAuthed();
+        if (!authed.ok) {
+          if (!isJson()) {
+            process.stderr.write(
+              `not authenticated with Google — opening browser for OAuth consent...\n`,
+            );
+          }
+          await runGwsAuthLogin();
+        }
+
+        ws = await Workspace.open(workspaceFile);
+
+        const includeOtherContacts = opts.otherContacts !== false;
+        const startedAt = Date.now();
+        const stderrTty = process.stderr.isTTY === true;
+        let lastTick = 0;
+
+        const stream = streamGoogleContacts({ includeOtherContacts });
+        const result = await importGoogleContacts(ws, {
+          contacts: stream,
+          default_country: opts.defaultCountry,
+          onProgress: ({ seen, stats }) => {
+            if (isJson()) return;
+            const now = Date.now();
+            if (now - lastTick < 250 && seen % 50 !== 0) return;
+            lastTick = now;
+            const line = `synced ${seen} contacts  (people: ${stats.people_created}, companies: ${stats.companies_created})`;
+            if (stderrTty) {
+              process.stderr.write(`\r${line}`);
+            } else {
+              process.stderr.write(`${line}\n`);
+            }
+          },
+        });
+
+        if (stderrTty && !isJson()) process.stderr.write("\n");
+
+        await ws.close();
+        ws = null;
+
+        ok({
+          ...result.stats,
+          duration_ms: Date.now() - startedAt,
+          included_other_contacts: includeOtherContacts,
+        });
+      } catch (e) {
+        if (ws) {
+          try {
+            await ws.close();
+          } catch {
+            // ignore
+          }
+        }
+        if (e instanceof AcrmError) fail(e.message, e.code, e.hint);
+        else fail(e instanceof Error ? e.message : String(e), ERR.IMPORT);
+        process.exit(1);
+      }
+    });
+}

--- a/packages/cli/src/lib/gws-bootstrap.test.ts
+++ b/packages/cli/src/lib/gws-bootstrap.test.ts
@@ -1,0 +1,61 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  ensureBundledClientSecret,
+  resolveGwsConfigDir,
+} from "./gws-bootstrap.js";
+
+describe("gws-bootstrap", () => {
+  let tmp: string;
+  const prevEnv = { ...process.env };
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "acrm-gws-bootstrap-"));
+    process.env.GOOGLE_WORKSPACE_CLI_CONFIG_DIR = tmp;
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    process.env = { ...prevEnv };
+  });
+
+  it("resolveGwsConfigDir honors GOOGLE_WORKSPACE_CLI_CONFIG_DIR", () => {
+    expect(resolveGwsConfigDir()).toBe(tmp);
+  });
+
+  it("ensureBundledClientSecret writes client_secret.json when missing (env-var creds)", () => {
+    process.env.ACRM_GOOGLE_CLIENT_ID = "test-client-id.apps.googleusercontent.com";
+    process.env.ACRM_GOOGLE_CLIENT_SECRET = "test-client-secret";
+    const result = ensureBundledClientSecret();
+    expect(result.wrote).toBe(true);
+    expect(result.path).toBe(join(tmp, "client_secret.json"));
+    const file = JSON.parse(readFileSync(result.path, "utf8")) as {
+      installed: { client_id: string; client_secret: string };
+    };
+    expect(file.installed.client_id).toBe(
+      "test-client-id.apps.googleusercontent.com",
+    );
+    expect(file.installed.client_secret).toBe("test-client-secret");
+  });
+
+  it("ensureBundledClientSecret leaves an existing file alone", () => {
+    const path = join(tmp, "client_secret.json");
+    const userSupplied = '{"installed":{"client_id":"user-owned","client_secret":"s"}}';
+    writeFileSync(path, userSupplied);
+    process.env.ACRM_GOOGLE_CLIENT_ID = "bundled";
+    process.env.ACRM_GOOGLE_CLIENT_SECRET = "bundled-secret";
+    const result = ensureBundledClientSecret();
+    expect(result.wrote).toBe(false);
+    expect(readFileSync(path, "utf8")).toBe(userSupplied);
+  });
+
+  it("ensureBundledClientSecret throws with a clear hint when no creds are available", () => {
+    delete process.env.ACRM_GOOGLE_CLIENT_ID;
+    delete process.env.ACRM_GOOGLE_CLIENT_SECRET;
+    expect(() => ensureBundledClientSecret()).toThrowError(
+      /no Google OAuth client available/i,
+    );
+  });
+});

--- a/packages/cli/src/lib/gws-bootstrap.test.ts
+++ b/packages/cli/src/lib/gws-bootstrap.test.ts
@@ -25,19 +25,42 @@ describe("gws-bootstrap", () => {
     expect(resolveGwsConfigDir()).toBe(tmp);
   });
 
-  it("ensureBundledClientSecret writes client_secret.json when missing (env-var creds)", () => {
+  it("ensureBundledClientSecret writes client_secret.json with env-var creds when set", () => {
     process.env.ACRM_GOOGLE_CLIENT_ID = "test-client-id.apps.googleusercontent.com";
     process.env.ACRM_GOOGLE_CLIENT_SECRET = "test-client-secret";
+    process.env.ACRM_GOOGLE_PROJECT_ID = "test-proj";
     const result = ensureBundledClientSecret();
     expect(result.wrote).toBe(true);
     expect(result.path).toBe(join(tmp, "client_secret.json"));
     const file = JSON.parse(readFileSync(result.path, "utf8")) as {
-      installed: { client_id: string; client_secret: string };
+      installed: {
+        client_id: string;
+        client_secret: string;
+        project_id: string;
+      };
     };
     expect(file.installed.client_id).toBe(
       "test-client-id.apps.googleusercontent.com",
     );
     expect(file.installed.client_secret).toBe("test-client-secret");
+    expect(file.installed.project_id).toBe("test-proj");
+  });
+
+  it("ensureBundledClientSecret falls back to bundled creds when env is unset", () => {
+    delete process.env.ACRM_GOOGLE_CLIENT_ID;
+    delete process.env.ACRM_GOOGLE_CLIENT_SECRET;
+    delete process.env.ACRM_GOOGLE_PROJECT_ID;
+    const result = ensureBundledClientSecret();
+    expect(result.wrote).toBe(true);
+    const file = JSON.parse(readFileSync(result.path, "utf8")) as {
+      installed: { client_id: string; project_id: string };
+    };
+    // The bundled GCP project for acrm's production OAuth client.
+    expect(file.installed.project_id).toBe("agent-crm-prod");
+    // Bundled client_id matches the value committed to source.
+    expect(file.installed.client_id).toMatch(
+      /^\d+-.+\.apps\.googleusercontent\.com$/,
+    );
   });
 
   it("ensureBundledClientSecret leaves an existing file alone", () => {
@@ -51,11 +74,14 @@ describe("gws-bootstrap", () => {
     expect(readFileSync(path, "utf8")).toBe(userSupplied);
   });
 
-  it("ensureBundledClientSecret throws with a clear hint when no creds are available", () => {
-    delete process.env.ACRM_GOOGLE_CLIENT_ID;
-    delete process.env.ACRM_GOOGLE_CLIENT_SECRET;
-    expect(() => ensureBundledClientSecret()).toThrowError(
-      /no Google OAuth client available/i,
-    );
+  it("ensureBundledClientSecret defaults project_id when env-var creds omit it", () => {
+    process.env.ACRM_GOOGLE_CLIENT_ID = "byo-id";
+    process.env.ACRM_GOOGLE_CLIENT_SECRET = "byo-secret";
+    delete process.env.ACRM_GOOGLE_PROJECT_ID;
+    const result = ensureBundledClientSecret();
+    const file = JSON.parse(readFileSync(result.path, "utf8")) as {
+      installed: { project_id: string };
+    };
+    expect(file.installed.project_id).toBe("user-supplied");
   });
 });

--- a/packages/cli/src/lib/gws-bootstrap.ts
+++ b/packages/cli/src/lib/gws-bootstrap.ts
@@ -42,8 +42,17 @@ export function ensureBundledClientSecret(): { wrote: boolean; path: string } {
   return { wrote: true, path };
 }
 
-// Drive `gws auth login -s people` ourselves so the user sees one browser
-// pop-up and that's it — no separate command for them to remember.
+// Scopes we request when driving the OAuth flow. These match what's
+// pre-approved on the consent screen of acrm's production OAuth client.
+// `-s` in gws is a SERVICE filter, not a scope list — use `--scopes` with
+// the full URLs.
+const PEOPLE_SCOPES = [
+  "https://www.googleapis.com/auth/contacts.readonly",
+  "https://www.googleapis.com/auth/contacts.other.readonly",
+].join(",");
+
+// Drive `gws auth login --scopes=...` ourselves so the user sees one
+// browser pop-up and that's it — no separate command for them to remember.
 //
 // gws prints status text ("Your browser has been opened…") to stdout. We
 // must not let that leak into acrm's stdout, because acrm reserves stdout
@@ -51,9 +60,13 @@ export function ensureBundledClientSecret(): { wrote: boolean; path: string } {
 // as malformed JSON. Route gws output to our stderr instead.
 export async function runGwsAuthLogin(): Promise<void> {
   await new Promise<void>((resolve, reject) => {
-    const child = spawn("gws", ["auth", "login", "-s", "people"], {
-      stdio: ["inherit", "pipe", "inherit"],
-    });
+    const child = spawn(
+      "gws",
+      ["auth", "login", "--scopes", PEOPLE_SCOPES],
+      {
+        stdio: ["inherit", "pipe", "inherit"],
+      },
+    );
     child.stdout?.on("data", (b: Buffer) => process.stderr.write(b));
     child.once("error", reject);
     child.once("close", (code) => {
@@ -63,7 +76,7 @@ export async function runGwsAuthLogin(): Promise<void> {
           new AcrmError(
             `gws auth login exited with code ${code}`,
             ERR.INVALID_INPUT,
-            "the browser-based OAuth flow did not complete. try running `gws auth login -s people` directly to see the full error.",
+            `the browser-based OAuth flow did not complete. try running \`gws auth login --scopes=${PEOPLE_SCOPES}\` directly to see the full error.`,
           ),
         );
     });

--- a/packages/cli/src/lib/gws-bootstrap.ts
+++ b/packages/cli/src/lib/gws-bootstrap.ts
@@ -1,0 +1,71 @@
+import { spawn } from "node:child_process";
+import { mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  AcrmError,
+  ERR,
+  buildClientSecretJson,
+  resolveGoogleClientCredentials,
+} from "@agent-crm/sdk";
+
+// Where gws stores its config — honors GOOGLE_WORKSPACE_CLI_CONFIG_DIR for
+// sandboxed test setups, otherwise the default ~/.config/gws.
+export function resolveGwsConfigDir(): string {
+  return process.env.GOOGLE_WORKSPACE_CLI_CONFIG_DIR || join(homedir(), ".config", "gws");
+}
+
+// Ensure ~/.config/gws/client_secret.json exists. We bundle acrm's own
+// OAuth client into the SDK so end users never have to create one. If a
+// client_secret.json is already present (user brought their own, or a prior
+// run wrote ours), leave it alone.
+export function ensureBundledClientSecret(): { wrote: boolean; path: string } {
+  const dir = resolveGwsConfigDir();
+  const path = join(dir, "client_secret.json");
+  if (existsSync(path)) return { wrote: false, path };
+
+  const creds = resolveGoogleClientCredentials();
+  if (!creds) {
+    throw new AcrmError(
+      "no Google OAuth client available",
+      ERR.INVALID_INPUT,
+      "this build of acrm was published without bundled OAuth credentials. set ACRM_GOOGLE_CLIENT_ID and ACRM_GOOGLE_CLIENT_SECRET in your environment to use your own, or upgrade acrm.",
+    );
+  }
+
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(
+    path,
+    JSON.stringify(buildClientSecretJson(creds), null, 2),
+    { mode: 0o600 },
+  );
+  return { wrote: true, path };
+}
+
+// Drive `gws auth login -s people` ourselves so the user sees one browser
+// pop-up and that's it — no separate command for them to remember.
+//
+// gws prints status text ("Your browser has been opened…") to stdout. We
+// must not let that leak into acrm's stdout, because acrm reserves stdout
+// for its own JSON output and downstream parsers see anything-else-on-stdout
+// as malformed JSON. Route gws output to our stderr instead.
+export async function runGwsAuthLogin(): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn("gws", ["auth", "login", "-s", "people"], {
+      stdio: ["inherit", "pipe", "inherit"],
+    });
+    child.stdout?.on("data", (b: Buffer) => process.stderr.write(b));
+    child.once("error", reject);
+    child.once("close", (code) => {
+      if (code === 0) resolve();
+      else
+        reject(
+          new AcrmError(
+            `gws auth login exited with code ${code}`,
+            ERR.INVALID_INPUT,
+            "the browser-based OAuth flow did not complete. try running `gws auth login -s people` directly to see the full error.",
+          ),
+        );
+    });
+  });
+}

--- a/packages/cli/src/lib/gws-contacts.test.ts
+++ b/packages/cli/src/lib/gws-contacts.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "vitest";
+import { __test } from "./gws-contacts.js";
+
+const { extractContacts, normalizePerson } = __test;
+
+// Fixtures mirror the shape Google's People API returns. They're the bits
+// of the response we actually consume — keep them realistic so a Google
+// API change shows up here first.
+
+describe("normalizePerson", () => {
+  it("returns null for non-object input", () => {
+    expect(normalizePerson(null, "connections")).toBeNull();
+    expect(normalizePerson("oops", "connections")).toBeNull();
+    expect(normalizePerson(123, "connections")).toBeNull();
+  });
+
+  it("returns null when resourceName is missing", () => {
+    expect(
+      normalizePerson(
+        { names: [{ displayName: "Anon" }] },
+        "connections",
+      ),
+    ).toBeNull();
+  });
+
+  it("picks displayName from the primary entry, not the first", () => {
+    const c = normalizePerson(
+      {
+        resourceName: "people/c1",
+        names: [
+          { displayName: "Alt Name" },
+          { displayName: "Primary Name", metadata: { primary: true } },
+        ],
+      },
+      "connections",
+    );
+    expect(c?.display_name).toBe("Primary Name");
+  });
+
+  it("falls back to first name when no primary is flagged", () => {
+    const c = normalizePerson(
+      {
+        resourceName: "people/c2",
+        names: [{ displayName: "Only One" }],
+      },
+      "connections",
+    );
+    expect(c?.display_name).toBe("Only One");
+  });
+
+  it("composes given+family when displayName is missing", () => {
+    const c = normalizePerson(
+      {
+        resourceName: "people/c3",
+        names: [{ givenName: "Jane", familyName: "Doe" }],
+      },
+      "connections",
+    );
+    expect(c?.display_name).toBe("Jane Doe");
+  });
+
+  it("composes from just givenName when familyName is missing", () => {
+    const c = normalizePerson(
+      {
+        resourceName: "people/c4",
+        names: [{ givenName: "Madonna" }],
+      },
+      "connections",
+    );
+    expect(c?.display_name).toBe("Madonna");
+  });
+
+  it("returns null display_name when names entries are empty objects", () => {
+    const c = normalizePerson(
+      { resourceName: "people/c5", names: [{}] },
+      "connections",
+    );
+    expect(c?.display_name).toBeNull();
+  });
+
+  it("primary email goes first in emails[] regardless of array order", () => {
+    const c = normalizePerson(
+      {
+        resourceName: "people/c6",
+        emailAddresses: [
+          { value: "work@acme.com" },
+          { value: "personal@acme.com", metadata: { primary: true } },
+          { value: "other@acme.com" },
+        ],
+      },
+      "connections",
+    );
+    expect(c?.emails).toEqual([
+      "personal@acme.com",
+      "work@acme.com",
+      "other@acme.com",
+    ]);
+  });
+
+  it("filters out non-string and whitespace-only email entries", () => {
+    const c = normalizePerson(
+      {
+        resourceName: "people/c7",
+        emailAddresses: [
+          { value: "real@acme.com" },
+          { value: "   " },
+          { value: 42 },
+          { notValue: "ignored" },
+          "junk-not-an-object",
+          null,
+        ],
+      },
+      "connections",
+    );
+    expect(c?.emails).toEqual(["real@acme.com"]);
+  });
+
+  it("sorts organizations with current:true first, regardless of array order", () => {
+    const c = normalizePerson(
+      {
+        resourceName: "people/c8",
+        organizations: [
+          { name: "Old Co", title: "former gig" },
+          { name: "Current Co", title: "today", current: true },
+          { name: "Older Co", title: "ancient" },
+        ],
+      },
+      "connections",
+    );
+    expect(c?.organizations?.[0]?.name).toBe("Current Co");
+    expect(c?.organizations?.[0]?.title).toBe("today");
+  });
+
+  it("preserves order when no organization is flagged current", () => {
+    const c = normalizePerson(
+      {
+        resourceName: "people/c9",
+        organizations: [
+          { name: "First Co" },
+          { name: "Second Co" },
+        ],
+      },
+      "connections",
+    );
+    expect(c?.organizations?.map((o) => o.name)).toEqual([
+      "First Co",
+      "Second Co",
+    ]);
+  });
+
+  it("collects URLs without primary-first reordering", () => {
+    // primaryFirst=false for urls — keep source order so the LinkedIn vs X
+    // sniffers see them as the user listed them.
+    const c = normalizePerson(
+      {
+        resourceName: "people/c10",
+        urls: [
+          { value: "https://example.com" },
+          { value: "https://linkedin.com/in/foo", metadata: { primary: true } },
+        ],
+      },
+      "connections",
+    );
+    expect(c?.urls).toEqual([
+      "https://example.com",
+      "https://linkedin.com/in/foo",
+    ]);
+  });
+
+  it("survives missing arrays — emails/phones/urls/organizations all default to empty", () => {
+    const c = normalizePerson(
+      { resourceName: "people/c11" },
+      "other_contacts",
+    );
+    expect(c?.emails).toEqual([]);
+    expect(c?.phones).toEqual([]);
+    expect(c?.urls).toEqual([]);
+    expect(c?.organizations).toEqual([]);
+    expect(c?.display_name).toBeNull();
+    expect(c?.origin).toBe("other_contacts");
+  });
+});
+
+describe("extractContacts", () => {
+  it("reads from `connections` when origin is connections", () => {
+    const page = {
+      connections: [
+        { resourceName: "people/a", names: [{ displayName: "A" }] },
+        { resourceName: "people/b", names: [{ displayName: "B" }] },
+      ],
+      otherContacts: [
+        { resourceName: "people/should-not-see", names: [{ displayName: "X" }] },
+      ],
+    };
+    const out = Array.from(extractContacts(page, "connections"));
+    expect(out.map((c) => c.resource_name)).toEqual([
+      "people/a",
+      "people/b",
+    ]);
+  });
+
+  it("reads from `otherContacts` when origin is other_contacts", () => {
+    const page = {
+      otherContacts: [
+        { resourceName: "people/o1", names: [{ displayName: "O1" }] },
+      ],
+    };
+    const out = Array.from(extractContacts(page, "other_contacts"));
+    expect(out).toHaveLength(1);
+    expect(out[0]?.resource_name).toBe("people/o1");
+    expect(out[0]?.origin).toBe("other_contacts");
+  });
+
+  it("yields nothing when the expected key is absent (e.g. empty page response)", () => {
+    expect(Array.from(extractContacts({}, "connections"))).toHaveLength(0);
+    expect(
+      Array.from(extractContacts({ nextPageToken: "abc" }, "connections")),
+    ).toHaveLength(0);
+  });
+
+  it("yields nothing for non-object pages", () => {
+    expect(Array.from(extractContacts(null, "connections"))).toHaveLength(0);
+    expect(Array.from(extractContacts("string", "connections"))).toHaveLength(0);
+    expect(Array.from(extractContacts(42, "connections"))).toHaveLength(0);
+  });
+
+  it("skips entries that don't normalize (e.g. missing resourceName)", () => {
+    const page = {
+      connections: [
+        { resourceName: "people/keep", names: [{ displayName: "K" }] },
+        { names: [{ displayName: "no resource name" }] },
+        null,
+        "garbage",
+      ],
+    };
+    const out = Array.from(extractContacts(page, "connections"));
+    expect(out).toHaveLength(1);
+    expect(out[0]?.resource_name).toBe("people/keep");
+  });
+});

--- a/packages/cli/src/lib/gws-contacts.ts
+++ b/packages/cli/src/lib/gws-contacts.ts
@@ -1,0 +1,281 @@
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import { AcrmError, ERR, type GoogleContact } from "@agent-crm/sdk";
+
+// Field masks the People API accepts. `urls` carries LinkedIn/X links on
+// well-tended contact cards; `organizations` gives us current employer +
+// job title.
+const CONNECTIONS_PERSON_FIELDS =
+  "names,emailAddresses,phoneNumbers,organizations,urls";
+// otherContacts is read-only and limited to these three by Google.
+const OTHER_READ_MASK = "names,emailAddresses,phoneNumbers";
+
+export type GwsInstalledCheck =
+  | { ok: true; version: string }
+  | { ok: false; detail: string };
+
+// Is the gws binary on PATH and runnable? Cheap — does not call any APIs.
+export async function checkGwsInstalled(): Promise<GwsInstalledCheck> {
+  const ver = await runCapture("gws", ["--version"]);
+  if (ver.code === "ENOENT") return { ok: false, detail: "gws not on PATH" };
+  if (ver.exit !== 0) {
+    return {
+      ok: false,
+      detail: ver.stderr || ver.stdout || "gws exited non-zero",
+    };
+  }
+  return { ok: true, version: ver.stdout.trim() };
+}
+
+// Is the user authenticated against the People API? Spends one cheap API
+// call. Requires client_secret.json to already exist — call this AFTER
+// ensureBundledClientSecret().
+export async function checkGwsAuthed(): Promise<{
+  ok: boolean;
+  detail: string;
+}> {
+  const me = await runCapture("gws", [
+    "people",
+    "people",
+    "get",
+    "--params",
+    JSON.stringify({ resourceName: "people/me", personFields: "names" }),
+  ]);
+  if (me.exit === 0) return { ok: true, detail: "" };
+  return {
+    ok: false,
+    detail: me.stderr.trim() || me.stdout.trim() || "auth probe failed",
+  };
+}
+
+export type GwsStreamOpts = {
+  includeOtherContacts: boolean;
+  // Optional override for testing.
+  spawnOverride?: typeof spawn;
+};
+
+// Yield every contact across `people.connections` and (optionally)
+// `otherContacts`, one at a time. The CLI consumer pipes this straight into
+// importGoogleContacts so memory stays bounded — we never hold the full
+// address book in a single array.
+export async function* streamGoogleContacts(
+  opts: GwsStreamOpts,
+): AsyncIterable<GoogleContact> {
+  yield* streamFrom("connections", opts);
+  if (opts.includeOtherContacts) {
+    yield* streamFrom("other_contacts", opts);
+  }
+}
+
+async function* streamFrom(
+  origin: "connections" | "other_contacts",
+  opts: GwsStreamOpts,
+): AsyncIterable<GoogleContact> {
+  const args =
+    origin === "connections"
+      ? [
+          "people",
+          "people",
+          "connections",
+          "list",
+          "--params",
+          JSON.stringify({
+            resourceName: "people/me",
+            personFields: CONNECTIONS_PERSON_FIELDS,
+            pageSize: 1000,
+          }),
+          "--page-all",
+        ]
+      : [
+          "people",
+          "otherContacts",
+          "list",
+          "--params",
+          JSON.stringify({
+            readMask: OTHER_READ_MASK,
+            pageSize: 1000,
+          }),
+          "--page-all",
+        ];
+
+  const spawner = opts.spawnOverride ?? spawn;
+  const child = spawner("gws", args, { stdio: ["ignore", "pipe", "pipe"] });
+  const stderrChunks: Buffer[] = [];
+  child.stderr?.on("data", (b: Buffer) => stderrChunks.push(b));
+
+  const exitPromise: Promise<number> = new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code) => resolve(code ?? 0));
+  });
+
+  if (!child.stdout) {
+    throw new AcrmError("gws produced no stdout stream", ERR.IMPORT);
+  }
+  const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let page: unknown;
+    try {
+      page = JSON.parse(trimmed);
+    } catch {
+      // gws emits well-formed NDJSON; non-JSON would be a real error.
+      continue;
+    }
+    yield* extractContacts(page, origin);
+  }
+  const exit = await exitPromise;
+  if (exit !== 0) {
+    const detail = Buffer.concat(stderrChunks).toString("utf8").trim();
+    throw new AcrmError(
+      `gws ${origin === "connections" ? "people.connections.list" : "people.otherContacts.list"} failed (exit ${exit})`,
+      ERR.IMPORT,
+      detail || undefined,
+    );
+  }
+}
+
+function* extractContacts(
+  page: unknown,
+  origin: "connections" | "other_contacts",
+): Iterable<GoogleContact> {
+  if (!page || typeof page !== "object") return;
+  const obj = page as Record<string, unknown>;
+  const key = origin === "connections" ? "connections" : "otherContacts";
+  const arr = obj[key];
+  if (!Array.isArray(arr)) return;
+  for (const raw of arr) {
+    const c = normalizePerson(raw, origin);
+    if (c) yield c;
+  }
+}
+
+function normalizePerson(
+  raw: unknown,
+  origin: "connections" | "other_contacts",
+): GoogleContact | null {
+  if (!raw || typeof raw !== "object") return null;
+  const p = raw as Record<string, unknown>;
+  const resource_name = typeof p.resourceName === "string" ? p.resourceName : "";
+  if (!resource_name) return null;
+
+  const display_name = pickName(p.names);
+  const emails = pickStrings(p.emailAddresses, "value", true /* primaryFirst */);
+  const phones = pickStrings(p.phoneNumbers, "value", true);
+  const urls = pickStrings(p.urls, "value", false);
+  const organizations = pickOrganizations(p.organizations);
+
+  return {
+    resource_name,
+    origin,
+    display_name,
+    emails,
+    phones,
+    urls,
+    organizations,
+  };
+}
+
+function pickName(field: unknown): string | null {
+  if (!Array.isArray(field) || field.length === 0) return null;
+  // Prefer the entry with metadata.primary === true; fall back to the first.
+  let chosen: Record<string, unknown> | undefined;
+  for (const n of field) {
+    if (n && typeof n === "object") {
+      const meta = (n as Record<string, unknown>).metadata as
+        | Record<string, unknown>
+        | undefined;
+      if (meta && meta.primary === true) {
+        chosen = n as Record<string, unknown>;
+        break;
+      }
+    }
+  }
+  if (!chosen && field[0] && typeof field[0] === "object") {
+    chosen = field[0] as Record<string, unknown>;
+  }
+  if (!chosen) return null;
+  const display =
+    typeof chosen.displayName === "string" ? chosen.displayName : null;
+  if (display) return display;
+  const given = typeof chosen.givenName === "string" ? chosen.givenName : "";
+  const family = typeof chosen.familyName === "string" ? chosen.familyName : "";
+  const composed = [given, family].filter(Boolean).join(" ").trim();
+  return composed || null;
+}
+
+function pickStrings(
+  field: unknown,
+  key: string,
+  primaryFirst: boolean,
+): string[] {
+  if (!Array.isArray(field)) return [];
+  const out: string[] = [];
+  let primary: string | null = null;
+  for (const entry of field) {
+    if (!entry || typeof entry !== "object") continue;
+    const obj = entry as Record<string, unknown>;
+    const v = obj[key];
+    if (typeof v !== "string") continue;
+    const trimmed = v.trim();
+    if (!trimmed) continue;
+    const meta = obj.metadata as Record<string, unknown> | undefined;
+    const isPrimary = primaryFirst && !!meta && meta.primary === true;
+    if (isPrimary && primary === null) primary = trimmed;
+    else out.push(trimmed);
+  }
+  return primary !== null ? [primary, ...out] : out;
+}
+
+function pickOrganizations(
+  field: unknown,
+): Array<{ name?: string | null; title?: string | null }> {
+  if (!Array.isArray(field)) return [];
+  // Sort: current employer first.
+  const sorted = [...field].sort((a, b) => {
+    const ac = !!(a as Record<string, unknown> | null)?.current;
+    const bc = !!(b as Record<string, unknown> | null)?.current;
+    if (ac === bc) return 0;
+    return ac ? -1 : 1;
+  });
+  return sorted
+    .filter((o) => o && typeof o === "object")
+    .map((o) => {
+      const obj = o as Record<string, unknown>;
+      return {
+        name: typeof obj.name === "string" ? obj.name : null,
+        title: typeof obj.title === "string" ? obj.title : null,
+      };
+    });
+}
+
+type CaptureResult = {
+  exit: number;
+  stdout: string;
+  stderr: string;
+  code?: string;
+};
+
+function runCapture(cmd: string, args: string[]): Promise<CaptureResult> {
+  return new Promise((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    const child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+    child.stdout.on("data", (b: Buffer) => {
+      stdout += b.toString("utf8");
+    });
+    child.stderr.on("data", (b: Buffer) => {
+      stderr += b.toString("utf8");
+    });
+    child.once("error", (err) => {
+      const code = (err as NodeJS.ErrnoException).code;
+      resolve({ exit: 1, stdout, stderr, code });
+    });
+    child.once("close", (exitCode) => {
+      resolve({ exit: exitCode ?? 0, stdout, stderr });
+    });
+  });
+}
+
+// Exported for unit tests.
+export const __test = { extractContacts, normalizePerson };

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -14,6 +14,7 @@ export * from "./domain/values.js";
 // overlapping symbol names — import them via subpath, e.g.
 // "@agent-crm/sdk/integrations/apify-linkedin.js".
 export * from "./integrations/apify-post.js";
+export * from "./integrations/google-oauth-client.js";
 export * from "./integrations/granola.js";
 export * from "./integrations/mcp-http-client.js";
 export * from "./integrations/post-mapping.js";
@@ -34,6 +35,7 @@ export { Workspace } from "./workspace.js";
 
 export * from "./operations/execute.js";
 export * from "./operations/import-csv.js";
+export * from "./operations/import-google.js";
 export * from "./operations/import-linkedin.js";
 export * from "./operations/import-post.js";
 export * from "./operations/import-transcript.js";

--- a/packages/sdk/src/integrations/google-oauth-client.ts
+++ b/packages/sdk/src/integrations/google-oauth-client.ts
@@ -22,8 +22,8 @@
 // cluster-software Google account) completes. Until then the env-var
 // override path is the only viable one — bundled values intentionally fail
 // so we notice if we ship without populating them.
-const BUNDLED_CLIENT_ID = "";
-const BUNDLED_CLIENT_SECRET = "";
+const BUNDLED_CLIENT_ID = "809836098986-6rmq1log3rc5mdao58ltcr83crrnmshh.apps.googleusercontent.com";
+const BUNDLED_CLIENT_SECRET = "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";
 
 // Standard installed-app OAuth endpoints. Identical across every Google
 // Desktop OAuth client; safe to hard-code.

--- a/packages/sdk/src/integrations/google-oauth-client.ts
+++ b/packages/sdk/src/integrations/google-oauth-client.ts
@@ -24,6 +24,7 @@
 // so we notice if we ship without populating them.
 const BUNDLED_CLIENT_ID = "809836098986-6rmq1log3rc5mdao58ltcr83crrnmshh.apps.googleusercontent.com";
 const BUNDLED_CLIENT_SECRET = "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";
+const BUNDLED_PROJECT_ID = "agent-crm-prod";
 
 // Standard installed-app OAuth endpoints. Identical across every Google
 // Desktop OAuth client; safe to hard-code.
@@ -49,6 +50,9 @@ export type GoogleOauthClientFile = {
 export type ResolvedClientCredentials = {
   client_id: string;
   client_secret: string;
+  // GCP project ID the OAuth client lives under. gws's JSON parser
+  // requires this field — without it the file is rejected as malformed.
+  project_id: string;
   source: "env" | "bundled";
 };
 
@@ -61,12 +65,18 @@ export function resolveGoogleClientCredentials(
   const envId = env.ACRM_GOOGLE_CLIENT_ID?.trim();
   const envSecret = env.ACRM_GOOGLE_CLIENT_SECRET?.trim();
   if (envId && envSecret) {
-    return { client_id: envId, client_secret: envSecret, source: "env" };
+    return {
+      client_id: envId,
+      client_secret: envSecret,
+      project_id: env.ACRM_GOOGLE_PROJECT_ID?.trim() || "user-supplied",
+      source: "env",
+    };
   }
   if (BUNDLED_CLIENT_ID && BUNDLED_CLIENT_SECRET) {
     return {
       client_id: BUNDLED_CLIENT_ID,
       client_secret: BUNDLED_CLIENT_SECRET,
+      project_id: BUNDLED_PROJECT_ID,
       source: "bundled",
     };
   }
@@ -80,6 +90,7 @@ export function buildClientSecretJson(
   return {
     installed: {
       client_id: creds.client_id,
+      project_id: creds.project_id,
       auth_uri: AUTH_URI,
       token_uri: TOKEN_URI,
       auth_provider_x509_cert_url: CERT_URL,

--- a/packages/sdk/src/integrations/google-oauth-client.ts
+++ b/packages/sdk/src/integrations/google-oauth-client.ts
@@ -1,0 +1,90 @@
+// Bundled OAuth credentials for `acrm import gmail`.
+//
+// Why credentials live in source: per Google's "OAuth 2.0 for Desktop apps"
+// docs, "the client secret cannot actually be kept secret in installed
+// applications. Therefore it is considered public information." This is the
+// same pattern used by `gh`, `supabase`, `vercel`, `gcloud`, and every other
+// public CLI that talks to Google. Shipping the client_id + client_secret in
+// the npm package is intended.
+//
+// What this buys us: end users do not need a GCP project, do not need
+// gcloud, do not need to click through the Cloud Console to create an OAuth
+// client. They run `acrm import gmail`, consent in their browser once, and
+// the import runs. acrm's CLI writes this credential file into the gws
+// config dir on first run.
+//
+// Replacing during development: set ACRM_GOOGLE_CLIENT_ID +
+// ACRM_GOOGLE_CLIENT_SECRET in the environment to override the bundled
+// values. Useful for dogfooding against a personal OAuth client before the
+// production one is verified.
+
+// Filled in once Phase 1 (GCP project + OAuth client creation under the
+// cluster-software Google account) completes. Until then the env-var
+// override path is the only viable one — bundled values intentionally fail
+// so we notice if we ship without populating them.
+const BUNDLED_CLIENT_ID = "";
+const BUNDLED_CLIENT_SECRET = "";
+
+// Standard installed-app OAuth endpoints. Identical across every Google
+// Desktop OAuth client; safe to hard-code.
+const AUTH_URI = "https://accounts.google.com/o/oauth2/auth";
+const TOKEN_URI = "https://oauth2.googleapis.com/token";
+const CERT_URL = "https://www.googleapis.com/oauth2/v1/certs";
+// gws negotiates an ephemeral localhost port; only the loopback redirect is
+// used and Desktop clients don't require registering specific URIs.
+const REDIRECT_URIS = ["http://localhost"];
+
+export type GoogleOauthClientFile = {
+  installed: {
+    client_id: string;
+    project_id?: string;
+    auth_uri: string;
+    token_uri: string;
+    auth_provider_x509_cert_url: string;
+    client_secret: string;
+    redirect_uris: string[];
+  };
+};
+
+export type ResolvedClientCredentials = {
+  client_id: string;
+  client_secret: string;
+  source: "env" | "bundled";
+};
+
+// Resolve the credentials to use at runtime. Env vars win so contributors
+// can dogfood against their own OAuth client before the production one is
+// verified by Google.
+export function resolveGoogleClientCredentials(
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedClientCredentials | null {
+  const envId = env.ACRM_GOOGLE_CLIENT_ID?.trim();
+  const envSecret = env.ACRM_GOOGLE_CLIENT_SECRET?.trim();
+  if (envId && envSecret) {
+    return { client_id: envId, client_secret: envSecret, source: "env" };
+  }
+  if (BUNDLED_CLIENT_ID && BUNDLED_CLIENT_SECRET) {
+    return {
+      client_id: BUNDLED_CLIENT_ID,
+      client_secret: BUNDLED_CLIENT_SECRET,
+      source: "bundled",
+    };
+  }
+  return null;
+}
+
+// Build the standard `client_secret.json` shape gws expects.
+export function buildClientSecretJson(
+  creds: ResolvedClientCredentials,
+): GoogleOauthClientFile {
+  return {
+    installed: {
+      client_id: creds.client_id,
+      auth_uri: AUTH_URI,
+      token_uri: TOKEN_URI,
+      auth_provider_x509_cert_url: CERT_URL,
+      client_secret: creds.client_secret,
+      redirect_uris: REDIRECT_URIS,
+    },
+  };
+}

--- a/packages/sdk/src/operations/import-google.ts
+++ b/packages/sdk/src/operations/import-google.ts
@@ -1,0 +1,310 @@
+import {
+  addMultiValue,
+  findCompanyByName,
+  findRecordByUnique,
+  insertRecord,
+  setSingleValue,
+} from "../db/upsert.js";
+import {
+  domainFromEmail,
+  normalizeDomain,
+  normalizeLinkedinUrl,
+  normalizePhoneNumber,
+  normalizeTwitterUrl,
+} from "../domain/values.js";
+import { resolvePersonByIdentifiers } from "../domain/resolve-person.js";
+import { generateUuid } from "../lib/ids.js";
+import type { Workspace } from "../workspace.js";
+
+// Subset of the Google People API `Person` resource we care about for
+// onboarding. The CLI shells out to `gws people ... --page-all` and flattens
+// each page's connections / otherContacts into this shape before handing it
+// to the SDK. Keeping the SDK pure (no child_process) makes it testable with
+// in-memory fixtures.
+export type GoogleContact = {
+  resource_name: string;
+  // Which People API list this contact came from. Written to acrm_value.source
+  // as `google:connections` / `google:other-contacts` so provenance is clear.
+  origin: "connections" | "other_contacts";
+  display_name?: string | null;
+  // Primary email first, then the rest. All lowercased upstream.
+  emails?: readonly string[];
+  phones?: readonly string[];
+  // Current employer first; older roles are ignored for now.
+  organizations?: ReadonlyArray<{
+    name?: string | null;
+    title?: string | null;
+  }>;
+  // Arbitrary URLs from the contact card; LinkedIn / X get sniffed out.
+  urls?: readonly string[];
+};
+
+export type ImportGoogleContactsStats = {
+  contacts_seen: number;
+  people_created: number;
+  companies_created: number;
+  people_skipped_no_identifier: number;
+};
+
+export type ImportGoogleContactsArgs = {
+  contacts: Iterable<GoogleContact> | AsyncIterable<GoogleContact>;
+  // ISO country code (e.g. "US") used to parse locally-formatted phones into
+  // E.164. Google often returns E.164 already, but contacts entered manually
+  // can be locale-shaped.
+  default_country?: string;
+  onProgress?: (info: { seen: number; stats: ImportGoogleContactsStats }) => void;
+};
+
+export type ImportGoogleContactsResult = {
+  stats: ImportGoogleContactsStats;
+};
+
+const LINKEDIN_RE = /(?:^|\/\/|\.)linkedin\.com\b/i;
+const TWITTER_RE = /(?:^|\/\/|\.)(?:x\.com|twitter\.com)\b/i;
+
+function pickLinkedin(urls: readonly string[] | undefined): string | null {
+  if (!urls) return null;
+  for (const u of urls) if (LINKEDIN_RE.test(u)) return normalizeLinkedinUrl(u);
+  return null;
+}
+
+function pickTwitter(urls: readonly string[] | undefined): string | null {
+  if (!urls) return null;
+  for (const u of urls) if (TWITTER_RE.test(u)) return normalizeTwitterUrl(u);
+  return null;
+}
+
+function looksLikeDomain(d: string): boolean {
+  if (!d) return false;
+  if (d.length < 3 || d.length > 253) return false;
+  if (!d.includes(".")) return false;
+  return /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$/i.test(d);
+}
+
+async function* asAsync<T>(
+  it: Iterable<T> | AsyncIterable<T>,
+): AsyncIterable<T> {
+  // Iterable<T> is structurally compatible — yield each item, awaiting if the
+  // source is async.
+  for await (const v of it as AsyncIterable<T>) yield v;
+}
+
+// Upsert one contact. Mirrors importCsv's row logic — company first (by
+// email domain, then by name), then person (deduped via the standard
+// email → linkedin → twitter → phone cascade), then link person → company.
+export async function importGoogleContacts(
+  workspace: Workspace,
+  args: ImportGoogleContactsArgs,
+): Promise<ImportGoogleContactsResult> {
+  const lix = workspace.lix;
+  const stats: ImportGoogleContactsStats = {
+    contacts_seen: 0,
+    people_created: 0,
+    companies_created: 0,
+    people_skipped_no_identifier: 0,
+  };
+
+  for await (const c of asAsync(args.contacts)) {
+    stats.contacts_seen++;
+    const source =
+      c.origin === "other_contacts"
+        ? "google:other-contacts"
+        : "google:connections";
+    const provenance = { resource_name: c.resource_name, origin: c.origin };
+
+    const emails = (c.emails ?? []).filter((e) => e && e.includes("@"));
+    const primaryEmail = emails[0] ?? null;
+    const phones = (c.phones ?? []).slice();
+    const orgs = c.organizations ?? [];
+    const currentOrg = orgs[0];
+    const companyName = currentOrg?.name?.trim() || null;
+    const jobTitle = currentOrg?.title?.trim() || null;
+    const fullName = c.display_name?.trim() || null;
+    const linkedin = pickLinkedin(c.urls);
+    const twitter = pickTwitter(c.urls);
+
+    // Company: domain from primary email first (matches importCsv), then
+    // fall back to organization name.
+    let companyId: string | null = null;
+    let companyDomain: string | null = null;
+    if (primaryEmail) {
+      const d = domainFromEmail(primaryEmail);
+      if (d) {
+        const norm = normalizeDomain(d);
+        if (looksLikeDomain(norm)) companyDomain = norm;
+      }
+    }
+
+    if (companyDomain) {
+      const existing = await findRecordByUnique(
+        lix,
+        "companies",
+        "domains",
+        companyDomain,
+      );
+      if (existing) {
+        companyId = existing;
+      } else {
+        companyId = await generateUuid(lix);
+        await insertRecord(lix, "companies", companyId);
+        await addMultiValue(lix, {
+          object_slug: "companies",
+          record_id: companyId,
+          attribute_slug: "domains",
+          attribute_type: "domain",
+          value: companyDomain,
+          source,
+          provenance,
+        });
+        if (companyName) {
+          await setSingleValue(lix, {
+            object_slug: "companies",
+            record_id: companyId,
+            attribute_slug: "name",
+            attribute_type: "text",
+            value: companyName,
+            source,
+            provenance,
+          });
+        }
+        stats.companies_created++;
+      }
+    } else if (companyName) {
+      const existing = await findCompanyByName(lix, companyName);
+      if (existing) {
+        companyId = existing;
+      } else {
+        companyId = await generateUuid(lix);
+        await insertRecord(lix, "companies", companyId);
+        await setSingleValue(lix, {
+          object_slug: "companies",
+          record_id: companyId,
+          attribute_slug: "name",
+          attribute_type: "text",
+          value: companyName,
+          source,
+          provenance,
+        });
+        stats.companies_created++;
+      }
+    }
+
+    // Person — resolve via the standard cascade.
+    const lookup = await resolvePersonByIdentifiers(
+      (attr, key) => findRecordByUnique(lix, "people", attr, key),
+      {
+        emails,
+        linkedin_url: linkedin ?? undefined,
+        twitter_url: twitter ?? undefined,
+        phones,
+      },
+      { default_country: args.default_country },
+    );
+
+    const linkedinKey = lookup.normalized.linkedin_url;
+    const twitterKey = lookup.normalized.twitter_url;
+    const phoneKeys = lookup.normalized.phones;
+    const hasIdentifier =
+      emails.length > 0 || !!linkedinKey || !!twitterKey || phoneKeys.length > 0;
+    if (!hasIdentifier) {
+      stats.people_skipped_no_identifier++;
+      args.onProgress?.({ seen: stats.contacts_seen, stats });
+      continue;
+    }
+
+    let personId = lookup.person_record_id;
+    if (!personId) {
+      personId = await generateUuid(lix);
+      await insertRecord(lix, "people", personId);
+      for (const e of emails) {
+        await addMultiValue(lix, {
+          object_slug: "people",
+          record_id: personId,
+          attribute_slug: "email_addresses",
+          attribute_type: "email-address",
+          value: e,
+          source,
+          provenance,
+        });
+      }
+      for (const p of phones) {
+        const normalized = normalizePhoneNumber(p, args.default_country);
+        if (!normalized) continue;
+        await addMultiValue(lix, {
+          object_slug: "people",
+          record_id: personId,
+          attribute_slug: "phone_numbers",
+          attribute_type: "phone-number",
+          value: p,
+          source,
+          provenance,
+        });
+      }
+      if (linkedinKey) {
+        await setSingleValue(lix, {
+          object_slug: "people",
+          record_id: personId,
+          attribute_slug: "linkedin_url",
+          attribute_type: "url",
+          value: linkedinKey,
+          source,
+          provenance,
+        });
+      }
+      if (twitterKey) {
+        await setSingleValue(lix, {
+          object_slug: "people",
+          record_id: personId,
+          attribute_slug: "twitter_url",
+          attribute_type: "url",
+          value: twitterKey,
+          source,
+          provenance,
+        });
+      }
+      if (fullName) {
+        await setSingleValue(lix, {
+          object_slug: "people",
+          record_id: personId,
+          attribute_slug: "name",
+          attribute_type: "personal-name",
+          value: fullName,
+          source,
+          provenance,
+        });
+      }
+      if (jobTitle) {
+        await setSingleValue(lix, {
+          object_slug: "people",
+          record_id: personId,
+          attribute_slug: "job_title",
+          attribute_type: "text",
+          value: jobTitle,
+          source,
+          provenance,
+        });
+      }
+      stats.people_created++;
+    }
+
+    // Always link person → company when we have one, even on an existing
+    // person — matches importCsv. The existing person may have been
+    // created without company info (CSV with name+email only), and the
+    // Google `organizations[]` field is the canonical source.
+    if (companyId) {
+      await setSingleValue(lix, {
+        object_slug: "people",
+        record_id: personId,
+        attribute_slug: "company",
+        attribute_type: "record-reference",
+        value: { target_object: "companies", target_record_id: companyId },
+        source,
+        provenance,
+      });
+    }
+
+    args.onProgress?.({ seen: stats.contacts_seen, stats });
+  }
+
+  return { stats };
+}


### PR DESCRIPTION
Closes #91

## Summary

- First-run `/acrm-onboarding` skill: takes a user from "nothing" to "populated `.acrm`" in one conversation. Detects whether a workspace exists, asks for a data source via `AskUserQuestion` (Gmail / CSV / LinkedIn-or-X profile), runs the right import, then suggests `/prep-call` or `/setup-transcripts` as the next step.
- New `acrm import gmail` command that shells to [`gws`](https://github.com/googleworkspace/cli), pulls People API `connections` + auto-created `otherContacts`, and upserts them as `people` + `companies` deduped by email and email-domain (matching `import csv`).
- acrm ships with its **own** Google Desktop OAuth client baked into the SDK. End-user flow is `npm i -g @googleworkspace/cli` + `acrm import gmail` → one browser consent → done. No GCP project, no `gcloud`, no Cloud Console.

## End-user flow

```sh
npm install -g @googleworkspace/cli
acrm import gmail
# ↓ writes bundled client_secret.json on first run
# ↓ probes people.googleapis.com
# ↓ if not authed, opens browser for `gws auth login -s people` automatically
# ↓ streams contacts → upserts people + companies
```

Power users who want their own OAuth client: set `ACRM_GOOGLE_CLIENT_ID` and `ACRM_GOOGLE_CLIENT_SECRET` in env.

## What's still needed before launch

- [ ] **Phase 1 (Enrique)**: create the production GCP project + OAuth Desktop client under the `cluster-software` Google account, paste `CLIENT_ID` + `CLIENT_SECRET` into `packages/sdk/src/integrations/google-oauth-client.ts`. Until then, end users see a clear error pointing them to the env-var override.
- [ ] **Phase 3 (async)**: file for Google OAuth verification once Phase 1 is done. We can ship in testing mode (≤100 users, 7-day token refresh, "unverified app" warning) immediately.

## What's in scope

- SDK: `importGoogleContacts(workspace, { contacts, default_country? })` accepts `Iterable | AsyncIterable<GoogleContact>` and runs the standard email→linkedin→twitter→phone dedup cascade. Existing person matches now gain a company link on re-import (matches `importCsv` semantics — was a bug, now fixed and tested).
- CLI: `acrm import gmail [--no-other-contacts] [--default-country <iso>]`. Preflights `gws --version`, seeds `client_secret.json` if missing, drives `gws auth login -s people` if not authed. Routes gws stdout to stderr so `--json` mode output stays clean.
- Skill: `packages/cli/skills/acrm-onboarding.md`, auto-installed across Claude Code / Codex / Cursor via the existing `acrm skills install` postinstall.

## Tests

182/182 passing (was 159). New coverage:

- **Parser** (`gws-contacts.test.ts`, 18 tests): `normalizePerson` + `extractContacts` against realistic People API shapes — primary-first email ordering, current-employer sort, missing keys, malformed entries, non-object input.
- **Bootstrap** (`gws-bootstrap.test.ts`, 3 tests): writes client_secret.json when missing, leaves user-supplied alone, errors with hint when no creds resolvable.
- **Importer** (`import-gmail.test.ts`, 6 tests, +1 new): people/company creation, dedup across CSV + Gmail, LinkedIn/X URL classification from contact card, existing-person company link via linkedin-only match (regression test for the bug found in self-review).

## Test plan

- [ ] Reviewer can run `npm test` and see 182/182 pass.
- [ ] Once Phase 1 credentials are pasted in, smoke test `acrm import gmail` against a real Google account: browser opens, consent flow completes, contacts land in `.acrm` with expected `people_created` / `companies_created` counts.
- [ ] Verify `--json` mode produces a single clean JSON line (no gws status text leaking to stdout).
- [ ] Verify idempotency: re-running `acrm import gmail` against an already-imported workspace produces 0 new people/companies.
- [ ] Test the `/acrm-onboarding` skill end-to-end in Claude Code: fresh dir → init → pick Gmail / CSV / LinkedIn-or-X branch → import → suggestion to run `/prep-call`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `acrm import gmail` command and `/acrm-onboarding` skill to agent-crm
> - Adds `acrm import gmail` CLI subcommand that bootstraps Google OAuth via the `gws` CLI, streams contacts from the Google People API as NDJSON, and upserts people and companies into the workspace with dedup semantics (email → LinkedIn → Twitter → phone cascade).
> - Adds `importGoogleContacts` SDK operation in [import-google.ts](https://github.com/cluster-software/agent-crm/pull/98/files#diff-d01594a925faace68b198244b982079e3020dbc86dac32da1ccf7490865d867f) that normalizes contacts, infers companies by email domain or org name, and returns detailed import stats.
> - Adds [gws-bootstrap.ts](https://github.com/cluster-software/agent-crm/pull/98/files#diff-f5e6ac87446554e95ece16d90a17125d2f703984d8f0a6f1e8518d318f38feb5) utilities to locate the gws config dir, write a bundled `client_secret.json` on first run, and automate the browser OAuth flow while keeping CLI stdout JSON-clean.
> - Adds the `/acrm-onboarding` skill spec in [acrm-onboarding.md](https://github.com/cluster-software/agent-crm/pull/98/files#diff-62c6a245c0067c368907b06da492d53a7808aedf9a47d02a16704ed93f5688c8) defining the guided workspace initialization flow across Gmail, CSV, LinkedIn, and X data sources.
> - Bundles default Google OAuth Desktop client credentials in the SDK so Gmail import works out of the box; env vars `ACRM_GOOGLE_CLIENT_ID`/`SECRET`/`PROJECT_ID` override the bundled values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4755da6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->