### PR TITLE
fix(onboarding): background-execute Gmail import so OAuth URL is shown

### DIFF
--- a/.changeset/onboarding-background-gmail-import.md
+++ b/.changeset/onboarding-background-gmail-import.md
@@ -1,0 +1,10 @@
+---
+"@agent-crm/cli": patch
+---
+
+`acrm-onboarding` skill: instruct Claude to run `acrm import gmail` in the
+background via `Bash(run_in_background=true)` and poll `BashOutput`, so the
+OAuth URL banner is surfaced *before* the user consents. A foreground Bash
+call doesn't return output until the command exits — and `gws auth login`
+blocks waiting on the consent callback, so the URL was effectively hidden
+until users manually backgrounded the process.

--- a/packages/cli/skills/acrm-onboarding.md
+++ b/packages/cli/skills/acrm-onboarding.md
@@ -65,19 +65,39 @@ gws --version       # is the gws CLI installed?
 ! npm install -g @googleworkspace/cli
 ```
 
-##### B — Run the import
+##### B — Run the import (MUST be run in the background)
 
-```sh
-! acrm import gmail
+**You MUST run `acrm import gmail` in the background**, not in the
+foreground. Reason: on first run the CLI spawns `gws auth login`, which
+prints the OAuth consent URL and then blocks waiting for the user to click
+Allow in their browser. A foreground Bash call does not return output to
+you until the command exits — meaning you would not see the URL until
+after the user has *already* consented, which is too late to surface it.
+
+Use the `Bash` tool with `run_in_background: true`:
+
+```
+Bash(command="acrm import gmail", run_in_background=true)
 ```
 
-The CLI handles everything:
+Then poll `BashOutput` for that shell every few seconds. As soon as you
+see the `===== ACRM AUTH URL =====` banner in the output, extract the
+URL on the next line and **immediately** surface it to the user as a
+clickable link with a short instruction ("open this URL in your browser
+and click Allow"). Keep polling `BashOutput` until the shell exits — that
+signals the import has finished and the JSON stats are in the output.
+
+If the URL line is truncated or unreadable in the polled output, fall
+back to reading the file path shown in the banner (e.g.
+`cat /var/folders/.../acrm-auth-url.txt`) to recover the full URL.
+
+What the CLI does under the hood:
 
 1. Writes acrm's bundled OAuth client into `~/.config/gws/client_secret.json`
    on first run (idempotent — leaves an existing file alone).
 2. Probes `people.googleapis.com` to see if there's an active session.
-3. If not, spawns `gws auth login -s people`, which opens a browser for the
-   user to consent.
+3. If not, spawns `gws auth login --scopes <people-scopes>`, which prints
+   the consent URL (no browser auto-opens inside Claude Code).
 4. Streams contacts from People API `connections` (the user's curated
    address book) plus `otherContacts` (everyone Google has auto-saved
    because the user emailed them) and upserts them as `people` +
@@ -101,29 +121,6 @@ JSON output reports counts:
 
 Pass `--no-other-contacts` for "My Contacts only" — skips the auto-saved
 bucket.
-
-##### If you see an `ACRM AUTH URL` banner
-
-When `gws` can't auto-open a browser (which is always the case inside
-Claude Code's Bash tool), `acrm import gmail` prints a block like:
-
-```
-===== ACRM AUTH URL =====
-https://accounts.google.com/o/oauth2/auth?…long…
-(also saved to /var/folders/…/acrm-auth-url.txt)
-=========================
-```
-
-The URL is long and **will be truncated** in the tool-output display.
-Do this:
-
-1. Read the file path shown in the banner (e.g.
-   `cat /var/folders/.../acrm-auth-url.txt`) to recover the full URL.
-2. Surface the **complete URL** to the user as a clickable link in your
-   reply — they need to open it in their own browser to consent.
-3. The `acrm import gmail` process is still running, waiting for the
-   loopback callback. Once the user clicks Allow, it resumes
-   automatically.
 
 ##### Heads-ups
 


### PR DESCRIPTION
## Summary

- Update the `acrm-onboarding` skill to instruct Claude to run `acrm import gmail` via `Bash(run_in_background=true)` and poll `BashOutput`, so the `===== ACRM AUTH URL =====` banner reaches Claude *before* the user consents.
- No CLI change; the banner + temp-file behavior shipped in #103 was already correct, but a foreground Bash call buffers output until the command exits — and `gws auth login` blocks waiting on the loopback consent callback. Net effect: users had to manually background the process to see the URL.

## Why this matters

Reported by Enrique while smoke-testing the freshly-deployed onboarding flow: the OAuth URL never appeared until he backgrounded the process himself. Skill-driven background execution + `BashOutput` polling is the right pattern for any long-running command that needs to surface mid-flight output to the user.

## Test plan

- [ ] In a fresh dir with no prior gws session, invoke `/acrm-onboarding`, pick **Sync from Gmail**, confirm Claude:
  1. Backgrounds the `acrm import gmail` call.
  2. Polls `BashOutput`, sees the `ACRM AUTH URL` banner, and posts the full URL as a clickable link in chat.
  3. Continues polling until the shell exits, then surfaces the import stats.
- [ ] Verify the URL is not truncated (banner is on its own line + temp-file fallback path is included).
- [ ] Regression: with an existing gws session (no consent needed), `acrm import gmail` still completes and the skill reports the JSON stats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run `acrm import gmail` in the background during onboarding so the OAuth URL is surfaced immediately
> - Updates the `acrm-onboarding` skill to run `acrm import gmail` with `Bash(run_in_background=true)` and poll `BashOutput`, instead of a blocking foreground call that hid the OAuth URL until after user consent.
> - Once the `===== ACRM AUTH URL =====` banner is detected, the skill extracts and surfaces the consent URL as a clickable link before polling continues to completion.
> - Adds a fallback to read the URL from a file path printed in the banner if the URL is truncated in output.
> - Integrates the previously separate "If you see an ACRM AUTH URL banner" section directly into the main background-run flow in [acrm-onboarding.md](https://github.com/cluster-software/agent-crm/pull/105/files#diff-62c6a245c0067c368907b06da492d53a7808aedf9a47d02a16704ed93f5688c8).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cc0225c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->