### PR TITLE
fix: show CLI install command in onboarding

### DIFF
--- a/.changeset/onboarding-cli-install.md
+++ b/.changeset/onboarding-cli-install.md
@@ -1,0 +1,5 @@
+---
+"@agent-crm/cli": patch
+---
+
+Show the global install command when `/acrm-onboarding` cannot find the `acrm` CLI.

--- a/packages/cli/skills/acrm-onboarding.md
+++ b/packages/cli/skills/acrm-onboarding.md
@@ -22,6 +22,13 @@ acrm execute "SELECT 1" --json
 ```
 
 - If that succeeds, you're already inside a workspace — skip to step 2.
+- If `acrm` is not found (`command not found`, `not found`, or exit code 127), stop. Do not search the filesystem, check brew, inspect npm globals, or ask follow-up questions. Tell the user to install the CLI with:
+
+  ```sh
+  npm i -g @agent-crm/cli
+  ```
+
+  Then ask them to rerun `/acrm-onboarding`.
 - If it fails with `ACRM_ERROR_NO_WORKSPACE`, ask the user what to name their workspace (default: `pipeline.acrm`) and run:
 
   ```sh
@@ -117,6 +124,7 @@ Keep the close short — one or two suggestions, not a feature dump.
 ## Hard rules
 
 - **Never** fabricate a workspace path or skip the `acrm init` step. If no workspace exists, the user must explicitly name one.
+- **If `acrm` is not installed, only show `npm i -g @agent-crm/cli` and stop.** Do not troubleshoot local install paths.
 - **Never** silently run a destructive command.
 - **Do not use `gws` for Gmail.** Gmail now goes through the hosted sync engine.
 - **Don't** fabricate OAuth credentials or paper over auth errors. The user owns the Google consent flow.


### PR DESCRIPTION
## Summary
- update /acrm-onboarding to stop when acrm is not installed
- show only the global install command: npm i -g @agent-crm/cli
- add a CLI patch changeset

## Tests
- npm run build

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show CLI install command in `/acrm-onboarding` when `acrm` is not found
> Updates [acrm-onboarding.md](https://github.com/cluster-software/agent-crm/pull/113/files#diff-62c6a245c0067c368907b06da492d53a7808aedf9a47d02a16704ed93f5688c8) to detect when the `acrm` command is missing and prompt the user to run `npm i -g @agent-crm/cli`, then stop and ask them to rerun `/acrm-onboarding`. Previously, the onboarding flow would continue with other troubleshooting steps instead of surfacing the install command.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa37a61.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->