### PR TITLE
test: update default workspace object expectation

### DIFF
--- a/packages/sdk/src/workspace.test.ts
+++ b/packages/sdk/src/workspace.test.ts
@@ -45,6 +45,8 @@ describe("Workspace", () => {
           "SELECT object_slug FROM acrm_object ORDER BY object_slug",
         );
         expect(objects.rows.map((r) => r.object_slug)).toEqual([
+          "communication_messages",
+          "communication_threads",
           "companies",
           "deals",
           "people",


### PR DESCRIPTION
## Summary
- update the SDK workspace initialization test to include communication_threads and communication_messages
- fixes the CI failure introduced by seeding communication objects by default

## Tests
- npm test

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `communication_messages` and `communication_threads` to default workspace object test expectations
> Updates the expected object slugs in the workspace initialization test in [workspace.test.ts](https://github.com/cluster-software/agent-crm/pull/112/files#diff-824d5330379379c97cf5f78501913e2127a6b2c3ea977c3ce38146cfff3f09ab) to include `communication_messages` and `communication_threads` alongside the existing defaults.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01e3802.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->