### PR TITLE
Import companies from communication batches

### DIFF
--- a/.changeset/gmail-communication-companies.md
+++ b/.changeset/gmail-communication-companies.md
@@ -1,0 +1,5 @@
+---
+"@agent-crm/sdk": patch
+---
+
+Import companies and person-company links from hosted communication batches.

--- a/packages/cli/src/commands/import-communication.test.ts
+++ b/packages/cli/src/commands/import-communication.test.ts
@@ -11,12 +11,21 @@ describe("importCommunicationBatch", () => {
         {
           sourceKey: "gmail:me@example.com:email:alice@example.com",
           email: "alice@example.com",
-          displayName: "Alice"
+          displayName: "Alice",
+          companySourceKey: "gmail:me@example.com:company_domain:example.com"
         },
         {
           sourceKey: "gmail:me@example.com:email:bob@example.com",
           email: "bob@example.com",
-          displayName: "Bob"
+          displayName: "Bob",
+          companySourceKey: "gmail:me@example.com:company_domain:example.com"
+        }
+      ],
+      companies: [
+        {
+          sourceKey: "gmail:me@example.com:company_domain:example.com",
+          domain: "example.com",
+          name: "Example"
         }
       ],
       communicationThreads: [
@@ -60,20 +69,25 @@ describe("importCommunicationBatch", () => {
     const second = await importCommunicationBatch(ws, batch);
 
     expect(first.stats.people_created).toBe(2);
+    expect(first.stats.companies_created).toBe(1);
     expect(first.stats.communication_threads_created).toBe(1);
     expect(first.stats.communication_messages_created).toBe(1);
     expect(second.stats.people_created).toBe(0);
+    expect(second.stats.companies_created).toBe(0);
     expect(second.stats.communication_threads_created).toBe(0);
     expect(second.stats.communication_messages_created).toBe(0);
     await expect(countValues(lix)).resolves.toBe(valuesAfterFirstImport);
 
     await expect(countRecords(lix, "people")).resolves.toBe(2);
+    await expect(countRecords(lix, "companies")).resolves.toBe(1);
     await expect(countRecords(lix, "communication_threads")).resolves.toBe(1);
     await expect(countRecords(lix, "communication_messages")).resolves.toBe(1);
     await expect(hasAttribute(lix, "people", "communication_threads")).resolves.toBe(true);
     await expect(hasAttribute(lix, "people", "communication_messages")).resolves.toBe(true);
     await expect(countRefs(lix, "people", "communication_threads")).resolves.toBe(2);
     await expect(countRefs(lix, "people", "communication_messages")).resolves.toBe(2);
+    await expect(countRefs(lix, "people", "company")).resolves.toBe(2);
+    await expect(countRefs(lix, "companies", "team")).resolves.toBe(2);
     await expect(countRefs(lix, "communication_threads", "messages")).resolves.toBe(1);
 
     await lix.close();

--- a/packages/sdk/src/operations/import-communication.ts
+++ b/packages/sdk/src/operations/import-communication.ts
@@ -6,6 +6,7 @@ import {
 } from "../db/value-row.js";
 import {
   encode,
+  normalizeDomain as normalizeDomainValue,
   type AttributeConfig,
   type AttributeType,
   type ValueJson,
@@ -19,6 +20,13 @@ export type CommunicationImportPerson = {
   sourceKey: string;
   email?: string;
   displayName?: string;
+  companySourceKey?: string;
+};
+
+export type CommunicationImportCompany = {
+  sourceKey: string;
+  domain?: string;
+  name?: string;
 };
 
 export type CommunicationImportThread = {
@@ -56,6 +64,7 @@ export type CommunicationImportMessage = {
 
 export type CommunicationImportBatch = {
   people: CommunicationImportPerson[];
+  companies?: CommunicationImportCompany[];
   communicationThreads: CommunicationImportThread[];
   communicationMessages: CommunicationImportMessage[];
 };
@@ -64,6 +73,8 @@ export type CommunicationImportResult = {
   stats: {
     people_seen: number;
     people_created: number;
+    companies_seen: number;
+    companies_created: number;
     communication_threads_seen: number;
     communication_threads_created: number;
     communication_messages_seen: number;
@@ -72,7 +83,7 @@ export type CommunicationImportResult = {
 };
 
 type RecordPlan = {
-  objectSlug: "people" | "communication_threads" | "communication_messages";
+  objectSlug: "people" | "companies" | "communication_threads" | "communication_messages";
   recordId: string;
   created: boolean;
 };
@@ -120,6 +131,8 @@ export async function importCommunicationBatch(
   const stats: CommunicationImportResult["stats"] = {
     people_seen: batch.people.length,
     people_created: 0,
+    companies_seen: batch.companies?.length ?? 0,
+    companies_created: 0,
     communication_threads_seen: batch.communicationThreads.length,
     communication_threads_created: 0,
     communication_messages_seen: batch.communicationMessages.length,
@@ -131,11 +144,26 @@ export async function importCommunicationBatch(
   const plannedSourceIndex = new Map(sourceIndex);
   const emailIndex = await loadPeopleByEmail(lix, batch.people);
   const plannedEmailIndex = new Map(emailIndex);
+  const companies = batch.companies ?? [];
+  const domainIndex = await loadCompaniesByDomain(lix, companies);
+  const plannedDomainIndex = new Map(domainIndex);
 
   const personPlans = new Map<string, RecordPlan>();
+  const companyPlans = new Map<string, RecordPlan>();
   const threadPlans = new Map<string, RecordPlan>();
   const messagePlans = new Map<string, RecordPlan>();
   const recordsToCreate: RecordPlan[] = [];
+
+  for (const company of companies) {
+    if (companyPlans.has(company.sourceKey)) continue;
+    const domain = normalizeDomain(company.domain);
+    const existingRecordId = plannedSourceIndex.get(sourceIndexKey("companies", company.sourceKey)) ??
+      (domain ? plannedDomainIndex.get(domain) : undefined);
+    const plan = planRecord("companies", company.sourceKey, existingRecordId, recordsToCreate, plannedSourceIndex);
+    companyPlans.set(company.sourceKey, plan);
+    if (domain) plannedDomainIndex.set(domain, plan.recordId);
+    if (plan.created) stats.companies_created++;
+  }
 
   for (const person of batch.people) {
     if (personPlans.has(person.sourceKey)) continue;
@@ -167,7 +195,15 @@ export async function importCommunicationBatch(
   const threadSourceByProviderId = new Map(
     batch.communicationThreads.map((thread) => [thread.providerThreadId, thread.sourceKey]),
   );
-  const touchedRecords = collectTouchedRecords(batch, personPlans, threadPlans, messagePlans, plannedSourceIndex, threadSourceByProviderId);
+  const touchedRecords = collectTouchedRecords(
+    batch,
+    personPlans,
+    companyPlans,
+    threadPlans,
+    messagePlans,
+    plannedSourceIndex,
+    threadSourceByProviderId,
+  );
   const existingValues = await loadExistingValues(lix, touchedRecords);
   const writer = new CommunicationWriteBatcher(lix);
 
@@ -187,6 +223,29 @@ export async function importCommunicationBatch(
     }
     if (person.displayName) {
       enqueueSingle(writer, existingValues, plan, "name", "personal-name", person.displayName);
+    }
+    if (person.companySourceKey) {
+      const companyId = resolveRecordId("companies", person.companySourceKey, companyPlans, plannedSourceIndex);
+      if (companyId) {
+        enqueueSingleReference(writer, existingValues, plan, "company", "companies", companyId);
+        enqueueReference(writer, existingValues, {
+          objectSlug: "companies",
+          recordId: companyId,
+          created: isCreatedRecord(recordsToCreate, "companies", companyId),
+        }, "team", "people", plan.recordId);
+      }
+    }
+  }
+
+  for (const company of companies) {
+    const plan = companyPlans.get(company.sourceKey);
+    if (!plan) continue;
+    enqueueMulti(writer, existingValues, plan, "source_keys", "text", company.sourceKey);
+    if (company.domain) {
+      enqueueMulti(writer, existingValues, plan, "domains", "domain", company.domain);
+    }
+    if (company.name) {
+      enqueueSingle(writer, existingValues, plan, "name", "text", company.name);
     }
   }
 
@@ -318,7 +377,11 @@ function planRecord(
 
 function collectSourceKeys(batch: CommunicationImportBatch): string[] {
   const keys = new Set<string>();
-  for (const person of batch.people) keys.add(person.sourceKey);
+  for (const company of batch.companies ?? []) keys.add(company.sourceKey);
+  for (const person of batch.people) {
+    keys.add(person.sourceKey);
+    if (person.companySourceKey) keys.add(person.companySourceKey);
+  }
   for (const thread of batch.communicationThreads) {
     keys.add(thread.sourceKey);
     for (const participant of thread.participantSourceKeys ?? []) keys.add(participant);
@@ -386,9 +449,37 @@ async function loadPeopleByEmail(
   return index;
 }
 
+async function loadCompaniesByDomain(
+  lix: Workspace["lix"],
+  companies: CommunicationImportCompany[],
+): Promise<Map<string, string>> {
+  const domains = unique(companies.map((company) => normalizeDomain(company.domain)).filter((domain): domain is string => Boolean(domain)));
+  const index = new Map<string, string>();
+  for (const chunk of chunks(domains, SELECT_CHUNK_SIZE)) {
+    const placeholders = chunk.map((_, index) => `$${index + 1}`).join(", ");
+    const result = await exec(
+      lix,
+      `SELECT record_id, normalized_key
+       FROM acrm_value
+       WHERE active_until IS NULL
+         AND object_slug = 'companies'
+         AND attribute_slug = 'domains'
+         AND normalized_key IN (${placeholders})`,
+      chunk,
+    );
+    for (const row of result.rows) {
+      if (typeof row.record_id === "string" && typeof row.normalized_key === "string") {
+        index.set(row.normalized_key, row.record_id);
+      }
+    }
+  }
+  return index;
+}
+
 function collectTouchedRecords(
   batch: CommunicationImportBatch,
   personPlans: Map<string, RecordPlan>,
+  companyPlans: Map<string, RecordPlan>,
   threadPlans: Map<string, RecordPlan>,
   messagePlans: Map<string, RecordPlan>,
   plannedSourceIndex: Map<string, string>,
@@ -403,8 +494,14 @@ function collectTouchedRecords(
   };
 
   for (const plan of personPlans.values()) add(plan.objectSlug, plan.recordId);
+  for (const plan of companyPlans.values()) add(plan.objectSlug, plan.recordId);
   for (const plan of threadPlans.values()) add(plan.objectSlug, plan.recordId);
   for (const plan of messagePlans.values()) add(plan.objectSlug, plan.recordId);
+
+  for (const person of batch.people) {
+    if (!person.companySourceKey) continue;
+    add("companies", resolveRecordId("companies", person.companySourceKey, companyPlans, plannedSourceIndex));
+  }
 
   for (const thread of batch.communicationThreads) {
     for (const personSourceKey of thread.participantSourceKeys ?? []) {
@@ -757,6 +854,11 @@ function sameValueJson(left: ValueJson, right: ValueJson): boolean {
 
 function normalizeEmail(email: string | undefined): string | undefined {
   const normalized = email?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+function normalizeDomain(domain: string | undefined): string | undefined {
+  const normalized = domain ? normalizeDomainValue(domain) : undefined;
   return normalized || undefined;
 }
 

--- a/packages/sdk/src/workspace/seeds.ts
+++ b/packages/sdk/src/workspace/seeds.ts
@@ -29,6 +29,7 @@ const OBJECTS: ObjectSeed[] = [
 
 const ATTRIBUTES: AttributeSeed[] = [
   // companies
+  { object_slug: "companies", attribute_slug: "source_keys", title: "Source keys", attribute_type: "text", is_multivalued: true, is_unique: true },
   { object_slug: "companies", attribute_slug: "name", title: "Name", attribute_type: "text", is_multivalued: false, is_unique: false },
   { object_slug: "companies", attribute_slug: "domains", title: "Domains", attribute_type: "domain", is_multivalued: true, is_unique: true },
   { object_slug: "companies", attribute_slug: "description", title: "Description", attribute_type: "text", is_multivalued: false, is_unique: false },


### PR DESCRIPTION
## Summary\n- extend importCommunicationBatch with optional companies\n- dedupe companies by domain and source key\n- link imported people to companies with people.company and companies.team\n- add SDK changeset for release\n\n## Tests\n- npm run build --workspace @agent-crm/sdk\n- npm run test --workspace @agent-crm/cli -- import-communication\n- npm run test --workspace @agent-crm/sdk

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Import companies from communication batches in `importCommunicationBatch`
> - Extends `importCommunicationBatch` in [import-communication.ts](https://github.com/cluster-software/agent-crm/pull/118/files#diff-661a21cea325c42d9744840a31f3f1b84f30ce87c2bacb33724e77dd96f84221) to accept a `companies` array and an optional `companySourceKey` on each person.
> - Companies are created or reused by source key or normalized domain, with attributes (`source_keys`, `domains`, `name`) written on each record.
> - People with a `companySourceKey` get bidirectional links: `person.company → companies` and `companies.team → people`.
> - Adds `companies_seen` and `companies_created` to the result stats for idempotency tracking.
> - Seeds the `companies.source_keys` attribute in [seeds.ts](https://github.com/cluster-software/agent-crm/pull/118/files#diff-e4ce857ac7ed9f022d6d03e8ee46e137426655be361db110ec330791dfe8ab77) for new workspaces.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee70bee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->