### PR TITLE
Add hosted LinkedIn connect and sync

### DIFF
--- a/packages/cli/src/bin/acrm.ts
+++ b/packages/cli/src/bin/acrm.ts
@@ -61,6 +61,7 @@ Typical flow:
   acrm init <name>.acrm           create a workspace
   acrm import csv ./leads.csv     load people + companies (and deals if columns present)
   acrm import gmail               connect Gmail through Agent CRM's hosted sync engine
+  acrm import linkedin            connect LinkedIn through Agent CRM's hosted sync engine
   acrm import linkedin <url>      add one person from a LinkedIn profile (creates person + company)
   acrm import x <handle>          add one person from an X/Twitter profile
   acrm import post <url>          add a LinkedIn or X **post** by URL — upserts the author as a person and stores the post (use when a user shares a post link they want to track)

--- a/packages/cli/src/commands/import-gmail.ts
+++ b/packages/cli/src/commands/import-gmail.ts
@@ -1,19 +1,9 @@
 import type { Command } from "commander";
-import { randomUUID } from "node:crypto";
-import { readFileSync, writeFileSync } from "node:fs";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname } from "node:path";
 import { AcrmError, ERR } from "@agent-crm/sdk";
 import { resolveWorkspacePath } from "../workspace-resolve.js";
 import { fail, isJson, ok, setJsonMode } from "../output/json.js";
-
-const DEFAULT_SYNC_ENGINE_URL = "https://agent-crm-sync-engine.onrender.com";
-const CLOUD_METADATA_FILENAME = ".agent-crm-cloud.json";
-
-type CloudMetadata = {
-  workspaceId?: string;
-  clientToken?: string;
-  createdAt?: string;
-};
+import { DEFAULT_SYNC_ENGINE_URL, ensureCloudWorkspaceMetadata } from "../lib/cloud-workspace.js";
 
 export function attachGmailSubcommand(parent: Command): void {
   parent
@@ -66,40 +56,6 @@ export function attachGmailSubcommand(parent: Command): void {
         process.exit(1);
       }
     });
-}
-
-function ensureCloudWorkspaceMetadata(
-  workspaceDir: string,
-  preferred: { workspaceId?: string; clientToken?: string } = {},
-): { workspaceId: string; clientToken: string } {
-  const metadataPath = join(workspaceDir, CLOUD_METADATA_FILENAME);
-  const existing = readCloudMetadata(metadataPath);
-  const workspaceId = existing.workspaceId || preferred.workspaceId || randomUUID();
-  const clientToken = existing.clientToken || preferred.clientToken || randomUUID();
-
-  if (workspaceId !== existing.workspaceId || clientToken !== existing.clientToken) {
-    writeFileSync(
-      metadataPath,
-      `${JSON.stringify({
-        ...existing,
-        workspaceId,
-        clientToken,
-        createdAt: existing.createdAt ?? new Date().toISOString(),
-      }, null, 2)}\n`,
-      "utf8"
-    );
-  }
-
-  return { workspaceId, clientToken };
-}
-
-function readCloudMetadata(metadataPath: string): CloudMetadata {
-  try {
-    const parsed = JSON.parse(readFileSync(metadataPath, "utf8")) as CloudMetadata;
-    return parsed && typeof parsed === "object" ? parsed : {};
-  } catch {
-    return {};
-  }
 }
 
 async function createGmailConnectUrl(input: {

--- a/packages/cli/src/commands/import-linkedin.test.ts
+++ b/packages/cli/src/commands/import-linkedin.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { __test as linkedinCommandTest } from "./import-linkedin.js";
+
+describe("import linkedin command", () => {
+  it("builds a hosted sync-engine LinkedIn connect URL", () => {
+    const url = linkedinCommandTest.linkedinConnectUrl({
+      syncEngineUrl: "https://sync.example.com",
+      workspaceId: "workspace-1",
+      clusterOrgId: "org-1",
+      workspaceName: "pipeline",
+    });
+
+    expect(url).toBe(
+      "https://sync.example.com/integrations/linkedin/connect?workspace_id=workspace-1&cluster_org_id=org-1&workspace_name=pipeline",
+    );
+  });
+});

--- a/packages/cli/src/commands/import-linkedin.ts
+++ b/packages/cli/src/commands/import-linkedin.ts
@@ -4,13 +4,20 @@ import {
   AcrmError,
   ERR,
   Workspace,
+  importCommunicationBatch,
   importLinkedinProfile,
+  type CommunicationImportResult,
   type LinkedinImportResult,
 } from "@agent-crm/sdk";
 import { resolveWorkspacePath } from "../workspace-resolve.js";
 import { fail, isJson, ok, setJsonMode } from "../output/json.js";
 import { loadDotenv } from "../lib/dotenv.js";
-import { DEFAULT_SYNC_ENGINE_URL, ensureCloudWorkspaceMetadata } from "../lib/cloud-workspace.js";
+import {
+  DEFAULT_SYNC_ENGINE_URL,
+  ensureCloudWorkspaceMetadata,
+  fetchCloudCommunicationExport,
+  registerCloudWorkspace,
+} from "../lib/cloud-workspace.js";
 import { type BackgroundSignalRun, startMissingSignalsForRecords } from "../signals.js";
 
 type Opts = {
@@ -18,6 +25,7 @@ type Opts = {
   cache?: boolean; // commander negation: --no-cache → cache=false
   signals?: boolean;
   orgId?: string;
+  sync?: boolean;
 };
 
 export function attachLinkedinSubcommand(parent: Command): void {
@@ -27,6 +35,7 @@ export function attachLinkedinSubcommand(parent: Command): void {
       "With no URL, connect LinkedIn through Agent CRM's hosted sync engine. With a LinkedIn profile URL (or `/in/<slug>`), import one person locally via Apify. For a LinkedIn post URL instead, use `acrm import post`.",
     )
     .option("--org-id <org-id>", "Cluster organization id for hosted LinkedIn sync")
+    .option("--sync", "pull LinkedIn messages from Agent CRM's hosted sync engine into this workspace")
     .option("--refresh", "bypass cache and re-fetch from Apify")
     .option("--no-cache", "do not write the response to cache")
     .option("--no-signals", "skip local signals after importing records")
@@ -36,8 +45,18 @@ export function attachLinkedinSubcommand(parent: Command): void {
         | undefined;
       setJsonMode(root?.json);
       try {
+        if (opts.sync) {
+          if (urlOrSlug) {
+            throw new AcrmError("--sync does not accept a LinkedIn profile URL", ERR.INVALID_INPUT);
+          }
+          const result = await runSyncLinkedin({
+            workspace: root?.workspace,
+          });
+          ok(result);
+          return;
+        }
         if (!urlOrSlug) {
-          const result = runConnectLinkedin({
+          const result = await runConnectLinkedin({
             workspace: root?.workspace,
             orgId: opts.orgId,
           });
@@ -80,12 +99,12 @@ export function attachLinkedinSubcommand(parent: Command): void {
     });
 }
 
-function runConnectLinkedin(opts: { workspace?: string; orgId?: string }): {
+async function runConnectLinkedin(opts: { workspace?: string; orgId?: string }): Promise<{
   auth_url: string;
   workspace_id: string;
   cluster_org_id: string;
   sync_engine_url: string;
-} {
+}> {
   const workspaceFile = resolveWorkspacePath(opts.workspace);
   const workspaceDir = path.dirname(workspaceFile);
   const metadata = ensureCloudWorkspaceMetadata(workspaceDir, {
@@ -101,6 +120,12 @@ function runConnectLinkedin(opts: { workspace?: string; orgId?: string }): {
     );
   }
   const syncEngineUrl = process.env.ACRM_SYNC_ENGINE_URL ?? DEFAULT_SYNC_ENGINE_URL;
+  await registerCloudWorkspace({
+    syncEngineUrl,
+    workspaceId: metadata.workspaceId,
+    clientToken: metadata.clientToken,
+    workspaceName: path.basename(workspaceDir),
+  });
   return {
     auth_url: linkedinConnectUrl({
       syncEngineUrl,
@@ -112,6 +137,38 @@ function runConnectLinkedin(opts: { workspace?: string; orgId?: string }): {
     cluster_org_id: metadata.clusterOrgId,
     sync_engine_url: syncEngineUrl,
   };
+}
+
+async function runSyncLinkedin(opts: { workspace?: string }): Promise<{
+  workspace_id: string;
+  sync_engine_url: string;
+  stats: CommunicationImportResult["stats"];
+}> {
+  const workspaceFile = resolveWorkspacePath(opts.workspace);
+  const workspaceDir = path.dirname(workspaceFile);
+  const metadata = ensureCloudWorkspaceMetadata(workspaceDir, {
+    workspaceId: process.env.ACRM_CLOUD_WORKSPACE_ID,
+    clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,
+    clusterOrgId: process.env.ACRM_CLOUD_CLUSTER_ORG_ID,
+  });
+  const syncEngineUrl = process.env.ACRM_SYNC_ENGINE_URL ?? DEFAULT_SYNC_ENGINE_URL;
+  const batch = await fetchCloudCommunicationExport({
+    syncEngineUrl,
+    workspaceId: metadata.workspaceId,
+    clientToken: metadata.clientToken,
+    provider: "linkedin",
+  });
+  const ws = await Workspace.open(workspaceFile);
+  try {
+    const result = await importCommunicationBatch(ws, batch);
+    return {
+      workspace_id: metadata.workspaceId,
+      sync_engine_url: syncEngineUrl,
+      stats: result.stats,
+    };
+  } finally {
+    await ws.close();
+  }
 }
 
 async function runImportLinkedin(

--- a/packages/cli/src/commands/import-linkedin.ts
+++ b/packages/cli/src/commands/import-linkedin.ts
@@ -8,31 +8,54 @@ import {
   type LinkedinImportResult,
 } from "@agent-crm/sdk";
 import { resolveWorkspacePath } from "../workspace-resolve.js";
-import { fail, ok, setJsonMode } from "../output/json.js";
+import { fail, isJson, ok, setJsonMode } from "../output/json.js";
 import { loadDotenv } from "../lib/dotenv.js";
+import { DEFAULT_SYNC_ENGINE_URL, ensureCloudWorkspaceMetadata } from "../lib/cloud-workspace.js";
 import { type BackgroundSignalRun, startMissingSignalsForRecords } from "../signals.js";
 
 type Opts = {
   refresh?: boolean;
   cache?: boolean; // commander negation: --no-cache → cache=false
   signals?: boolean;
+  orgId?: string;
 };
 
 export function attachLinkedinSubcommand(parent: Command): void {
   parent
-    .command("linkedin <url-or-slug>")
+    .command("linkedin [url-or-slug]")
     .description(
-      "Import a person from a LinkedIn profile URL (or `/in/<slug>`). Use when the user shares a LinkedIn **profile** link (e.g. \"add this person\", \"import this LinkedIn\"). For a LinkedIn **post** URL instead, use `acrm import post`. Fetches the profile via Apify, upserts the person (deduped by linkedin_url), and creates/links their current employer as a company. Requires APIFY_API_TOKEN in .env.",
+      "With no URL, connect LinkedIn through Agent CRM's hosted sync engine. With a LinkedIn profile URL (or `/in/<slug>`), import one person locally via Apify. For a LinkedIn post URL instead, use `acrm import post`.",
     )
+    .option("--org-id <org-id>", "Cluster organization id for hosted LinkedIn sync")
     .option("--refresh", "bypass cache and re-fetch from Apify")
     .option("--no-cache", "do not write the response to cache")
     .option("--no-signals", "skip local signals after importing records")
-    .action(async (urlOrSlug: string, opts: Opts) => {
+    .action(async (urlOrSlug: string | undefined, opts: Opts) => {
       const root = parent.parent?.opts() as
         | { workspace?: string; json?: boolean }
         | undefined;
       setJsonMode(root?.json);
       try {
+        if (!urlOrSlug) {
+          const result = runConnectLinkedin({
+            workspace: root?.workspace,
+            orgId: opts.orgId,
+          });
+          if (!isJson()) {
+            process.stdout.write(
+              [
+                "Open this URL to connect LinkedIn:",
+                result.auth_url,
+                "",
+                "After login, LinkedIn sync runs in the background through Agent CRM's hosted sync engine.",
+                "",
+              ].join("\n")
+            );
+            return;
+          }
+          ok(result);
+          return;
+        }
         const result = await runImportLinkedin(urlOrSlug, {
           workspace: root?.workspace,
           refresh: opts.refresh,
@@ -55,6 +78,40 @@ export function attachLinkedinSubcommand(parent: Command): void {
         process.exit(1);
       }
     });
+}
+
+function runConnectLinkedin(opts: { workspace?: string; orgId?: string }): {
+  auth_url: string;
+  workspace_id: string;
+  cluster_org_id: string;
+  sync_engine_url: string;
+} {
+  const workspaceFile = resolveWorkspacePath(opts.workspace);
+  const workspaceDir = path.dirname(workspaceFile);
+  const metadata = ensureCloudWorkspaceMetadata(workspaceDir, {
+    workspaceId: process.env.ACRM_CLOUD_WORKSPACE_ID,
+    clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,
+    clusterOrgId: opts.orgId ?? process.env.ACRM_CLOUD_CLUSTER_ORG_ID,
+  });
+  if (!metadata.clusterOrgId) {
+    throw new AcrmError(
+      "Cluster organization is not configured",
+      ERR.INVALID_INPUT,
+      "pass --org-id <cluster-org-id> once or set ACRM_CLOUD_CLUSTER_ORG_ID",
+    );
+  }
+  const syncEngineUrl = process.env.ACRM_SYNC_ENGINE_URL ?? DEFAULT_SYNC_ENGINE_URL;
+  return {
+    auth_url: linkedinConnectUrl({
+      syncEngineUrl,
+      workspaceId: metadata.workspaceId,
+      clusterOrgId: metadata.clusterOrgId,
+      workspaceName: path.basename(workspaceDir),
+    }),
+    workspace_id: metadata.workspaceId,
+    cluster_org_id: metadata.clusterOrgId,
+    sync_engine_url: syncEngineUrl,
+  };
 }
 
 async function runImportLinkedin(
@@ -109,3 +166,20 @@ async function runImportLinkedin(
     ...(signalRun?.warning ? { signals_warning: signalRun.warning } : {}),
   };
 }
+
+function linkedinConnectUrl(input: {
+  syncEngineUrl: string;
+  workspaceId: string;
+  clusterOrgId: string;
+  workspaceName: string;
+}): string {
+  const url = new URL("/integrations/linkedin/connect", input.syncEngineUrl);
+  url.searchParams.set("workspace_id", input.workspaceId);
+  url.searchParams.set("cluster_org_id", input.clusterOrgId);
+  url.searchParams.set("workspace_name", input.workspaceName || "Agent CRM workspace");
+  return url.toString();
+}
+
+export const __test = {
+  linkedinConnectUrl,
+};

--- a/packages/cli/src/commands/import-linkedin.ts
+++ b/packages/cli/src/commands/import-linkedin.ts
@@ -107,6 +107,9 @@ async function runConnectLinkedin(opts: { workspace?: string; orgId?: string }):
 }> {
   const workspaceFile = resolveWorkspacePath(opts.workspace);
   const workspaceDir = path.dirname(workspaceFile);
+  loadDotenv(workspaceDir);
+  loadDotenv(process.cwd());
+
   const metadata = ensureCloudWorkspaceMetadata(workspaceDir, {
     workspaceId: process.env.ACRM_CLOUD_WORKSPACE_ID,
     clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,
@@ -146,6 +149,9 @@ async function runSyncLinkedin(opts: { workspace?: string }): Promise<{
 }> {
   const workspaceFile = resolveWorkspacePath(opts.workspace);
   const workspaceDir = path.dirname(workspaceFile);
+  loadDotenv(workspaceDir);
+  loadDotenv(process.cwd());
+
   const metadata = ensureCloudWorkspaceMetadata(workspaceDir, {
     workspaceId: process.env.ACRM_CLOUD_WORKSPACE_ID,
     clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,

--- a/packages/cli/src/lib/cloud-workspace.test.ts
+++ b/packages/cli/src/lib/cloud-workspace.test.ts
@@ -1,10 +1,18 @@
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
-import { ensureCloudWorkspaceMetadata } from "./cloud-workspace.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ensureCloudWorkspaceMetadata,
+  fetchCloudCommunicationExport,
+  registerCloudWorkspace
+} from "./cloud-workspace.js";
 
 describe("cloud workspace metadata", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("persists a preferred Cluster org id for future hosted connects", async () => {
     const dir = await mkdtemp(join(tmpdir(), "acrm-cloud-workspace-"));
     try {
@@ -24,5 +32,53 @@ describe("cloud workspace metadata", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  it("registers a cloud workspace with the sync engine", async () => {
+    const fetchMock = vi.fn(async () => Response.json({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await registerCloudWorkspace({
+      syncEngineUrl: "https://sync.example.com",
+      workspaceId: "workspace-1",
+      clientToken: "client-token-1",
+      workspaceName: "pipeline",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://sync.example.com/workspaces/workspace-1/register?workspace_name=pipeline",
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer client-token-1",
+        },
+      },
+    );
+  });
+
+  it("fetches linkedIn communication export data", async () => {
+    const data = {
+      people: [],
+      communicationThreads: [],
+      communicationMessages: [],
+    };
+    const fetchMock = vi.fn(async () => Response.json({ ok: true, data }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchCloudCommunicationExport({
+      syncEngineUrl: "https://sync.example.com",
+      workspaceId: "workspace-1",
+      clientToken: "client-token-1",
+      provider: "linkedin",
+    })).resolves.toEqual(data);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://sync.example.com/workspaces/workspace-1/integrations/linkedin/export",
+      {
+        headers: {
+          authorization: "Bearer client-token-1",
+        },
+      },
+    );
   });
 });

--- a/packages/cli/src/lib/cloud-workspace.test.ts
+++ b/packages/cli/src/lib/cloud-workspace.test.ts
@@ -1,0 +1,28 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { ensureCloudWorkspaceMetadata } from "./cloud-workspace.js";
+
+describe("cloud workspace metadata", () => {
+  it("persists a preferred Cluster org id for future hosted connects", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "acrm-cloud-workspace-"));
+    try {
+      const first = ensureCloudWorkspaceMetadata(dir, {
+        workspaceId: "workspace-1",
+        clientToken: "client-token-1",
+        clusterOrgId: "org-1",
+      });
+      const second = ensureCloudWorkspaceMetadata(dir);
+      const raw = JSON.parse(await readFile(join(dir, ".agent-crm-cloud.json"), "utf8")) as {
+        clusterOrgId?: string;
+      };
+
+      expect(first.clusterOrgId).toBe("org-1");
+      expect(second.clusterOrgId).toBe("org-1");
+      expect(raw.clusterOrgId).toBe("org-1");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/lib/cloud-workspace.ts
+++ b/packages/cli/src/lib/cloud-workspace.ts
@@ -1,0 +1,57 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export const DEFAULT_SYNC_ENGINE_URL = "https://agent-crm-sync-engine.onrender.com";
+const CLOUD_METADATA_FILENAME = ".agent-crm-cloud.json";
+
+export type CloudMetadata = {
+  workspaceId?: string;
+  clientToken?: string;
+  clusterOrgId?: string;
+  createdAt?: string;
+};
+
+export function ensureCloudWorkspaceMetadata(
+  workspaceDir: string,
+  preferred: { workspaceId?: string; clientToken?: string; clusterOrgId?: string } = {},
+): { workspaceId: string; clientToken: string; clusterOrgId?: string } {
+  const metadataPath = join(workspaceDir, CLOUD_METADATA_FILENAME);
+  const existing = readCloudMetadata(metadataPath);
+  const workspaceId = existing.workspaceId || preferred.workspaceId || randomUUID();
+  const clientToken = existing.clientToken || preferred.clientToken || randomUUID();
+  const clusterOrgId = preferred.clusterOrgId || existing.clusterOrgId;
+
+  if (
+    workspaceId !== existing.workspaceId ||
+    clientToken !== existing.clientToken ||
+    clusterOrgId !== existing.clusterOrgId
+  ) {
+    writeFileSync(
+      metadataPath,
+      `${JSON.stringify({
+        ...existing,
+        workspaceId,
+        clientToken,
+        ...(clusterOrgId ? { clusterOrgId } : {}),
+        createdAt: existing.createdAt ?? new Date().toISOString(),
+      }, null, 2)}\n`,
+      "utf8"
+    );
+  }
+
+  return {
+    workspaceId,
+    clientToken,
+    ...(clusterOrgId ? { clusterOrgId } : {}),
+  };
+}
+
+function readCloudMetadata(metadataPath: string): CloudMetadata {
+  try {
+    const parsed = JSON.parse(readFileSync(metadataPath, "utf8")) as CloudMetadata;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}

--- a/packages/cli/src/lib/cloud-workspace.ts
+++ b/packages/cli/src/lib/cloud-workspace.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { AcrmError, ERR, type CommunicationImportBatch } from "@agent-crm/sdk";
 
 export const DEFAULT_SYNC_ENGINE_URL = "https://agent-crm-sync-engine.onrender.com";
 const CLOUD_METADATA_FILENAME = ".agent-crm-cloud.json";
@@ -54,4 +55,58 @@ function readCloudMetadata(metadataPath: string): CloudMetadata {
   } catch {
     return {};
   }
+}
+
+export async function registerCloudWorkspace(input: {
+  syncEngineUrl: string;
+  workspaceId: string;
+  clientToken: string;
+  workspaceName: string;
+}): Promise<void> {
+  const url = new URL(`/workspaces/${encodeURIComponent(input.workspaceId)}/register`, input.syncEngineUrl);
+  url.searchParams.set("workspace_name", input.workspaceName || "Agent CRM workspace");
+  const response = await fetch(url.toString(), {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${input.clientToken}`,
+    },
+  });
+  const payload = await response.json().catch(() => undefined) as
+    | { ok?: unknown; error?: unknown }
+    | undefined;
+  if (!response.ok || payload?.ok !== true) {
+    throw new AcrmError(
+      "failed to register cloud workspace",
+      ERR.IMPORT,
+      typeof payload?.error === "string" ? payload.error : `sync engine returned HTTP ${response.status}`,
+    );
+  }
+}
+
+export async function fetchCloudCommunicationExport(input: {
+  syncEngineUrl: string;
+  workspaceId: string;
+  clientToken: string;
+  provider: "gmail" | "linkedin";
+}): Promise<CommunicationImportBatch> {
+  const url = new URL(
+    `/workspaces/${encodeURIComponent(input.workspaceId)}/integrations/${input.provider}/export`,
+    input.syncEngineUrl,
+  );
+  const response = await fetch(url.toString(), {
+    headers: {
+      authorization: `Bearer ${input.clientToken}`,
+    },
+  });
+  const payload = await response.json().catch(() => undefined) as
+    | { ok?: unknown; data?: unknown; error?: unknown }
+    | undefined;
+  if (!response.ok || payload?.ok !== true || !payload.data || typeof payload.data !== "object") {
+    throw new AcrmError(
+      `failed to export ${input.provider} communication data`,
+      ERR.IMPORT,
+      typeof payload?.error === "string" ? payload.error : `sync engine returned HTTP ${response.status}`,
+    );
+  }
+  return payload.data as CommunicationImportBatch;
 }


### PR DESCRIPTION
## Summary
- add hosted LinkedIn connect flow for local .acrm workspaces
- create/register cloud workspace metadata with the sync engine
- add LinkedIn cloud export sync into local communication import
- cover cloud workspace registration and LinkedIn import command behavior in tests

## Verification
- npm run build --workspace @agent-crm/sdk
- npm run build --workspace @agent-crm/cli
- npm run test --workspace @agent-crm/cli

Note: I had to run npm rebuild better-sqlite3 locally because node_modules had been built for a different Node ABI.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hosted LinkedIn connect and sync to `acrm import linkedin`
> - Adds two new modes to the `acrm import linkedin` command: a connect flow (no argument) that registers the workspace with the hosted sync engine and returns a LinkedIn OAuth URL, and a `--sync` mode that fetches a LinkedIn communication export from the sync engine and imports it into the local workspace.
> - Extracts shared cloud workspace utilities (`ensureCloudWorkspaceMetadata`, `registerCloudWorkspace`, `fetchCloudCommunicationExport`, `DEFAULT_SYNC_ENGINE_URL`) into [`lib/cloud-workspace.ts`](https://github.com/cluster-software/agent-crm/pull/120/files#diff-dc6510de9617586a0aa8a79f5c9728fc7df1f39cd1bf1e4d708624e7fb8ccd20), replacing duplicate code previously in [`import-gmail.ts`](https://github.com/cluster-software/agent-crm/pull/120/files#diff-36789d97aa605afd689fd8e3680527a4ed53b7308da55e0aef8403eb0bb206bc).
> - The connect flow requires a `clusterOrgId` (settable via `--org-id`) to be present in the cloud metadata file; missing values throw a structured `AcrmError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61245c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->