### PR TITLE
fix: clarify Gmail onboarding link copy

### DIFF
--- a/.changeset/gmail-onboarding-copy.md
+++ b/.changeset/gmail-onboarding-copy.md
@@ -1,0 +1,5 @@
+---
+"@agent-crm/cli": patch
+---
+
+Make the Gmail onboarding OAuth link copy clearer and clickable.

--- a/packages/cli/skills/acrm-onboarding.md
+++ b/packages/cli/skills/acrm-onboarding.md
@@ -58,9 +58,20 @@ Run:
 acrm import gmail --json
 ```
 
-Extract `data.auth_url` from the JSON response and show it to the user as
-a clickable link. Tell the user to open the URL, choose their Google
-account, and click Allow.
+Extract `data.auth_url` from the JSON response. Show it as a Markdown
+link so it is clickable:
+
+```md
+Open this URL to connect Gmail:
+
+[<auth_url>](<auth_url>)
+
+Pick your Google account and click Allow.
+
+After you finish Google OAuth, Agent CRM's hosted sync engine will start
+importing Gmail in the background. The Agent CRM app will then pull
+people, threads, and messages into your local `.acrm` workspace.
+```
 
 What `acrm import gmail` does now:
 
@@ -102,10 +113,10 @@ Both require `APIFY_API_TOKEN` in `.env` next to the workspace. If missing, the 
 
 ### 4. Confirm + next step
 
-For Gmail, tell the user:
-
-> Gmail sync has started. It runs in the background and will keep updating
-> through Agent CRM's hosted sync engine.
+For Gmail, do not add a separate confirmation or next-step message after
+the OAuth link copy above. Do not suggest `/prep-call`,
+`/setup-transcripts`, or any other next step. The user still needs to
+finish OAuth first.
 
 For local imports, after the import succeeds, show a short summary tied to
 what they actually have:


### PR DESCRIPTION
## Summary
- show the Gmail OAuth URL as a clickable Markdown link
- avoid saying Gmail sync has started before OAuth completes
- remove Gmail next-step suggestions after the OAuth link
- add a CLI patch changeset

## Tests
- npm run build

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clarify Gmail onboarding OAuth link copy in `acrm-onboarding` skill
> Updates the Gmail onboarding instructions in [acrm-onboarding.md](https://github.com/cluster-software/agent-crm/pull/115/files#diff-62c6a245c0067c368907b06da492d53a7808aedf9a47d02a16704ed93f5688c8) to render `data.auth_url` as a clickable Markdown link and suppresses any confirmation or follow-up message until OAuth is completed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5afa287.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->