### PR TITLE
fix(cli): surface gws OAuth URL via banner + temp file

### DIFF
--- a/.changeset/gmail-auth-url-banner.md
+++ b/.changeset/gmail-auth-url-banner.md
@@ -1,0 +1,11 @@
+---
+"@agent-crm/cli": patch
+---
+
+Fix `acrm import gmail` OAuth URL truncation. When `gws` prints the consent
+URL because it can't auto-open a browser (Claude Code's Bash tool, CI, ssh
+without `$BROWSER`), acrm now detects the URL in the stream, prints a
+clearly-delimited `===== ACRM AUTH URL =====` banner, and writes the URL to
+`<tmpdir>/acrm-auth-url.txt` so skills can read it back without scraping the
+truncated stderr. The `acrm-onboarding` skill is updated to surface the full
+URL to the user as a clickable link.

--- a/packages/cli/skills/acrm-onboarding.md
+++ b/packages/cli/skills/acrm-onboarding.md
@@ -102,6 +102,29 @@ JSON output reports counts:
 Pass `--no-other-contacts` for "My Contacts only" — skips the auto-saved
 bucket.
 
+##### If you see an `ACRM AUTH URL` banner
+
+When `gws` can't auto-open a browser (which is always the case inside
+Claude Code's Bash tool), `acrm import gmail` prints a block like:
+
+```
+===== ACRM AUTH URL =====
+https://accounts.google.com/o/oauth2/auth?…long…
+(also saved to /var/folders/…/acrm-auth-url.txt)
+=========================
+```
+
+The URL is long and **will be truncated** in the tool-output display.
+Do this:
+
+1. Read the file path shown in the banner (e.g.
+   `cat /var/folders/.../acrm-auth-url.txt`) to recover the full URL.
+2. Surface the **complete URL** to the user as a clickable link in your
+   reply — they need to open it in their own browser to consent.
+3. The `acrm import gmail` process is still running, waiting for the
+   loopback callback. Once the user clicks Allow, it resumes
+   automatically.
+
 ##### Heads-ups
 
 - **"Google hasn't verified this app"** — until acrm completes Google's

--- a/packages/cli/src/lib/gws-bootstrap.ts
+++ b/packages/cli/src/lib/gws-bootstrap.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { mkdirSync, writeFileSync, existsSync } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
   AcrmError,
@@ -51,6 +51,15 @@ const PEOPLE_SCOPES = [
   "https://www.googleapis.com/auth/contacts.other.readonly",
 ].join(",");
 
+// Matches the Google OAuth consent URL gws prints when it can't auto-open a
+// browser (e.g. when stdout isn't a real terminal — Claude Code's Bash tool,
+// CI, ssh sessions without $BROWSER, etc).
+const AUTH_URL_REGEX = /https:\/\/accounts\.google\.com\/o\/oauth2\/\S+/;
+
+// Stable path so skills / wrappers can read the URL back without parsing
+// streamed stderr. Overwritten on each auth attempt.
+export const AUTH_URL_FILE = join(tmpdir(), "acrm-auth-url.txt");
+
 // Drive `gws auth login --scopes=...` ourselves so the user sees one
 // browser pop-up and that's it — no separate command for them to remember.
 //
@@ -58,6 +67,11 @@ const PEOPLE_SCOPES = [
 // must not let that leak into acrm's stdout, because acrm reserves stdout
 // for its own JSON output and downstream parsers see anything-else-on-stdout
 // as malformed JSON. Route gws output to our stderr instead.
+//
+// When the URL appears in the stream we ALSO emit a clearly-delimited banner
+// and write the URL to a temp file. Without the banner, long URLs get
+// truncated in Claude Code's tool-output renderer and the user can't click
+// them; the file gives skills a stable place to read the URL from.
 export async function runGwsAuthLogin(): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     const child = spawn(
@@ -67,7 +81,28 @@ export async function runGwsAuthLogin(): Promise<void> {
         stdio: ["inherit", "pipe", "inherit"],
       },
     );
-    child.stdout?.on("data", (b: Buffer) => process.stderr.write(b));
+    let buffer = "";
+    let urlEmitted = false;
+    child.stdout?.on("data", (b: Buffer) => {
+      const chunk = b.toString("utf8");
+      buffer += chunk;
+      if (!urlEmitted) {
+        const m = buffer.match(AUTH_URL_REGEX);
+        if (m) {
+          const url = m[0];
+          urlEmitted = true;
+          try {
+            writeFileSync(AUTH_URL_FILE, url + "\n", { mode: 0o600 });
+          } catch {
+            // best-effort; auth still works if the file write fails
+          }
+          process.stderr.write(
+            `\n===== ACRM AUTH URL =====\n${url}\n(also saved to ${AUTH_URL_FILE})\n=========================\n\n`,
+          );
+        }
+      }
+      process.stderr.write(chunk);
+    });
     child.once("error", reject);
     child.once("close", (code) => {
       if (code === 0) resolve();


### PR DESCRIPTION
When `gws` can't auto-open a browser (Claude Code's Bash tool, CI, ssh without $BROWSER), it prints the consent URL to stdout. The URL is long and gets truncated in tool-output renderers, leaving the user with nothing to click. Detect the URL in the stream, emit a delimited banner, and persist the URL to `<tmpdir>/acrm-auth-url.txt` so the skill can recover the full link and surface it to the user.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface gws OAuth URL via stderr banner and temp file during `acrm import gmail`
> - Buffers stdout from the `gws auth login` subprocess in [`gws-bootstrap.ts`](https://github.com/cluster-software/agent-crm/pull/103/files#diff-f5e6ac87446554e95ece16d90a17125d2f703984d8f0a6f1e8518d318f38feb5) and scans it for the Google OAuth consent URL using a new `AUTH_URL_REGEX` pattern.
> - On first match, writes the URL to `<tmpdir>/acrm-auth-url.txt` (mode 0600) and emits a delimited `ACRM AUTH URL` banner to stderr; all stdout is still forwarded to stderr.
> - Updates [`acrm-onboarding.md`](https://github.com/cluster-software/agent-crm/pull/103/files#diff-62c6a245c0067c368907b06da492d53a7808aedf9a47d02a16704ed93f5688c8) to document the banner format and instruct agents to read the full URL from the temp file when tool output may truncate it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67f53c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->