### PR TITLE
Let LinkedIn connect infer Cluster org

### DIFF
--- a/packages/cli/skills/connect-linkedin-to-acrm.md
+++ b/packages/cli/skills/connect-linkedin-to-acrm.md
@@ -38,24 +38,15 @@ Set the workspace path:
 export WORKSPACE=/path/to/workspace.acrm
 ```
 
-Find the Cluster org id from existing workspace config or env. This id comes from Cluster after the user creates or joins an organization; do not invent it.
+Start the connect flow:
 
 ```sh
-WORKSPACE_DIR="$(dirname "$WORKSPACE")"
-ORG_ID="${ACRM_CLOUD_CLUSTER_ORG_ID:-$(jq -r '.clusterOrgId // empty' "$WORKSPACE_DIR/.agent-crm-cloud.json" 2>/dev/null)}"
-```
-
-If `ORG_ID` is empty, stop and ask the user which Cluster organization to connect.
-
-Start the connect flow with the resolved org:
-
-```sh
-CONNECT_JSON=$(acrm --json -w "$WORKSPACE" import linkedin --org-id "$ORG_ID")
+CONNECT_JSON=$(acrm --json -w "$WORKSPACE" import linkedin)
 echo "$CONNECT_JSON"
 open "$(echo "$CONNECT_JSON" | jq -r '.data.auth_url')"
 ```
 
-Have the user finish Cluster auth and LinkedIn verification in the browser. LinkedIn may ask for an email, SMS, or authenticator-app code.
+Have the user finish Cluster auth and LinkedIn verification in the browser. If they belong to multiple Cluster organizations, the hosted page will ask which one to use. LinkedIn may ask for an email, SMS, or authenticator-app code.
 
 ## Sync now
 

--- a/packages/cli/src/commands/import-linkedin.test.ts
+++ b/packages/cli/src/commands/import-linkedin.test.ts
@@ -14,4 +14,16 @@ describe("import linkedin command", () => {
       "https://sync.example.com/integrations/linkedin/connect?workspace_id=workspace-1&cluster_org_id=org-1&workspace_name=pipeline",
     );
   });
+
+  it("omits Cluster org id when browser auth should infer it", () => {
+    const url = linkedinCommandTest.linkedinConnectUrl({
+      syncEngineUrl: "https://sync.example.com",
+      workspaceId: "workspace-1",
+      workspaceName: "pipeline",
+    });
+
+    expect(url).toBe(
+      "https://sync.example.com/integrations/linkedin/connect?workspace_id=workspace-1&workspace_name=pipeline",
+    );
+  });
 });

--- a/packages/cli/src/commands/import-linkedin.ts
+++ b/packages/cli/src/commands/import-linkedin.ts
@@ -102,7 +102,7 @@ export function attachLinkedinSubcommand(parent: Command): void {
 async function runConnectLinkedin(opts: { workspace?: string; orgId?: string }): Promise<{
   auth_url: string;
   workspace_id: string;
-  cluster_org_id: string;
+  cluster_org_id: string | null;
   sync_engine_url: string;
 }> {
   const workspaceFile = resolveWorkspacePath(opts.workspace);
@@ -115,13 +115,6 @@ async function runConnectLinkedin(opts: { workspace?: string; orgId?: string }):
     clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,
     clusterOrgId: opts.orgId ?? process.env.ACRM_CLOUD_CLUSTER_ORG_ID,
   });
-  if (!metadata.clusterOrgId) {
-    throw new AcrmError(
-      "Cluster organization is not configured",
-      ERR.INVALID_INPUT,
-      "pass --org-id <cluster-org-id> once or set ACRM_CLOUD_CLUSTER_ORG_ID",
-    );
-  }
   const syncEngineUrl = process.env.ACRM_SYNC_ENGINE_URL ?? DEFAULT_SYNC_ENGINE_URL;
   await registerCloudWorkspace({
     syncEngineUrl,
@@ -137,7 +130,7 @@ async function runConnectLinkedin(opts: { workspace?: string; orgId?: string }):
       workspaceName: path.basename(workspaceDir),
     }),
     workspace_id: metadata.workspaceId,
-    cluster_org_id: metadata.clusterOrgId,
+    cluster_org_id: metadata.clusterOrgId ?? null,
     sync_engine_url: syncEngineUrl,
   };
 }
@@ -233,12 +226,12 @@ async function runImportLinkedin(
 function linkedinConnectUrl(input: {
   syncEngineUrl: string;
   workspaceId: string;
-  clusterOrgId: string;
+  clusterOrgId?: string;
   workspaceName: string;
 }): string {
   const url = new URL("/integrations/linkedin/connect", input.syncEngineUrl);
   url.searchParams.set("workspace_id", input.workspaceId);
-  url.searchParams.set("cluster_org_id", input.clusterOrgId);
+  if (input.clusterOrgId) url.searchParams.set("cluster_org_id", input.clusterOrgId);
   url.searchParams.set("workspace_name", input.workspaceName || "Agent CRM workspace");
   return url.toString();
 }


### PR DESCRIPTION
## Summary
- Stop requiring `acrm import linkedin` to know the Cluster org before opening hosted auth
- Keep optional org-id support for explicit/test flows
- Update the bundled LinkedIn connect skill to rely on hosted Cluster auth/org selection

## Tests
- `npm run build --workspace @agent-crm/cli`
- `npm test --workspace @agent-crm/cli -- import-linkedin`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow LinkedIn connect to infer Cluster org when no org ID is configured
> - `runConnectLinkedin` in [import-linkedin.ts](https://github.com/cluster-software/agent-crm/pull/122/files#diff-d12da4064a84a7426efb0bae2fc9fd45042f3d2b1906667389d5b683d1dcfe6f) no longer throws when `clusterOrgId` is missing; it now sets `cluster_org_id` to `null` in the returned JSON instead.
> - `linkedinConnectUrl` omits the `cluster_org_id` query parameter entirely when no value is provided, letting the hosted page prompt the user to select an organization.
> - The [connect-linkedin-to-acrm.md](https://github.com/cluster-software/agent-crm/pull/122/files#diff-b969a2be9eded716d7c83777adc64e3813af3bfc9f1bb352f2a6e1438ab5e35f) skill instructions are updated to remove the shell steps that resolved `ORG_ID` and the requirement to abort when it was empty.
> - Behavioral Change: the `acrm import linkedin` command no longer errors for users not yet associated with a Cluster org; organization selection now happens on the hosted page.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a19ef00.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->