### PR TITLE
Import communication LinkedIn URLs

### DIFF
--- a/.changeset/linkedin-communication-urls.md
+++ b/.changeset/linkedin-communication-urls.md
@@ -1,0 +1,6 @@
+---
+"@agent-crm/sdk": patch
+"@agent-crm/cli": patch
+---
+
+Persist and dedupe LinkedIn URLs from communication sync imports.

--- a/packages/cli/src/commands/import-communication.test.ts
+++ b/packages/cli/src/commands/import-communication.test.ts
@@ -11,6 +11,7 @@ describe("importCommunicationBatch", () => {
         {
           sourceKey: "gmail:me@example.com:email:alice@example.com",
           email: "alice@example.com",
+          linkedinUrl: "https://www.linkedin.com/in/alice-lovelace/",
           displayName: "Alice",
           companySourceKey: "gmail:me@example.com:company_domain:example.com"
         },
@@ -89,6 +90,42 @@ describe("importCommunicationBatch", () => {
     await expect(countRefs(lix, "people", "company")).resolves.toBe(2);
     await expect(countRefs(lix, "companies", "team")).resolves.toBe(2);
     await expect(countRefs(lix, "communication_threads", "messages")).resolves.toBe(1);
+    await expect(singleValueFor(lix, "people", "linkedin_url")).resolves.toBe("linkedin.com/in/alice-lovelace");
+
+    await lix.close();
+  });
+
+  it("dedupes communication people by LinkedIn URL", async () => {
+    const lix = await openTestWorkspace();
+    const ws = Workspace.fromLix(lix);
+
+    const first = await importCommunicationBatch(ws, {
+      people: [
+        {
+          sourceKey: "linkedin_unipile:acct-1:profile:ACo123",
+          linkedinUrl: "https://www.linkedin.com/in/ada-lovelace/",
+          displayName: "Ada Lovelace"
+        }
+      ],
+      communicationThreads: [],
+      communicationMessages: []
+    });
+    const second = await importCommunicationBatch(ws, {
+      people: [
+        {
+          sourceKey: "linkedin_unipile:acct-2:profile:ACo456",
+          linkedinUrl: "linkedin.com/in/ada-lovelace",
+          displayName: "Ada L."
+        }
+      ],
+      communicationThreads: [],
+      communicationMessages: []
+    });
+
+    expect(first.stats.people_created).toBe(1);
+    expect(second.stats.people_created).toBe(0);
+    await expect(countRecords(lix, "people")).resolves.toBe(1);
+    await expect(singleValueFor(lix, "people", "linkedin_url")).resolves.toBe("linkedin.com/in/ada-lovelace");
 
     await lix.close();
   });
@@ -133,4 +170,30 @@ async function countRefs(
     [objectSlug, attributeSlug],
   );
   return Number(result.rows[0]?.n ?? 0);
+}
+
+async function singleValueFor(
+  lix: Awaited<ReturnType<typeof openTestWorkspace>>,
+  objectSlug: string,
+  attributeSlug: string,
+) {
+  const result = await exec(
+    lix,
+    `SELECT value_json FROM acrm_value
+     WHERE object_slug = $1
+       AND attribute_slug = $2
+       AND active_until IS NULL
+     LIMIT 1`,
+    [objectSlug, attributeSlug],
+  );
+  const value = result.rows[0]?.value_json;
+  if (typeof value === "string") {
+    const parsed = JSON.parse(value) as { value?: unknown };
+    return typeof parsed.value === "string" ? parsed.value : null;
+  }
+  if (value && typeof value === "object" && "value" in value) {
+    const item = value.value;
+    return typeof item === "string" ? item : null;
+  }
+  return null;
 }

--- a/packages/sdk/src/operations/import-communication.ts
+++ b/packages/sdk/src/operations/import-communication.ts
@@ -7,6 +7,7 @@ import {
 import {
   encode,
   normalizeDomain as normalizeDomainValue,
+  normalizeLinkedinUrl,
   type AttributeConfig,
   type AttributeType,
   type ValueJson,
@@ -20,6 +21,7 @@ export type CommunicationImportPerson = {
   sourceKey: string;
   email?: string;
   displayName?: string;
+  linkedinUrl?: string;
   companySourceKey?: string;
 };
 
@@ -144,6 +146,8 @@ export async function importCommunicationBatch(
   const plannedSourceIndex = new Map(sourceIndex);
   const emailIndex = await loadPeopleByEmail(lix, batch.people);
   const plannedEmailIndex = new Map(emailIndex);
+  const linkedinIndex = await loadPeopleByLinkedInUrl(lix, batch.people);
+  const plannedLinkedinIndex = new Map(linkedinIndex);
   const companies = batch.companies ?? [];
   const domainIndex = await loadCompaniesByDomain(lix, companies);
   const plannedDomainIndex = new Map(domainIndex);
@@ -168,11 +172,14 @@ export async function importCommunicationBatch(
   for (const person of batch.people) {
     if (personPlans.has(person.sourceKey)) continue;
     const email = normalizeEmail(person.email);
+    const linkedinUrl = normalizeLinkedin(person.linkedinUrl);
     const existingRecordId = plannedSourceIndex.get(sourceIndexKey("people", person.sourceKey)) ??
-      (email ? plannedEmailIndex.get(email) : undefined);
+      (email ? plannedEmailIndex.get(email) : undefined) ??
+      (linkedinUrl ? plannedLinkedinIndex.get(linkedinUrl) : undefined);
     const plan = planRecord("people", person.sourceKey, existingRecordId, recordsToCreate, plannedSourceIndex);
     personPlans.set(person.sourceKey, plan);
     if (email) plannedEmailIndex.set(email, plan.recordId);
+    if (linkedinUrl) plannedLinkedinIndex.set(linkedinUrl, plan.recordId);
     if (plan.created) stats.people_created++;
   }
 
@@ -223,6 +230,10 @@ export async function importCommunicationBatch(
     }
     if (person.displayName) {
       enqueueSingle(writer, existingValues, plan, "name", "personal-name", person.displayName);
+    }
+    const linkedinUrl = normalizeLinkedin(person.linkedinUrl);
+    if (linkedinUrl) {
+      enqueueSingle(writer, existingValues, plan, "linkedin_url", "url", linkedinUrl);
     }
     if (person.companySourceKey) {
       const companyId = resolveRecordId("companies", person.companySourceKey, companyPlans, plannedSourceIndex);
@@ -437,6 +448,33 @@ async function loadPeopleByEmail(
        WHERE active_until IS NULL
          AND object_slug = 'people'
          AND attribute_slug = 'email_addresses'
+         AND normalized_key IN (${placeholders})`,
+      chunk,
+    );
+    for (const row of result.rows) {
+      if (typeof row.record_id === "string" && typeof row.normalized_key === "string") {
+        index.set(row.normalized_key, row.record_id);
+      }
+    }
+  }
+  return index;
+}
+
+async function loadPeopleByLinkedInUrl(
+  lix: Workspace["lix"],
+  people: CommunicationImportPerson[],
+): Promise<Map<string, string>> {
+  const linkedinUrls = unique(people.map((person) => normalizeLinkedin(person.linkedinUrl)).filter((url): url is string => Boolean(url)));
+  const index = new Map<string, string>();
+  for (const chunk of chunks(linkedinUrls, SELECT_CHUNK_SIZE)) {
+    const placeholders = chunk.map((_, index) => `$${index + 1}`).join(", ");
+    const result = await exec(
+      lix,
+      `SELECT record_id, normalized_key
+       FROM acrm_value
+       WHERE active_until IS NULL
+         AND object_slug = 'people'
+         AND attribute_slug = 'linkedin_url'
          AND normalized_key IN (${placeholders})`,
       chunk,
     );
@@ -859,6 +897,11 @@ function normalizeEmail(email: string | undefined): string | undefined {
 
 function normalizeDomain(domain: string | undefined): string | undefined {
   const normalized = domain ? normalizeDomainValue(domain) : undefined;
+  return normalized || undefined;
+}
+
+function normalizeLinkedin(url: string | undefined): string | undefined {
+  const normalized = url ? normalizeLinkedinUrl(url) : undefined;
   return normalized || undefined;
 }
 


### PR DESCRIPTION
## Summary
- Allow communication imports to carry person LinkedIn URLs
- Dedupe imported communication people by normalized LinkedIn URL
- Add coverage for URL persistence and dedupe

## Tests
- npm run build
- npm test --workspace @agent-crm/cli

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deduplicate and persist LinkedIn URLs during communication sync imports
> - Extends `CommunicationImportPerson` with an optional `linkedinUrl` field and persists it as a `linkedin_url` attribute of type `url` on the person record.
> - Adds LinkedIn URL as a third deduplication key (alongside `sourceKey` and email) in `importCommunicationBatch`, using normalized URLs via `normalizeLinkedinUrl`.
> - Adds `loadPeopleByLinkedInUrl` to look up existing people by normalized LinkedIn URL before creating new records.
> - Behavioral Change: people that previously would have been created as duplicates (different `sourceKey`, same LinkedIn URL) are now merged into a single record.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4738f05.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->