### PR TITLE
Batch prefetch CSV import identity lookups

### DIFF
--- a/packages/sdk/src/operations/import-csv.ts
+++ b/packages/sdk/src/operations/import-csv.ts
@@ -13,14 +13,17 @@ import {
   type AttributeConfig,
   type AttributeType,
 } from "../domain/values.js";
-import { resolvePersonByIdentifiers } from "../domain/resolve-person.js";
+import {
+  normalizeIdentifiers,
+  resolvePersonByIdentifiers,
+} from "../domain/resolve-person.js";
 import { generateUuid } from "../lib/ids.js";
 import { nowIso } from "../lib/time.js";
 import { loadAttribute } from "../workspace/catalog.js";
 import type { Workspace } from "../workspace.js";
 
 type CsvRow = Record<string, string>;
-type LookupCache = Map<string, string>;
+type LookupCache = Map<string, string | null>;
 
 function parseCsv(text: string): CsvRow[] {
   const rows: string[][] = [];
@@ -106,6 +109,12 @@ function cacheKey(object_slug: string, attribute_slug: string, normalized_key: s
   return `${object_slug}\x00${attribute_slug}\x00${normalized_key}`;
 }
 
+type LookupKey = {
+  object_slug: string;
+  attribute_slug: string;
+  normalized_key: string;
+};
+
 async function findRecordByUnique(
   lix: Lix,
   cache: LookupCache,
@@ -114,8 +123,7 @@ async function findRecordByUnique(
   normalized_key: string,
 ): Promise<string | null> {
   const ck = cacheKey(object_slug, attribute_slug, normalized_key);
-  const hit = cache.get(ck);
-  if (hit) return hit;
+  if (cache.has(ck)) return cache.get(ck) ?? null;
   const r = await exec(
     lix,
     `SELECT record_id FROM acrm_value
@@ -125,7 +133,7 @@ async function findRecordByUnique(
     [object_slug, attribute_slug, normalized_key],
   );
   const id = (r.rows[0]?.record_id as string | undefined) ?? null;
-  if (id) cache.set(ck, id);
+  cache.set(ck, id);
   return id;
 }
 
@@ -136,8 +144,7 @@ async function findCompanyByName(
 ): Promise<string | null> {
   const key = name.trim().toLowerCase();
   const ck = cacheKey("companies", "name__ci", key);
-  const hit = cache.get(ck);
-  if (hit) return hit;
+  if (cache.has(ck)) return cache.get(ck) ?? null;
   const r = await exec(
     lix,
     `SELECT record_id FROM acrm_value
@@ -148,7 +155,7 @@ async function findCompanyByName(
     [key],
   );
   const id = (r.rows[0]?.record_id as string | undefined) ?? null;
-  if (id) cache.set(ck, id);
+  cache.set(ck, id);
   return id;
 }
 
@@ -393,6 +400,116 @@ function collectPhones(row: CsvRow, defaultCountry?: string): string[] {
     }
   }
   return out;
+}
+
+function collectLookupKeysForRow(
+  row: CsvRow,
+  defaultCountry: string | undefined,
+): LookupKey[] {
+  const keys: LookupKey[] = [];
+  const add = (
+    object_slug: string,
+    attribute_slug: string,
+    normalized_key: string | null | undefined,
+  ) => {
+    if (!normalized_key) return;
+    keys.push({ object_slug, attribute_slug, normalized_key });
+  };
+
+  const emails = collectEmails(row);
+  const primaryEmail = emails[0] ?? null;
+  const phones = collectPhones(row, defaultCountry);
+  const domainRaw = pick(row, "domain", "website", "company_domain");
+  const linkedin = findLinkedin(row);
+  const twitter = findTwitter(row);
+
+  let companyDomain: string | null = null;
+  if (domainRaw) {
+    const norm = normalizeDomain(domainRaw);
+    if (looksLikeDomain(norm)) companyDomain = norm;
+  }
+  if (!companyDomain && primaryEmail) {
+    const fromEmail = domainFromEmail(primaryEmail);
+    if (fromEmail && looksLikeDomain(fromEmail)) companyDomain = fromEmail;
+  }
+  add("companies", "domains", companyDomain);
+
+  const normalized = normalizeIdentifiers(
+    {
+      emails,
+      linkedin_url: linkedin ?? undefined,
+      twitter_url: twitter ?? undefined,
+      phones,
+    },
+    { default_country: defaultCountry },
+  );
+  for (const email of normalized.emails) {
+    add("people", "email_addresses", email);
+  }
+  add("people", "linkedin_url", normalized.linkedin_url);
+  add("people", "twitter_url", normalized.twitter_url);
+  for (const phone of normalized.phones) {
+    add("people", "phone_numbers", phone);
+  }
+  return keys;
+}
+
+const LOOKUP_PREFETCH_CHUNK_SIZE = 500;
+
+async function prefetchUniqueLookups(
+  lix: Lix,
+  cache: LookupCache,
+  rows: readonly CsvRow[],
+  defaultCountry: string | undefined,
+): Promise<void> {
+  const candidates = new Map<string, LookupKey>();
+  for (const row of rows) {
+    for (const key of collectLookupKeysForRow(row, defaultCountry)) {
+      const ck = cacheKey(key.object_slug, key.attribute_slug, key.normalized_key);
+      if (!cache.has(ck)) candidates.set(ck, key);
+    }
+  }
+  for (const [ck] of candidates) {
+    cache.set(ck, null);
+  }
+
+  const groups = new Map<string, LookupKey[]>();
+  for (const key of candidates.values()) {
+    const groupKey = `${key.object_slug}\x00${key.attribute_slug}`;
+    const group = groups.get(groupKey);
+    if (group) group.push(key);
+    else groups.set(groupKey, [key]);
+  }
+
+  for (const group of groups.values()) {
+    const first = group[0];
+    if (!first) continue;
+    for (let i = 0; i < group.length; i += LOOKUP_PREFETCH_CHUNK_SIZE) {
+      const chunk = group.slice(i, i + LOOKUP_PREFETCH_CHUNK_SIZE);
+      const placeholders = chunk.map((_, j) => `$${j + 3}`).join(", ");
+      const result = await exec(
+        lix,
+        `SELECT record_id, normalized_key FROM acrm_value
+         WHERE object_slug = $1 AND attribute_slug = $2
+           AND active_until IS NULL
+           AND normalized_key IN (${placeholders})`,
+        [
+          first.object_slug,
+          first.attribute_slug,
+          ...chunk.map((key) => key.normalized_key),
+        ],
+      );
+      for (const row of result.rows) {
+        const normalizedKey = row.normalized_key as string | undefined;
+        const recordId = row.record_id as string | undefined;
+        if (!normalizedKey || !recordId) continue;
+        cache.set(
+          cacheKey(first.object_slug, first.attribute_slug, normalizedKey),
+          recordId,
+        );
+      }
+    }
+  }
 }
 
 export type DetectedColumns = {
@@ -841,6 +958,7 @@ export async function importCsv(
     people_skipped_no_identifier: 0,
   };
   const cache: LookupCache = new Map();
+  await prefetchUniqueLookups(lix, cache, rows, args.default_country);
   const batcher = new WriteBatcher(lix);
   const flushEvery =
     rows.length > LARGE_CSV_THRESHOLD


### PR DESCRIPTION
## Summary
- precollect CSV company/person identity lookup keys before row import
- bulk prefetch existing `acrm_value` matches with grouped `IN` queries
- cache misses as `null` so mostly-new imports do not re-query each identifier

## Benchmark
On `/root/lix/artifact/beauty-us-50k-100k-enriched.csv` with local Lix SDK build:
- before: 64.45s wall-clock
- after: 1.66s wall-clock

## Verification
- `npm run build --workspace @agent-crm/sdk`
- `npm run build --workspace @agent-crm/cli`
- `npm run test --workspace @agent-crm/sdk`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Batch prefetch identity lookups before processing CSV import rows
> - Before row-by-row processing, `importCsv` now calls `prefetchUniqueLookups`, which collects normalized identifiers (emails, phones, LinkedIn, Twitter, company domains) from all rows and bulk-fetches matching record IDs via chunked `SELECT ... IN` queries.
> - The `LookupCache` type now allows `null` values, and `findRecordByUnique`/`findCompanyByName` cache misses as `null` to avoid redundant DB queries for keys that don't exist.
> - Behavioral Change: the lookup cache is now pre-warmed before import, so per-row DB queries are significantly reduced for large imports.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 69da297.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->