### PR TITLE
Add bundled LinkedIn connect skill

### DIFF
--- a/packages/cli/skills/connect-linkedin-to-acrm.md
+++ b/packages/cli/skills/connect-linkedin-to-acrm.md
@@ -1,0 +1,87 @@
+---
+name: connect-linkedin-to-acrm
+description: Connect LinkedIn to an Agent CRM / ACRM workspace through the hosted sync engine. Use when the user asks to connect, integrate, hook up, sync, import, or troubleshoot LinkedIn with Agent CRM, ACRM, or an `.acrm` workspace.
+---
+
+# connect-linkedin-to-acrm
+
+Use this when the user wants LinkedIn messages synced into their current `.acrm` workspace.
+
+## What this does
+
+This is the hosted LinkedIn sync flow:
+
+1. The local workspace gets a cloud workspace binding in `.agent-crm-cloud.json`.
+2. The user opens Agent CRM's hosted LinkedIn connect page.
+3. The sync engine receives post-connection LinkedIn message events from Unipile.
+4. The local workspace imports those messages as `people`, `communication_threads`, and `communication_messages`.
+
+It is not a full LinkedIn contact-book or history backfill.
+
+## Run
+
+First confirm the workspace path. If the user did not provide one, use the current directory and run:
+
+```sh
+find . -maxdepth 2 -name '*.acrm' -print
+```
+
+If no workspace is found, ask which `.acrm` file to use or initialize one:
+
+```sh
+acrm init workspace.acrm
+```
+
+Set the workspace path:
+
+```sh
+export WORKSPACE=/path/to/workspace.acrm
+```
+
+Find the Cluster org id from existing workspace config or env. This id comes from Cluster after the user creates or joins an organization; do not invent it.
+
+```sh
+WORKSPACE_DIR="$(dirname "$WORKSPACE")"
+ORG_ID="${ACRM_CLOUD_CLUSTER_ORG_ID:-$(jq -r '.clusterOrgId // empty' "$WORKSPACE_DIR/.agent-crm-cloud.json" 2>/dev/null)}"
+```
+
+If `ORG_ID` is empty, stop and ask the user which Cluster organization to connect.
+
+Start the connect flow with the resolved org:
+
+```sh
+CONNECT_JSON=$(acrm --json -w "$WORKSPACE" import linkedin --org-id "$ORG_ID")
+echo "$CONNECT_JSON"
+open "$(echo "$CONNECT_JSON" | jq -r '.data.auth_url')"
+```
+
+Have the user finish Cluster auth and LinkedIn verification in the browser. LinkedIn may ask for an email, SMS, or authenticator-app code.
+
+## Sync now
+
+After the browser flow completes, pull any available LinkedIn messages:
+
+```sh
+acrm --json -w "$WORKSPACE" import linkedin --sync
+```
+
+Verify recent imported message bodies:
+
+```sh
+acrm --json -w "$WORKSPACE" execute "
+SELECT value_json, active_from
+FROM acrm_value
+WHERE object_slug = 'communication_messages'
+  AND attribute_slug = 'body_text'
+  AND active_until IS NULL
+ORDER BY active_from DESC
+LIMIT 5
+"
+```
+
+## Hard rules
+
+- Do not fabricate a Cluster org id.
+- Do not ask for or store the user's LinkedIn password in chat.
+- Do not use Gmail commands for this flow.
+- If `acrm` is missing, tell the user to install it with `npm i -g @agent-crm/cli`.


### PR DESCRIPTION
## Summary
- Add a bundled `connect-linkedin-to-acrm` skill for connecting LinkedIn sync to an .acrm workspace
- Document hosted sync-engine connect, manual sync, verification query, and local sync-engine testing

## Tests
- `npm run build --workspace @agent-crm/sdk`
- `npm run build --workspace @agent-crm/cli`
- `node --input-type=module -e "import { discoverBundledSkills } from './packages/cli/dist/skills-installer/skill.js'; const skills = await discoverBundledSkills(new URL('./packages/cli/skills', import.meta.url).pathname); const hit = skills.find((s) => s.name === 'connect-linkedin-to-acrm'); if (!hit) throw new Error('skill not discovered'); console.log(JSON.stringify({name: hit.name, description: hit.description}, null, 2));"`
- `npm test --workspace @agent-crm/cli`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add bundled LinkedIn connect skill for Agent CRM workspaces
> Adds [connect-linkedin-to-acrm.md](https://github.com/cluster-software/agent-crm/pull/121/files#diff-b969a2be9eded716d7c83777adc64e3813af3bfc9f1bb352f2a6e1438ab5e35f), a skill document with step-by-step instructions for connecting LinkedIn to an ACRM workspace via a hosted sync engine. Covers workspace initialization, org ID derivation, OAuth auth flow via `acrm import linkedin`, initial sync, and a SQL verification query. Includes hard rules around Cluster org IDs, credential handling, and installation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4224bec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->