### PR TITLE
feat: add communication batch import

### DIFF
--- a/.changeset/local-gmail-import.md
+++ b/.changeset/local-gmail-import.md
@@ -1,0 +1,6 @@
+---
+"@agent-crm/sdk": minor
+"@agent-crm/cli": patch
+---
+
+Add local communication import support for hosted Gmail sync.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Then import your CSVs
 ## Why Agent CRM
 - **🧩 Headless:** Ships as a CLI.
 - **⚒️ Skills based:** Claude writes skills against the CLI (transcript ingestion, stale-deal sweeps, weekly reports) as `.md` files.
-- **🧱 Modeled:** uses Attio's data model out of the box — `people`, `companies`, `deals`, `posts`, `transcripts`. Typed, related, queryable with plain SQL. Fixed schema = predictable agent edits.
+- **🧱 Modeled:** uses Attio's data model out of the box — `people`, `companies`, `deals`, `posts`, `transcripts`, and communication records. Typed, related, queryable with plain SQL. Fixed schema = predictable agent edits.
 - **🔀 Version controlled:** every change is a checkpoint on a branch. Diff, merge, revert, time-travel.
 - **🔌 Pluggable transcript providers:** `transcripts` are vendor-agnostic. Drop a `transcript-provider-<vendor>` skill into `~/.claude/skills/` to plug in Granola, Otter, Fireflies, Fathom, Zoom, manual paste, or anything else.
 
@@ -83,6 +83,8 @@ A grab-bag of jobs Agent CRM handles today. Each is a skill or a CLI command —
 **Draft follow-ups in your voice.** [`/follow-up`](packages/cli/skills/follow-up.md) finds leads with stale activity, reads the prior thread plus any past-call transcripts, and drafts the next message. You review and send.
 
 **Import a scraped list.** `acrm import csv ./leads.csv` ingests a CSV with auto-derived attributes. New columns become typed attributes on the right object — no schema setup.
+
+**Sync Gmail.** `/acrm-onboarding` starts hosted Google OAuth. The sync engine imports Gmail in the background, and the Electron app pulls people, threads, and messages back into your local `.acrm` file.
 
 **Sweep stale deals.** Ask Claude to query your `.acrm` for deals untouched in N days and surface them. It's just SQL underneath, so any filter you can describe, Claude can run.
 

--- a/packages/cli/skills/acrm-onboarding.md
+++ b/packages/cli/skills/acrm-onboarding.md
@@ -58,12 +58,12 @@ account, and click Allow.
 What `acrm import gmail` does now:
 
 1. Reads or creates `.agent-crm-cloud.json` next to the local workspace.
-2. Builds a hosted sync-engine OAuth URL.
-3. Returns immediately; it does not run a local Gmail import.
+2. Starts a hosted sync-engine OAuth attempt.
+3. Returns the Google OAuth URL immediately.
 
 After OAuth, the sync engine redirects to a "Gmail sync started" page and
 imports Gmail in the background. Gmail data is written to the cloud
-workspace as:
+workspace, then the Electron app pulls it into the local `.acrm` file as:
 
 ```text
 people

--- a/packages/cli/src/commands/import-communication.test.ts
+++ b/packages/cli/src/commands/import-communication.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { exec, importCommunicationBatch, Workspace } from "@agent-crm/sdk";
+import { openTestWorkspace } from "../test/open-test-lix.js";
+
+describe("importCommunicationBatch", () => {
+  it("imports Gmail communication data idempotently with relationships", async () => {
+    const lix = await openTestWorkspace();
+    const ws = Workspace.fromLix(lix);
+    const batch = {
+      people: [
+        {
+          sourceKey: "gmail:me@example.com:email:alice@example.com",
+          email: "alice@example.com",
+          displayName: "Alice"
+        },
+        {
+          sourceKey: "gmail:me@example.com:email:bob@example.com",
+          email: "bob@example.com",
+          displayName: "Bob"
+        }
+      ],
+      communicationThreads: [
+        {
+          sourceKey: "gmail:me@example.com:thread:thread-1",
+          provider: "gmail",
+          channel: "email" as const,
+          providerAccountId: "acct-1",
+          providerThreadId: "thread-1",
+          subject: "Hello",
+          messageCount: 1,
+          participantSourceKeys: [
+            "gmail:me@example.com:email:alice@example.com",
+            "gmail:me@example.com:email:bob@example.com"
+          ]
+        }
+      ],
+      communicationMessages: [
+        {
+          sourceKey: "gmail:me@example.com:message:msg-1",
+          provider: "gmail",
+          channel: "email" as const,
+          providerAccountId: "acct-1",
+          providerMessageId: "msg-1",
+          providerThreadId: "thread-1",
+          threadSourceKey: "gmail:me@example.com:thread:thread-1",
+          subject: "Hello",
+          direction: "inbound" as const,
+          senderSourceKey: "gmail:me@example.com:email:alice@example.com",
+          recipientSourceKeys: ["gmail:me@example.com:email:bob@example.com"],
+          participantSourceKeys: [
+            "gmail:me@example.com:email:alice@example.com",
+            "gmail:me@example.com:email:bob@example.com"
+          ]
+        }
+      ]
+    };
+
+    const first = await importCommunicationBatch(ws, batch);
+    const valuesAfterFirstImport = await countValues(lix);
+    const second = await importCommunicationBatch(ws, batch);
+
+    expect(first.stats.people_created).toBe(2);
+    expect(first.stats.communication_threads_created).toBe(1);
+    expect(first.stats.communication_messages_created).toBe(1);
+    expect(second.stats.people_created).toBe(0);
+    expect(second.stats.communication_threads_created).toBe(0);
+    expect(second.stats.communication_messages_created).toBe(0);
+    await expect(countValues(lix)).resolves.toBe(valuesAfterFirstImport);
+
+    await expect(countRecords(lix, "people")).resolves.toBe(2);
+    await expect(countRecords(lix, "communication_threads")).resolves.toBe(1);
+    await expect(countRecords(lix, "communication_messages")).resolves.toBe(1);
+    await expect(hasAttribute(lix, "people", "communication_threads")).resolves.toBe(true);
+    await expect(hasAttribute(lix, "people", "communication_messages")).resolves.toBe(true);
+    await expect(countRefs(lix, "people", "communication_threads")).resolves.toBe(2);
+    await expect(countRefs(lix, "people", "communication_messages")).resolves.toBe(2);
+    await expect(countRefs(lix, "communication_threads", "messages")).resolves.toBe(1);
+
+    await lix.close();
+  });
+});
+
+async function countRecords(lix: Awaited<ReturnType<typeof openTestWorkspace>>, objectSlug: string) {
+  const result = await exec(
+    lix,
+    "SELECT COUNT(*) AS n FROM acrm_record WHERE object_slug = $1",
+    [objectSlug],
+  );
+  return Number(result.rows[0]?.n ?? 0);
+}
+
+async function countValues(lix: Awaited<ReturnType<typeof openTestWorkspace>>) {
+  const result = await exec(lix, "SELECT COUNT(*) AS n FROM acrm_value", []);
+  return Number(result.rows[0]?.n ?? 0);
+}
+
+async function hasAttribute(
+  lix: Awaited<ReturnType<typeof openTestWorkspace>>,
+  objectSlug: string,
+  attributeSlug: string,
+) {
+  const result = await exec(
+    lix,
+    "SELECT 1 FROM acrm_attribute WHERE object_slug = $1 AND attribute_slug = $2",
+    [objectSlug, attributeSlug],
+  );
+  return result.rows.length > 0;
+}
+
+async function countRefs(
+  lix: Awaited<ReturnType<typeof openTestWorkspace>>,
+  objectSlug: string,
+  attributeSlug: string,
+) {
+  const result = await exec(
+    lix,
+    `SELECT COUNT(*) AS n FROM acrm_value
+     WHERE object_slug = $1 AND attribute_slug = $2 AND active_until IS NULL`,
+    [objectSlug, attributeSlug],
+  );
+  return Number(result.rows[0]?.n ?? 0);
+}

--- a/packages/cli/src/commands/import-gmail.ts
+++ b/packages/cli/src/commands/import-gmail.ts
@@ -11,6 +11,7 @@ const CLOUD_METADATA_FILENAME = ".agent-crm-cloud.json";
 
 type CloudMetadata = {
   workspaceId?: string;
+  clientToken?: string;
   createdAt?: string;
 };
 
@@ -29,14 +30,15 @@ export function attachGmailSubcommand(parent: Command): void {
       try {
         const workspaceFile = resolveWorkspacePath(root?.workspace);
         const workspaceDir = dirname(workspaceFile);
-        const workspaceId = ensureCloudWorkspaceId(
-          workspaceDir,
-          process.env.ACRM_CLOUD_WORKSPACE_ID,
-        );
+        const metadata = ensureCloudWorkspaceMetadata(workspaceDir, {
+          workspaceId: process.env.ACRM_CLOUD_WORKSPACE_ID,
+          clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,
+        });
         const syncEngineUrl = process.env.ACRM_SYNC_ENGINE_URL ?? DEFAULT_SYNC_ENGINE_URL;
-        const authUrl = gmailConnectUrl({
+        const authUrl = await createGmailConnectUrl({
           syncEngineUrl,
-          workspaceId,
+          workspaceId: metadata.workspaceId,
+          clientToken: metadata.clientToken,
           workspaceName: basename(workspaceDir),
         });
 
@@ -55,7 +57,7 @@ export function attachGmailSubcommand(parent: Command): void {
 
         ok({
           auth_url: authUrl,
-          workspace_id: workspaceId,
+          workspace_id: metadata.workspaceId,
           sync_engine_url: syncEngineUrl,
         });
       } catch (error) {
@@ -66,25 +68,29 @@ export function attachGmailSubcommand(parent: Command): void {
     });
 }
 
-function ensureCloudWorkspaceId(
+function ensureCloudWorkspaceMetadata(
   workspaceDir: string,
-  preferredWorkspaceId?: string,
-): string {
+  preferred: { workspaceId?: string; clientToken?: string } = {},
+): { workspaceId: string; clientToken: string } {
   const metadataPath = join(workspaceDir, CLOUD_METADATA_FILENAME);
   const existing = readCloudMetadata(metadataPath);
-  if (existing.workspaceId) return existing.workspaceId;
+  const workspaceId = existing.workspaceId || preferred.workspaceId || randomUUID();
+  const clientToken = existing.clientToken || preferred.clientToken || randomUUID();
 
-  const workspaceId = preferredWorkspaceId || randomUUID();
-  writeFileSync(
-    metadataPath,
-    `${JSON.stringify({
-      ...existing,
-      workspaceId,
-      createdAt: existing.createdAt ?? new Date().toISOString(),
-    }, null, 2)}\n`,
-    "utf8"
-  );
-  return workspaceId;
+  if (workspaceId !== existing.workspaceId || clientToken !== existing.clientToken) {
+    writeFileSync(
+      metadataPath,
+      `${JSON.stringify({
+        ...existing,
+        workspaceId,
+        clientToken,
+        createdAt: existing.createdAt ?? new Date().toISOString(),
+      }, null, 2)}\n`,
+      "utf8"
+    );
+  }
+
+  return { workspaceId, clientToken };
 }
 
 function readCloudMetadata(metadataPath: string): CloudMetadata {
@@ -94,6 +100,36 @@ function readCloudMetadata(metadataPath: string): CloudMetadata {
   } catch {
     return {};
   }
+}
+
+async function createGmailConnectUrl(input: {
+  syncEngineUrl: string;
+  workspaceId: string;
+  clientToken: string;
+  workspaceName: string;
+}): Promise<string> {
+  const url = gmailConnectUrl({
+    syncEngineUrl: input.syncEngineUrl,
+    workspaceId: input.workspaceId,
+    workspaceName: input.workspaceName,
+  });
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${input.clientToken}`,
+    },
+  });
+  const payload = await response.json().catch(() => undefined) as
+    | { authUrl?: unknown; error?: unknown }
+    | undefined;
+  if (!response.ok || typeof payload?.authUrl !== "string") {
+    throw new AcrmError(
+      "failed to start hosted Gmail OAuth",
+      ERR.IMPORT,
+      typeof payload?.error === "string" ? payload.error : `sync engine returned HTTP ${response.status}`,
+    );
+  }
+  return payload.authUrl;
 }
 
 function gmailConnectUrl(input: {
@@ -108,5 +144,6 @@ function gmailConnectUrl(input: {
 }
 
 export const __test = {
+  createGmailConnectUrl,
   gmailConnectUrl
 };

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -35,6 +35,7 @@ export { Workspace } from "./workspace.js";
 
 export * from "./operations/execute.js";
 export * from "./operations/import-csv.js";
+export * from "./operations/import-communication.js";
 export * from "./operations/import-google.js";
 export * from "./operations/import-linkedin.js";
 export * from "./operations/import-post.js";

--- a/packages/sdk/src/operations/import-communication.ts
+++ b/packages/sdk/src/operations/import-communication.ts
@@ -1,0 +1,354 @@
+import { exec } from "../db/execute.js";
+import {
+  addMultiValue,
+  findRecordByUnique,
+  insertRecord,
+  setSingleValue,
+} from "../db/upsert.js";
+import {
+  encode,
+  type AttributeType,
+  type ValueJson,
+} from "../domain/values.js";
+import { generateUuid } from "../lib/ids.js";
+import { loadAttributeConfig } from "../workspace/catalog.js";
+import type { Workspace } from "../workspace.js";
+import { seedAttributes, seedObjects } from "../workspace/seeds.js";
+
+export type CommunicationImportPerson = {
+  sourceKey: string;
+  email?: string;
+  displayName?: string;
+};
+
+export type CommunicationImportThread = {
+  sourceKey: string;
+  provider: string;
+  channel: "email" | "linkedin";
+  providerAccountId: string;
+  providerThreadId: string;
+  subject?: string;
+  snippet?: string;
+  firstMessageAt?: string;
+  lastMessageAt?: string;
+  messageCount?: number;
+  participantSourceKeys?: string[];
+};
+
+export type CommunicationImportMessage = {
+  sourceKey: string;
+  provider: string;
+  channel: "email" | "linkedin";
+  providerAccountId: string;
+  providerMessageId: string;
+  providerThreadId?: string;
+  threadSourceKey?: string;
+  subject?: string;
+  snippet?: string;
+  bodyText?: string;
+  sentAt?: string;
+  direction?: "inbound" | "outbound";
+  labelIds?: string[];
+  senderSourceKey?: string;
+  recipientSourceKeys?: string[];
+  participantSourceKeys?: string[];
+};
+
+export type CommunicationImportBatch = {
+  people: CommunicationImportPerson[];
+  communicationThreads: CommunicationImportThread[];
+  communicationMessages: CommunicationImportMessage[];
+};
+
+export type CommunicationImportResult = {
+  stats: {
+    people_seen: number;
+    people_created: number;
+    communication_threads_seen: number;
+    communication_threads_created: number;
+    communication_messages_seen: number;
+    communication_messages_created: number;
+  };
+};
+
+const SOURCE = "sync-engine";
+
+export async function importCommunicationBatch(
+  workspace: Workspace,
+  batch: CommunicationImportBatch,
+): Promise<CommunicationImportResult> {
+  await ensureCommunicationSchema(workspace);
+  const lix = workspace.lix;
+  const stats: CommunicationImportResult["stats"] = {
+    people_seen: batch.people.length,
+    people_created: 0,
+    communication_threads_seen: batch.communicationThreads.length,
+    communication_threads_created: 0,
+    communication_messages_seen: batch.communicationMessages.length,
+    communication_messages_created: 0,
+  };
+
+  const personIds = new Map<string, string>();
+  const threadIds = new Map<string, string>();
+  const messageIds = new Map<string, string>();
+
+  for (const person of batch.people) {
+    const { recordId, created } = await upsertPerson(workspace, person);
+    personIds.set(person.sourceKey, recordId);
+    if (created) stats.people_created++;
+  }
+
+  for (const thread of batch.communicationThreads) {
+    const { recordId, created } = await upsertThread(workspace, thread);
+    threadIds.set(thread.sourceKey, recordId);
+    if (created) stats.communication_threads_created++;
+  }
+
+  for (const message of batch.communicationMessages) {
+    const { recordId, created } = await upsertMessage(workspace, message);
+    messageIds.set(message.sourceKey, recordId);
+    if (created) stats.communication_messages_created++;
+  }
+
+  for (const thread of batch.communicationThreads) {
+    const threadId = threadIds.get(thread.sourceKey);
+    if (!threadId) continue;
+    for (const personSourceKey of thread.participantSourceKeys ?? []) {
+      const personId = personIds.get(personSourceKey) ?? await findBySourceKey(lix, "people", personSourceKey);
+      if (!personId) continue;
+      await addReference(lix, "people", personId, "communication_threads", "communication_threads", threadId);
+      await addReference(lix, "communication_threads", threadId, "participants", "people", personId);
+    }
+  }
+
+  for (const message of batch.communicationMessages) {
+    const messageId = messageIds.get(message.sourceKey);
+    if (!messageId) continue;
+
+    const threadSourceKey = message.threadSourceKey ??
+      batch.communicationThreads.find((thread) => thread.providerThreadId === message.providerThreadId)?.sourceKey;
+    const threadId = threadSourceKey
+      ? threadIds.get(threadSourceKey) ?? await findBySourceKey(lix, "communication_threads", threadSourceKey)
+      : null;
+    if (threadId) {
+      await setSingleValueIfChanged(lix, referenceValue("communication_messages", messageId, "thread", "communication_threads", threadId));
+      await addReference(lix, "communication_threads", threadId, "messages", "communication_messages", messageId);
+    }
+
+    if (message.senderSourceKey) {
+      const senderId = personIds.get(message.senderSourceKey) ?? await findBySourceKey(lix, "people", message.senderSourceKey);
+      if (senderId) await setSingleValueIfChanged(lix, referenceValue("communication_messages", messageId, "sender", "people", senderId));
+    }
+
+    for (const personSourceKey of message.recipientSourceKeys ?? []) {
+      const personId = personIds.get(personSourceKey) ?? await findBySourceKey(lix, "people", personSourceKey);
+      if (personId) await addReference(lix, "communication_messages", messageId, "recipients", "people", personId);
+    }
+
+    for (const personSourceKey of message.participantSourceKeys ?? []) {
+      const personId = personIds.get(personSourceKey) ?? await findBySourceKey(lix, "people", personSourceKey);
+      if (!personId) continue;
+      await addReference(lix, "people", personId, "communication_messages", "communication_messages", messageId);
+      await addReference(lix, "communication_messages", messageId, "participants", "people", personId);
+    }
+  }
+
+  return { stats };
+}
+
+async function ensureCommunicationSchema(workspace: Workspace): Promise<void> {
+  await seedObjects(workspace.lix);
+  await seedAttributes(workspace.lix);
+}
+
+async function upsertPerson(
+  workspace: Workspace,
+  person: CommunicationImportPerson,
+): Promise<{ recordId: string; created: boolean }> {
+  const lix = workspace.lix;
+  let recordId = await findBySourceKey(lix, "people", person.sourceKey);
+  if (!recordId && person.email) {
+    recordId = await findRecordByUnique(lix, "people", "email_addresses", person.email.trim().toLowerCase());
+  }
+  const created = !recordId;
+  if (!recordId) {
+    recordId = await generateUuid(lix);
+    await insertRecord(lix, "people", recordId);
+  }
+
+  await addTextKey(lix, "people", recordId, "source_keys", person.sourceKey);
+  if (person.email) {
+    await addMultiValue(lix, value("people", recordId, "email_addresses", "email-address", person.email));
+  }
+  if (person.displayName) {
+    await setSingleValueIfChanged(lix, value("people", recordId, "name", "personal-name", person.displayName));
+  }
+
+  return { recordId, created };
+}
+
+async function upsertThread(
+  workspace: Workspace,
+  thread: CommunicationImportThread,
+): Promise<{ recordId: string; created: boolean }> {
+  const lix = workspace.lix;
+  let recordId = await findBySourceKey(lix, "communication_threads", thread.sourceKey);
+  const created = !recordId;
+  if (!recordId) {
+    recordId = await generateUuid(lix);
+    await insertRecord(lix, "communication_threads", recordId);
+  }
+
+  await addTextKey(lix, "communication_threads", recordId, "source_keys", thread.sourceKey);
+  await setSingleValueIfChanged(lix, value("communication_threads", recordId, "channel", "status", thread.channel));
+  await setSingleValueIfChanged(lix, value("communication_threads", recordId, "provider", "text", thread.provider));
+  await setSingleValueIfChanged(lix, value("communication_threads", recordId, "provider_account_id", "text", thread.providerAccountId));
+  await setSingleValueIfChanged(lix, value("communication_threads", recordId, "provider_thread_id", "text", thread.providerThreadId));
+  if (thread.subject) await setSingleValueIfChanged(lix, value("communication_threads", recordId, "subject", "text", thread.subject));
+  if (thread.snippet) await setSingleValueIfChanged(lix, value("communication_threads", recordId, "snippet", "text", thread.snippet));
+  if (thread.firstMessageAt) await setSingleValueIfChanged(lix, value("communication_threads", recordId, "first_message_at", "timestamp", thread.firstMessageAt));
+  if (thread.lastMessageAt) await setSingleValueIfChanged(lix, value("communication_threads", recordId, "last_message_at", "timestamp", thread.lastMessageAt));
+  if (thread.messageCount != null) await setSingleValueIfChanged(lix, value("communication_threads", recordId, "message_count", "number", thread.messageCount));
+
+  return { recordId, created };
+}
+
+async function upsertMessage(
+  workspace: Workspace,
+  message: CommunicationImportMessage,
+): Promise<{ recordId: string; created: boolean }> {
+  const lix = workspace.lix;
+  let recordId = await findBySourceKey(lix, "communication_messages", message.sourceKey);
+  const created = !recordId;
+  if (!recordId) {
+    recordId = await generateUuid(lix);
+    await insertRecord(lix, "communication_messages", recordId);
+  }
+
+  await addTextKey(lix, "communication_messages", recordId, "source_keys", message.sourceKey);
+  await setSingleValueIfChanged(lix, value("communication_messages", recordId, "channel", "status", message.channel));
+  await setSingleValueIfChanged(lix, value("communication_messages", recordId, "provider", "text", message.provider));
+  await setSingleValueIfChanged(lix, value("communication_messages", recordId, "provider_account_id", "text", message.providerAccountId));
+  await setSingleValueIfChanged(lix, value("communication_messages", recordId, "provider_message_id", "text", message.providerMessageId));
+  if (message.providerThreadId) await setSingleValueIfChanged(lix, value("communication_messages", recordId, "provider_thread_id", "text", message.providerThreadId));
+  if (message.sentAt) await setSingleValueIfChanged(lix, value("communication_messages", recordId, "sent_at", "timestamp", message.sentAt));
+  if (message.subject) await setSingleValueIfChanged(lix, value("communication_messages", recordId, "subject", "text", message.subject));
+  if (message.snippet) await setSingleValueIfChanged(lix, value("communication_messages", recordId, "snippet", "text", message.snippet));
+  if (message.bodyText) await setSingleValueIfChanged(lix, value("communication_messages", recordId, "body_text", "text", message.bodyText));
+  if (message.direction) await setSingleValueIfChanged(lix, value("communication_messages", recordId, "direction", "status", message.direction));
+  for (const labelId of message.labelIds ?? []) {
+    await addTextKey(lix, "communication_messages", recordId, "label_ids", labelId);
+  }
+
+  return { recordId, created };
+}
+
+async function findBySourceKey(
+  lix: Workspace["lix"],
+  objectSlug: string,
+  sourceKey: string,
+): Promise<string | null> {
+  return findRecordByUnique(lix, objectSlug, "source_keys", sourceKey);
+}
+
+async function addTextKey(
+  lix: Workspace["lix"],
+  objectSlug: string,
+  recordId: string,
+  attributeSlug: string,
+  sourceKey: string,
+): Promise<void> {
+  await addMultiValue(lix, value(objectSlug, recordId, attributeSlug, "text", sourceKey));
+}
+
+async function addReference(
+  lix: Workspace["lix"],
+  objectSlug: string,
+  recordId: string,
+  attributeSlug: string,
+  targetObject: string,
+  targetRecordId: string,
+): Promise<void> {
+  const existing = await exec(
+    lix,
+    `SELECT 1 FROM acrm_value
+     WHERE object_slug = $1 AND record_id = $2 AND attribute_slug = $3
+       AND ref_object = $4 AND ref_record_id = $5 AND active_until IS NULL
+     LIMIT 1`,
+    [objectSlug, recordId, attributeSlug, targetObject, targetRecordId],
+  );
+  if (existing.rows.length) return;
+  await addMultiValue(lix, referenceValue(objectSlug, recordId, attributeSlug, targetObject, targetRecordId));
+}
+
+async function setSingleValueIfChanged(
+  lix: Workspace["lix"],
+  args: ReturnType<typeof value>,
+): Promise<void> {
+  const config = args.attribute_type === "status" || args.attribute_type === "select"
+    ? await loadAttributeConfig(lix, args.object_slug, args.attribute_slug)
+    : undefined;
+  const nextValue = encode(args.attribute_type, args.value, config);
+  const existing = await exec(
+    lix,
+    `SELECT value_json FROM acrm_value
+     WHERE object_slug = $1 AND record_id = $2 AND attribute_slug = $3
+       AND active_until IS NULL
+     LIMIT 1`,
+    [args.object_slug, args.record_id, args.attribute_slug],
+  );
+  const currentValue = parseValueJson(existing.rows[0]?.value_json);
+  if (currentValue && sameValueJson(currentValue, nextValue)) return;
+  await setSingleValue(lix, args);
+}
+
+function value(
+  object_slug: string,
+  record_id: string,
+  attribute_slug: string,
+  attribute_type: AttributeType,
+  value: unknown,
+) {
+  return {
+    object_slug,
+    record_id,
+    attribute_slug,
+    attribute_type,
+    value,
+    source: SOURCE,
+    provenance: {},
+  };
+}
+
+function referenceValue(
+  object_slug: string,
+  record_id: string,
+  attribute_slug: string,
+  target_object: string,
+  target_record_id: string,
+) {
+  return value(object_slug, record_id, attribute_slug, "record-reference", {
+    target_object,
+    target_record_id,
+  });
+}
+
+function parseValueJson(value: unknown): ValueJson | null {
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      return isObject(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+  return isObject(value) ? value : null;
+}
+
+function sameValueJson(left: ValueJson, right: ValueJson): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function isObject(value: unknown): value is ValueJson {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/sdk/src/workspace/seeds.ts
+++ b/packages/sdk/src/workspace/seeds.ts
@@ -23,6 +23,8 @@ const OBJECTS: ObjectSeed[] = [
   { object_slug: "deals", singular_name: "Deal", plural_name: "Deals" },
   { object_slug: "posts", singular_name: "Post", plural_name: "Posts" },
   { object_slug: "transcripts", singular_name: "Transcript", plural_name: "Transcripts" },
+  { object_slug: "communication_threads", singular_name: "Communication thread", plural_name: "Communication threads" },
+  { object_slug: "communication_messages", singular_name: "Communication message", plural_name: "Communication messages" },
 ];
 
 const ATTRIBUTES: AttributeSeed[] = [
@@ -41,7 +43,10 @@ const ATTRIBUTES: AttributeSeed[] = [
   { object_slug: "people", attribute_slug: "job_title", title: "Job title", attribute_type: "text", is_multivalued: false, is_unique: false },
   { object_slug: "people", attribute_slug: "linkedin_url", title: "LinkedIn", attribute_type: "url", is_multivalued: false, is_unique: false },
   { object_slug: "people", attribute_slug: "twitter_url", title: "Twitter / X", attribute_type: "url", is_multivalued: false, is_unique: false },
+  { object_slug: "people", attribute_slug: "source_keys", title: "Source keys", attribute_type: "text", is_multivalued: true, is_unique: true },
   { object_slug: "people", attribute_slug: "company", title: "Company", attribute_type: "record-reference", is_multivalued: false, is_unique: false, config: { target_object: "companies", inverse: "team" } },
+  { object_slug: "people", attribute_slug: "communication_threads", title: "Communication threads", attribute_type: "record-reference", is_multivalued: true, is_unique: false, config: { target_object: "communication_threads", inverse: "participants" } },
+  { object_slug: "people", attribute_slug: "communication_messages", title: "Communication messages", attribute_type: "record-reference", is_multivalued: true, is_unique: false, config: { target_object: "communication_messages", inverse: "participants" } },
   { object_slug: "people", attribute_slug: "associated_deals", title: "Associated deals", attribute_type: "record-reference", is_multivalued: true, is_unique: false, config: { target_object: "deals", inverse: "associated_people" } },
   { object_slug: "people", attribute_slug: "associated_posts", title: "Associated posts", attribute_type: "record-reference", is_multivalued: true, is_unique: false, config: { target_object: "posts", inverse: "author" } },
   { object_slug: "people", attribute_slug: "associated_transcripts", title: "Associated transcripts", attribute_type: "record-reference", is_multivalued: true, is_unique: false, config: { target_object: "transcripts", inverse: "participants" } },
@@ -72,6 +77,38 @@ const ATTRIBUTES: AttributeSeed[] = [
   { object_slug: "transcripts", attribute_slug: "summary", title: "Summary", attribute_type: "text", is_multivalued: false, is_unique: false },
   { object_slug: "transcripts", attribute_slug: "content", title: "Content", attribute_type: "text", is_multivalued: false, is_unique: false },
   { object_slug: "transcripts", attribute_slug: "participants", title: "Participants", attribute_type: "record-reference", is_multivalued: true, is_unique: false, config: { target_object: "people", inverse: "associated_transcripts" } },
+
+  // communication threads
+  { object_slug: "communication_threads", attribute_slug: "source_keys", title: "Source keys", attribute_type: "text", is_multivalued: true, is_unique: true },
+  { object_slug: "communication_threads", attribute_slug: "channel", title: "Channel", attribute_type: "status", is_multivalued: false, is_unique: false, config: { options: [{ id: "email", title: "Email" }, { id: "linkedin", title: "LinkedIn" }] } },
+  { object_slug: "communication_threads", attribute_slug: "provider", title: "Provider", attribute_type: "text", is_multivalued: false, is_unique: false },
+  { object_slug: "communication_threads", attribute_slug: "provider_account_id", title: "Provider account ID", attribute_type: "text", is_multivalued: false, is_unique: false },
+  { object_slug: "communication_threads", attribute_slug: "provider_thread_id", title: "Provider thread ID", attribute_type: "text", is_multivalued: false, is_unique: false },
+  { object_slug: "communication_threads", attribute_slug: "subject", title: "Subject", attribute_type: "text", is_multivalued: false, is_unique: false },
+  { object_slug: "communication_threads", attribute_slug: "snippet", title: "Snippet", attribute_type: "text", is_multivalued: false, is_unique: false },
+  { object_slug: "communication_threads", attribute_slug: "first_message_at", title: "First message at", attribute_type: "timestamp", is_multivalued: false, is_unique: false },
+  { object_slug: "communication_threads", attribute_slug: "last_message_at", title: "Last message at", attribute_type: "timestamp", is_multivalued: false, is_unique: false },
+  { object_slug: "communication_threads", attribute_slug: "message_count", title: "Message count", attribute_type: "number", is_multivalued: false, is_unique: false },
+  { object_slug: "communication_threads", attribute_slug: "participants", title: "Participants", attribute_type: "record-reference", is_multivalued: true, is_unique: false, config: { target_object: "people", inverse: "communication_threads" } },
+  { object_slug: "communication_threads", attribute_slug: "messages", title: "Messages", attribute_type: "record-reference", is_multivalued: true, is_unique: false, config: { target_object: "communication_messages", inverse: "thread" } },
+
+  // communication messages
+  { object_slug: "communication_messages", attribute_slug: "source_keys", title: "Source keys", attribute_type: "text", is_multivalued: true, is_unique: true },
+  { object_slug: "communication_messages", attribute_slug: "channel", title: "Channel", attribute_type: "status", is_multivalued: false, is_unique: false, config: { options: [{ id: "email", title: "Email" }, { id: "linkedin", title: "LinkedIn" }] } },
+  { object_slug: "communication_messages", attribute_slug: "provider", title: "Provider", attribute_type: "text", is_multivalued: false, is_unique: false },
+  { object_slug: "communication_messages", attribute_slug: "provider_account_id", title: "Provider account ID", attribute_type: "text", is_multivalued: false, is_unique: false },
+  { object_slug: "communication_messages", attribute_slug: "provider_message_id", title: "Provider message ID", attribute_type: "text", is_multivalued: false, is_unique: false },
+  { object_slug: "communication_messages", attribute_slug: "provider_thread_id", title: "Provider thread ID", attribute_type: "text", is_multivalued: false, is_unique: false },
+  { object_slug: "communication_messages", attribute_slug: "thread", title: "Thread", attribute_type: "record-reference", is_multivalued: false, is_unique: false, config: { target_object: "communication_threads", inverse: "messages" } },
+  { object_slug: "communication_messages", attribute_slug: "sent_at", title: "Sent at", attribute_type: "timestamp", is_multivalued: false, is_unique: false },
+  { object_slug: "communication_messages", attribute_slug: "subject", title: "Subject", attribute_type: "text", is_multivalued: false, is_unique: false },
+  { object_slug: "communication_messages", attribute_slug: "snippet", title: "Snippet", attribute_type: "text", is_multivalued: false, is_unique: false },
+  { object_slug: "communication_messages", attribute_slug: "body_text", title: "Body text", attribute_type: "text", is_multivalued: false, is_unique: false },
+  { object_slug: "communication_messages", attribute_slug: "label_ids", title: "Labels", attribute_type: "text", is_multivalued: true, is_unique: false },
+  { object_slug: "communication_messages", attribute_slug: "direction", title: "Direction", attribute_type: "status", is_multivalued: false, is_unique: false, config: { options: [{ id: "inbound", title: "Inbound" }, { id: "outbound", title: "Outbound" }] } },
+  { object_slug: "communication_messages", attribute_slug: "sender", title: "Sender", attribute_type: "record-reference", is_multivalued: false, is_unique: false, config: { target_object: "people" } },
+  { object_slug: "communication_messages", attribute_slug: "recipients", title: "Recipients", attribute_type: "record-reference", is_multivalued: true, is_unique: false, config: { target_object: "people" } },
+  { object_slug: "communication_messages", attribute_slug: "participants", title: "Participants", attribute_type: "record-reference", is_multivalued: true, is_unique: false, config: { target_object: "people", inverse: "communication_messages" } },
 ];
 
 export async function seedObjects(lix: Lix): Promise<void> {


### PR DESCRIPTION
## Summary
- add importCommunicationBatch to @agent-crm/sdk
- seed communication thread/message schema and reverse people relationships
- update acrm import gmail to start hosted OAuth through the sync engine
- add changeset for SDK and CLI release

## Tests
- npm run build
- npm run test --workspace @agent-crm/cli

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add batch import for communication threads and messages to the SDK
> - Adds `importCommunicationBatch` to [packages/sdk/src/operations/import-communication.ts](https://github.com/cluster-software/agent-crm/pull/110/files#diff-661a21cea325c42d9744840a31f3f1b84f30ce87c2bacb33724e77dd96f84221), which idempotently upserts people, threads, and messages and wires up all relationships and attributes.
> - Seeds two new workspace objects (`communication_threads`, `communication_messages`) and their full attribute sets in [packages/sdk/src/workspace/seeds.ts](https://github.com/cluster-software/agent-crm/pull/110/files#diff-e4ce857ac7ed9f022d6d03e8ee46e137426655be361db110ec330791dfe8ab77).
> - Updates the Gmail import command to use a stored `clientToken` alongside `workspaceId`, POSTing to the sync engine to initiate hosted OAuth and returning the resulting Google OAuth URL.
> - Exports `importCommunicationBatch` from the SDK's public entrypoint so consumers can call it directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d6f2c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->