### PR TITLE
Add LinkedIn network import

### DIFF
--- a/.changeset/linkedin-network-import.md
+++ b/.changeset/linkedin-network-import.md
@@ -1,0 +1,6 @@
+---
+"@agent-crm/cli": minor
+"@agent-crm/sdk": minor
+---
+
+Add explicit LinkedIn connect flow and lightweight LinkedIn network import.

--- a/README.md
+++ b/README.md
@@ -86,11 +86,13 @@ A grab-bag of jobs Agent CRM handles today. Each is a skill or a CLI command —
 
 **Sync Gmail.** `/acrm-onboarding` starts hosted Google OAuth. The sync engine imports Gmail in the background, and the Electron app pulls people, threads, and messages back into your local `.acrm` file.
 
+**Import your LinkedIn network.** `acrm connect linkedin` opens the hosted LinkedIn connect flow. After that, `acrm import linkedin` imports existing 1st-degree connections as lightweight contacts, with `--cutoff-date <YYYY-MM-DD>` for recent connections.
+
 **Sweep stale deals.** Ask Claude to query your `.acrm` for deals untouched in N days and surface them. It's just SQL underneath, so any filter you can describe, Claude can run.
 
 **Import X / LinkedIn posts.** You're scrolling and see a post worth following up on. Paste the URL into Claude Code — `acrm import post <url>` upserts the post and adds the author as a contact.
 
-**Import X / LinkedIn profiles.** Come across someone you want to chat to. Paste the profile URL into Claude Code — `acrm import linkedin <url>` or `acrm import x <handle>` pulls the enriched profile and dedupes against existing people.
+**Import X / LinkedIn profiles.** Come across someone you want to chat to. Paste the profile URL into Claude Code — `acrm import linkedin <url>` or `acrm import x <handle>` pulls one enriched profile and dedupes against existing people.
 
 **Plug in a new transcript provider.** Adapters are themselves skills. Drop a `transcript-provider-<vendor>` SKILL.md into `~/.claude/skills/` following the contract in [`docs/transcript-provider-protocol.md`](docs/transcript-provider-protocol.md) (Otter, Fireflies, Fathom, Zoom). [`/setup-transcripts`](packages/cli/skills/setup-transcripts.md) picks it up and walks you through connecting it before your first `/post-call`.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -76,15 +76,16 @@ A grab-bag of jobs Agent CRM handles today. Each is a skill or a CLI command —
 
 **Import a scraped list.** `acrm import csv ./leads.csv` ingests a CSV with auto-derived attributes. New columns become typed attributes on the right object — no schema setup.
 
+**Import your LinkedIn network.** `acrm connect linkedin` opens the hosted LinkedIn connect flow. After that, `acrm import linkedin` imports existing 1st-degree connections as lightweight contacts, with `--cutoff-date <YYYY-MM-DD>` for recent connections.
+
 **Sweep stale deals.** Ask Claude to query your `.acrm` for deals untouched in N days and surface them. It's just SQL underneath, so any filter you can describe, Claude can run.
 
 **Import X / LinkedIn posts.** You're scrolling and see a post worth following up on. Paste the URL into Claude Code — `acrm import post <url>` upserts the post and adds the author as a contact.
 
-**Import X / LinkedIn profiles.** Come across someone you want to chat to. Paste the profile URL into Claude Code — `acrm import linkedin <url>` or `acrm import x <handle>` pulls the enriched profile and dedupes against existing people.
+**Import X / LinkedIn profiles.** Come across someone you want to chat to. Paste the profile URL into Claude Code — `acrm import linkedin <url>` or `acrm import x <handle>` pulls one enriched profile and dedupes against existing people.
 
 **Plug in a new transcript provider.** Adapters are themselves skills. Drop a `transcript-provider-<vendor>` SKILL.md into `~/.claude/skills/` following the contract in [`docs/transcript-provider-protocol.md`](docs/transcript-provider-protocol.md) (Otter, Fireflies, Fathom, Zoom). [`/setup-transcripts`](skills/setup-transcripts.md) picks it up and walks you through connecting it before your first `/post-call`.
 
 **Write your own skill.** Ask Claude for _"a skill that reads my call transcripts, updates deal stages, and posts a summary to Slack"_ and it writes a `.md` file into `~/.claude/skills/`. No code.
 
 **Query with plain SQL.** `acrm execute "SELECT ..."` runs against the Attio-style schema. It's just SQLite — bring any client you like.
-

--- a/packages/cli/skills/connect-linkedin-to-acrm.md
+++ b/packages/cli/skills/connect-linkedin-to-acrm.md
@@ -1,11 +1,11 @@
 ---
 name: connect-linkedin-to-acrm
-description: Connect LinkedIn to an Agent CRM / ACRM workspace through the hosted sync engine. Use when the user asks to connect, integrate, hook up, sync, import, or troubleshoot LinkedIn with Agent CRM, ACRM, or an `.acrm` workspace.
+description: Connect LinkedIn to an Agent CRM / ACRM workspace through the hosted sync engine, then optionally import existing LinkedIn contacts. Use when the user asks to connect, integrate, hook up, sync, import, or troubleshoot LinkedIn with Agent CRM, ACRM, or an `.acrm` workspace.
 ---
 
 # connect-linkedin-to-acrm
 
-Use this when the user wants LinkedIn messages synced into their current `.acrm` workspace.
+Use this when the user wants LinkedIn connected to their current `.acrm` workspace or wants to import existing LinkedIn contacts.
 
 ## What this does
 
@@ -13,10 +13,9 @@ This is the hosted LinkedIn sync flow:
 
 1. The local workspace gets a cloud workspace binding in `.agent-crm-cloud.json`.
 2. The user opens Agent CRM's hosted LinkedIn connect page.
-3. The sync engine receives post-connection LinkedIn message events from Unipile.
-4. The local workspace imports those messages as `people`, `communication_threads`, and `communication_messages`.
-
-It is not a full LinkedIn contact-book or history backfill.
+3. The sync engine can receive post-connection LinkedIn message events from Unipile.
+4. The user chooses whether to import existing 1st-degree LinkedIn relations.
+5. Existing relations import as lightweight `people` records without bulk profile enrichment.
 
 ## Run
 
@@ -41,14 +40,40 @@ export WORKSPACE=/path/to/workspace.acrm
 Start the connect flow:
 
 ```sh
-CONNECT_JSON=$(acrm --json -w "$WORKSPACE" import linkedin)
+CONNECT_JSON=$(acrm --json -w "$WORKSPACE" connect linkedin)
 echo "$CONNECT_JSON"
 open "$(echo "$CONNECT_JSON" | jq -r '.data.auth_url')"
 ```
 
 Have the user finish Cluster auth and LinkedIn verification in the browser. If they belong to multiple Cluster organizations, the hosted page will ask which one to use. LinkedIn may ask for an email, SMS, or authenticator-app code.
 
-## Sync now
+## Choose import behavior
+
+After the browser flow completes, use `AskUserQuestion` with this exact question and options (single-select, multipleChoice off):
+
+- **Question**: `How should Agent CRM import LinkedIn contacts?`
+- **Options**:
+  1. `Future messages only` — do not import existing contacts; only new message sync creates people later
+  2. `All existing contacts` — import all current 1st-degree LinkedIn connections
+  3. `Recent connections` — import connections after a cutoff date
+
+If they choose `Future messages only`, stop after confirming LinkedIn is connected.
+
+If they choose `All existing contacts`, run:
+
+```sh
+acrm --json -w "$WORKSPACE" import linkedin
+```
+
+If they choose `Recent connections`, ask for a cutoff date. Default to 30 days ago, but accept any `YYYY-MM-DD` date the user chooses. Then run:
+
+```sh
+acrm --json -w "$WORKSPACE" import linkedin --cutoff-date <YYYY-MM-DD>
+```
+
+If `acrm import linkedin` says LinkedIn is not connected, send the user back to the connect flow above.
+
+## Sync messages
 
 After the browser flow completes, pull any available LinkedIn messages:
 

--- a/packages/cli/src/bin/acrm.ts
+++ b/packages/cli/src/bin/acrm.ts
@@ -7,6 +7,7 @@ import { registerRecords } from "../commands/records.js";
 import { registerSchema } from "../commands/schema.js";
 import { registerSignals } from "../commands/signals.js";
 import { registerImport, getOrCreateImportCommand } from "../commands/import.js";
+import { registerConnect } from "../commands/connect.js";
 import { attachLinkedinSubcommand } from "../commands/import-linkedin.js";
 import { attachXSubcommand } from "../commands/import-x.js";
 import { attachPostSubcommand } from "../commands/import-post.js";
@@ -59,9 +60,10 @@ Data model:
 
 Typical flow:
   acrm init <name>.acrm           create a workspace
+  acrm connect linkedin           connect LinkedIn through Agent CRM's hosted sync engine
   acrm import csv ./leads.csv     load people + companies (and deals if columns present)
   acrm import gmail               connect Gmail through Agent CRM's hosted sync engine
-  acrm import linkedin            connect LinkedIn through Agent CRM's hosted sync engine
+  acrm import linkedin            import existing LinkedIn contacts from the connected account
   acrm import linkedin <url>      add one person from a LinkedIn profile (creates person + company)
   acrm import x <handle>          add one person from an X/Twitter profile
   acrm import post <url>          add a LinkedIn or X **post** by URL — upserts the author as a person and stores the post (use when a user shares a post link they want to track)
@@ -112,6 +114,7 @@ JSON value shapes per attribute_type (key for lix_json_get_text):
   );
 
 registerInit(program);
+registerConnect(program);
 registerImport(program);
 attachLinkedinSubcommand(getOrCreateImportCommand(program));
 attachXSubcommand(getOrCreateImportCommand(program));

--- a/packages/cli/src/commands/connect.test.ts
+++ b/packages/cli/src/commands/connect.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { __test as connectCommandTest } from "./connect.js";
+
+describe("connect linkedin command", () => {
+  it("builds a hosted sync-engine LinkedIn connect URL", () => {
+    const url = connectCommandTest.linkedinConnectUrl({
+      syncEngineUrl: "https://sync.example.com",
+      workspaceId: "workspace-1",
+      clusterOrgId: "org-1",
+      workspaceName: "pipeline",
+    });
+
+    expect(url).toBe(
+      "https://sync.example.com/integrations/linkedin/connect?workspace_id=workspace-1&cluster_org_id=org-1&workspace_name=pipeline",
+    );
+  });
+
+  it("omits Cluster org id when browser auth should infer it", () => {
+    const url = connectCommandTest.linkedinConnectUrl({
+      syncEngineUrl: "https://sync.example.com",
+      workspaceId: "workspace-1",
+      workspaceName: "pipeline",
+    });
+
+    expect(url).toBe(
+      "https://sync.example.com/integrations/linkedin/connect?workspace_id=workspace-1&workspace_name=pipeline",
+    );
+  });
+});

--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -1,0 +1,112 @@
+import path from "node:path";
+import type { Command } from "commander";
+import { AcrmError, ERR } from "@agent-crm/sdk";
+import { resolveWorkspacePath } from "../workspace-resolve.js";
+import { fail, isJson, ok, setJsonMode } from "../output/json.js";
+import { loadDotenv } from "../lib/dotenv.js";
+import {
+  DEFAULT_SYNC_ENGINE_URL,
+  ensureCloudWorkspaceMetadata,
+  registerCloudWorkspace,
+} from "../lib/cloud-workspace.js";
+
+type LinkedinConnectOpts = {
+  orgId?: string;
+};
+
+export function registerConnect(program: Command): void {
+  const connectCmd = getOrCreateConnectCommand(program);
+  connectCmd
+    .command("linkedin")
+    .description("connect LinkedIn through Agent CRM's hosted sync engine")
+    .option("--org-id <org-id>", "Cluster organization id for hosted LinkedIn sync")
+    .action(async (opts: LinkedinConnectOpts) => {
+      const root = program.opts() as { workspace?: string; json?: boolean };
+      setJsonMode(root.json);
+      try {
+        const result = await runConnectLinkedin({
+          workspace: root.workspace,
+          orgId: opts.orgId,
+        });
+        if (!isJson()) {
+          process.stdout.write(
+            [
+              "Open this URL to connect LinkedIn:",
+              result.auth_url,
+              "",
+              "After login, LinkedIn sync runs in the background through Agent CRM's hosted sync engine.",
+              "",
+            ].join("\n")
+          );
+          return;
+        }
+        ok(result);
+      } catch (e) {
+        if (e instanceof AcrmError) fail(e.message, e.code, e.hint);
+        else fail(e instanceof Error ? e.message : String(e), ERR.UNHANDLED);
+        process.exit(1);
+      }
+    });
+}
+
+function getOrCreateConnectCommand(program: Command): Command {
+  const existing = program.commands.find((c) => c.name() === "connect");
+  if (existing) return existing;
+  return program
+    .command("connect")
+    .description("connect external accounts to this .acrm workspace");
+}
+
+async function runConnectLinkedin(opts: { workspace?: string; orgId?: string }): Promise<{
+  auth_url: string;
+  workspace_id: string;
+  cluster_org_id: string | null;
+  sync_engine_url: string;
+}> {
+  const workspaceFile = resolveWorkspacePath(opts.workspace);
+  const workspaceDir = path.dirname(workspaceFile);
+  loadDotenv(workspaceDir);
+  loadDotenv(process.cwd());
+
+  const metadata = ensureCloudWorkspaceMetadata(workspaceDir, {
+    workspaceId: process.env.ACRM_CLOUD_WORKSPACE_ID,
+    clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,
+    clusterOrgId: opts.orgId ?? process.env.ACRM_CLOUD_CLUSTER_ORG_ID,
+  });
+  const syncEngineUrl = process.env.ACRM_SYNC_ENGINE_URL ?? DEFAULT_SYNC_ENGINE_URL;
+  await registerCloudWorkspace({
+    syncEngineUrl,
+    workspaceId: metadata.workspaceId,
+    clientToken: metadata.clientToken,
+    workspaceName: path.basename(workspaceDir),
+  });
+  return {
+    auth_url: linkedinConnectUrl({
+      syncEngineUrl,
+      workspaceId: metadata.workspaceId,
+      clusterOrgId: metadata.clusterOrgId,
+      workspaceName: path.basename(workspaceDir),
+    }),
+    workspace_id: metadata.workspaceId,
+    cluster_org_id: metadata.clusterOrgId ?? null,
+    sync_engine_url: syncEngineUrl,
+  };
+}
+
+function linkedinConnectUrl(input: {
+  syncEngineUrl: string;
+  workspaceId: string;
+  clusterOrgId?: string;
+  workspaceName: string;
+}): string {
+  const url = new URL("/integrations/linkedin/connect", input.syncEngineUrl);
+  url.searchParams.set("workspace_id", input.workspaceId);
+  if (input.clusterOrgId) url.searchParams.set("cluster_org_id", input.clusterOrgId);
+  url.searchParams.set("workspace_name", input.workspaceName || "Agent CRM workspace");
+  return url.toString();
+}
+
+export const __test = {
+  linkedinConnectUrl,
+  runConnectLinkedin,
+};

--- a/packages/cli/src/commands/import-linkedin-relations.test.ts
+++ b/packages/cli/src/commands/import-linkedin-relations.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import {
+  addMultiValue,
+  exec,
+  importLinkedinRelations,
+  insertRecord,
+  setSingleValue,
+  Workspace,
+  type LinkedinRelation,
+} from "@agent-crm/sdk";
+import { openTestWorkspace } from "../test/open-test-lix.js";
+
+describe("importLinkedinRelations", () => {
+  it("imports LinkedIn relation rows into people", async () => {
+    const lix = await openTestWorkspace();
+    const ws = Workspace.fromLix(lix);
+
+    const result = await importLinkedinRelations(ws, {
+      relations: [
+        relation({
+          member_id: "member-1",
+          created_at: 1742051769000,
+          first_name: "Ada",
+          last_name: "Lovelace",
+          headline: "Founder at Analytical Engines",
+          public_identifier: "ada-lovelace",
+          public_profile_url: "https://www.linkedin.com/in/ada-lovelace/",
+        }),
+      ],
+    });
+
+    expect(result.stats.people_created).toBe(1);
+    await expect(valueFor(ws, "linkedin_url")).resolves.toBe("linkedin.com/in/ada-lovelace");
+    await expect(valueFor(ws, "name")).resolves.toBe("Ada Lovelace");
+    await expect(valueFor(ws, "job_title")).resolves.toBe("Founder at Analytical Engines");
+    await expect(valueFor(ws, "linkedin_connected_at")).resolves.toBe("2025-03-15T15:16:09.000Z");
+    await expect(countValues(ws, "source_keys")).resolves.toBe(1);
+    await lix.close();
+  });
+
+  it("is idempotent across repeated imports", async () => {
+    const lix = await openTestWorkspace();
+    const ws = Workspace.fromLix(lix);
+    const relations = [
+      relation({
+        member_id: "member-1",
+        first_name: "Ada",
+        last_name: "Lovelace",
+        public_profile_url: "https://www.linkedin.com/in/ada-lovelace/",
+      }),
+    ];
+
+    const first = await importLinkedinRelations(ws, { relations });
+    const valuesAfterFirstImport = await countAllValues(ws);
+    const second = await importLinkedinRelations(ws, { relations });
+
+    expect(first.stats.people_created).toBe(1);
+    expect(second.stats.people_created).toBe(0);
+    expect(second.stats.people_updated).toBe(0);
+    await expect(countRecords(ws)).resolves.toBe(1);
+    await expect(countAllValues(ws)).resolves.toBe(valuesAfterFirstImport);
+    await lix.close();
+  });
+
+  it("dedupes by LinkedIn URL before relation source key", async () => {
+    const lix = await openTestWorkspace();
+    const ws = Workspace.fromLix(lix);
+
+    await importLinkedinRelations(ws, {
+      relations: [
+        relation({
+          member_id: "member-1",
+          first_name: "Ada",
+          public_profile_url: "https://www.linkedin.com/in/ada-lovelace/",
+        }),
+        relation({
+          member_id: "member-2",
+          first_name: "Ada",
+          public_profile_url: "https://linkedin.com/in/ada-lovelace",
+        }),
+      ],
+    });
+
+    await expect(countRecords(ws)).resolves.toBe(1);
+    await expect(countValues(ws, "source_keys")).resolves.toBe(2);
+    await lix.close();
+  });
+
+  it("does not overwrite richer existing person fields", async () => {
+    const lix = await openTestWorkspace();
+    const ws = Workspace.fromLix(lix);
+    const personId = "person-existing";
+    await insertRecord(lix, "people", personId);
+    await addMultiValue(lix, {
+      object_slug: "people",
+      record_id: personId,
+      attribute_slug: "source_keys",
+      attribute_type: "text",
+      value: "csv:ada",
+      source: "test",
+      provenance: {},
+    });
+    await setSingleValue(lix, {
+      object_slug: "people",
+      record_id: personId,
+      attribute_slug: "linkedin_url",
+      attribute_type: "url",
+      value: "linkedin.com/in/ada-lovelace",
+      source: "test",
+      provenance: {},
+    });
+    await setSingleValue(lix, {
+      object_slug: "people",
+      record_id: personId,
+      attribute_slug: "name",
+      attribute_type: "personal-name",
+      value: "Augusta Ada King",
+      source: "test",
+      provenance: {},
+    });
+    await setSingleValue(lix, {
+      object_slug: "people",
+      record_id: personId,
+      attribute_slug: "job_title",
+      attribute_type: "text",
+      value: "Mathematician",
+      source: "test",
+      provenance: {},
+    });
+
+    const result = await importLinkedinRelations(ws, {
+      relations: [
+        relation({
+          member_id: "member-1",
+          created_at: 1742051769000,
+          first_name: "Ada",
+          last_name: "Lovelace",
+          headline: "Founder at Analytical Engines",
+          public_profile_url: "https://www.linkedin.com/in/ada-lovelace/",
+        }),
+      ],
+    });
+
+    expect(result.stats.people_created).toBe(0);
+    await expect(valueFor(ws, "name")).resolves.toBe("Augusta Ada King");
+    await expect(valueFor(ws, "job_title")).resolves.toBe("Mathematician");
+    await expect(valueFor(ws, "linkedin_connected_at")).resolves.toBe("2025-03-15T15:16:09.000Z");
+    await expect(countValues(ws, "source_keys")).resolves.toBe(2);
+    await lix.close();
+  });
+});
+
+function relation(overrides: Partial<LinkedinRelation>): LinkedinRelation {
+  return {
+    object: "UserRelation",
+    connection_urn: "urn:li:fsd_connection:member-1",
+    member_id: "member-1",
+    member_urn: "urn:li:fsd_profile:member-1",
+    ...overrides,
+  };
+}
+
+async function valueFor(ws: Workspace, attributeSlug: string): Promise<string | null> {
+  const result = await exec(
+    ws.lix,
+    `SELECT value_json
+     FROM acrm_value
+     WHERE object_slug = 'people'
+       AND attribute_slug = $1
+       AND active_until IS NULL
+     ORDER BY active_from DESC
+     LIMIT 1`,
+    [attributeSlug],
+  );
+  const raw = result.rows[0]?.value_json;
+  const parsed = typeof raw === "string"
+    ? JSON.parse(raw) as { value?: string; full_name?: string; timestamp?: string }
+    : raw as { value?: string; full_name?: string; timestamp?: string } | undefined;
+  return parsed?.value ?? parsed?.full_name ?? parsed?.timestamp ?? null;
+}
+
+async function countRecords(ws: Workspace): Promise<number> {
+  const result = await exec(
+    ws.lix,
+    "SELECT COUNT(*) AS n FROM acrm_record WHERE object_slug = 'people'",
+  );
+  return Number(result.rows[0]?.n ?? 0);
+}
+
+async function countValues(ws: Workspace, attributeSlug: string): Promise<number> {
+  const result = await exec(
+    ws.lix,
+    `SELECT COUNT(*) AS n
+     FROM acrm_value
+     WHERE object_slug = 'people'
+       AND attribute_slug = $1
+       AND active_until IS NULL`,
+    [attributeSlug],
+  );
+  return Number(result.rows[0]?.n ?? 0);
+}
+
+async function countAllValues(ws: Workspace): Promise<number> {
+  const result = await exec(
+    ws.lix,
+    "SELECT COUNT(*) AS n FROM acrm_value WHERE active_until IS NULL",
+  );
+  return Number(result.rows[0]?.n ?? 0);
+}

--- a/packages/cli/src/commands/import-linkedin.test.ts
+++ b/packages/cli/src/commands/import-linkedin.test.ts
@@ -1,29 +1,136 @@
-import { describe, expect, it } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ERR, Workspace, exec, type AcrmError } from "@agent-crm/sdk";
 import { __test as linkedinCommandTest } from "./import-linkedin.js";
+import {
+  LINKEDIN_NOT_CONNECTED_HINT,
+  LINKEDIN_NOT_CONNECTED_MESSAGE,
+} from "../lib/cloud-workspace.js";
 
 describe("import linkedin command", () => {
-  it("builds a hosted sync-engine LinkedIn connect URL", () => {
-    const url = linkedinCommandTest.linkedinConnectUrl({
-      syncEngineUrl: "https://sync.example.com",
-      workspaceId: "workspace-1",
-      clusterOrgId: "org-1",
-      workspaceName: "pipeline",
-    });
+  const oldSyncEngineUrl = process.env.ACRM_SYNC_ENGINE_URL;
 
-    expect(url).toBe(
-      "https://sync.example.com/integrations/linkedin/connect?workspace_id=workspace-1&cluster_org_id=org-1&workspace_name=pipeline",
-    );
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (oldSyncEngineUrl === undefined) delete process.env.ACRM_SYNC_ENGINE_URL;
+    else process.env.ACRM_SYNC_ENGINE_URL = oldSyncEngineUrl;
   });
 
-  it("omits Cluster org id when browser auth should infer it", () => {
-    const url = linkedinCommandTest.linkedinConnectUrl({
-      syncEngineUrl: "https://sync.example.com",
-      workspaceId: "workspace-1",
-      workspaceName: "pipeline",
-    });
+  it("imports relations from the hosted sync-engine export endpoint", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "acrm-linkedin-import-"));
+    const workspacePath = join(dir, "workspace.acrm");
+    const ws = await Workspace.create(workspacePath);
+    await ws.close();
+    process.env.ACRM_SYNC_ENGINE_URL = "https://sync.example.com";
+    const fetchMock = vi.fn(async () => Response.json({
+      ok: true,
+      data: {
+        relations: [
+          {
+            object: "UserRelation",
+            member_id: "member-1",
+            created_at: 1742051769000,
+            first_name: "Ada",
+            last_name: "Lovelace",
+            headline: "Founder at Analytical Engines",
+            public_identifier: "ada-lovelace",
+            public_profile_url: "https://www.linkedin.com/in/ada-lovelace/",
+          },
+        ],
+      },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
 
-    expect(url).toBe(
-      "https://sync.example.com/integrations/linkedin/connect?workspace_id=workspace-1&workspace_name=pipeline",
-    );
+    try {
+      const result = await linkedinCommandTest.runImportLinkedinNetwork({
+        workspace: workspacePath,
+      });
+
+      expect(result.stats.people_created).toBe(1);
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const [url] = fetchMock.mock.calls[0] as [string];
+      expect(url).toContain("/integrations/linkedin/relations/export");
+      const reopened = await Workspace.open(workspacePath);
+      try {
+        await expect(singleValue(reopened, "linkedin_url")).resolves.toBe("linkedin.com/in/ada-lovelace");
+        await expect(singleValue(reopened, "linkedin_connected_at")).resolves.toBe("2025-03-15T15:16:09.000Z");
+      } finally {
+        await reopened.close();
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("passes cutoff-date to the relations export endpoint", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "acrm-linkedin-import-"));
+    const workspacePath = join(dir, "workspace.acrm");
+    const ws = await Workspace.create(workspacePath);
+    await ws.close();
+    process.env.ACRM_SYNC_ENGINE_URL = "https://sync.example.com";
+    const fetchMock = vi.fn(async () => Response.json({
+      ok: true,
+      data: { relations: [] },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      await linkedinCommandTest.runImportLinkedinNetwork({
+        workspace: workspacePath,
+        cutoffDate: "2026-04-25",
+      });
+
+      const [url] = fetchMock.mock.calls[0] as [string];
+      const metadata = JSON.parse(await readFile(join(dir, ".agent-crm-cloud.json"), "utf8")) as {
+        workspaceId: string;
+      };
+      expect(url).toBe(
+        `https://sync.example.com/workspaces/${encodeURIComponent(metadata.workspaceId)}/integrations/linkedin/relations/export?cutoff_date=2026-04-25`,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns the helpful connect error when LinkedIn is not connected", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "acrm-linkedin-import-"));
+    const workspacePath = join(dir, "workspace.acrm");
+    const ws = await Workspace.create(workspacePath);
+    await ws.close();
+    process.env.ACRM_SYNC_ENGINE_URL = "https://sync.example.com";
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json({
+      ok: false,
+      error: { code: "linkedin_not_connected" },
+    }, { status: 409 })));
+
+    try {
+      await expect(
+        linkedinCommandTest.runImportLinkedinNetwork({ workspace: workspacePath }),
+      ).rejects.toMatchObject({
+        message: LINKEDIN_NOT_CONNECTED_MESSAGE,
+        code: ERR.INVALID_INPUT,
+        hint: LINKEDIN_NOT_CONNECTED_HINT,
+      } satisfies Partial<AcrmError>);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });
+
+async function singleValue(ws: Workspace, attributeSlug: string): Promise<string | null> {
+  const result = await exec(
+    ws.lix,
+    `SELECT value_json
+     FROM acrm_value
+     WHERE object_slug = 'people'
+       AND attribute_slug = $1
+       AND active_until IS NULL
+     LIMIT 1`,
+    [attributeSlug],
+  );
+  const raw = result.rows[0]?.value_json;
+  const parsed = typeof raw === "string" ? JSON.parse(raw) as { value?: string; timestamp?: string } : raw as { value?: string; timestamp?: string } | undefined;
+  return parsed?.value ?? parsed?.timestamp ?? null;
+}

--- a/packages/cli/src/commands/import-linkedin.ts
+++ b/packages/cli/src/commands/import-linkedin.ts
@@ -5,18 +5,20 @@ import {
   ERR,
   Workspace,
   importCommunicationBatch,
+  importLinkedinRelations,
   importLinkedinProfile,
   type CommunicationImportResult,
+  type ImportLinkedinRelationsResult,
   type LinkedinImportResult,
 } from "@agent-crm/sdk";
 import { resolveWorkspacePath } from "../workspace-resolve.js";
-import { fail, isJson, ok, setJsonMode } from "../output/json.js";
+import { fail, ok, setJsonMode } from "../output/json.js";
 import { loadDotenv } from "../lib/dotenv.js";
 import {
   DEFAULT_SYNC_ENGINE_URL,
   ensureCloudWorkspaceMetadata,
   fetchCloudCommunicationExport,
-  registerCloudWorkspace,
+  fetchCloudLinkedinRelationsExport,
 } from "../lib/cloud-workspace.js";
 import { type BackgroundSignalRun, startMissingSignalsForRecords } from "../signals.js";
 
@@ -24,18 +26,18 @@ type Opts = {
   refresh?: boolean;
   cache?: boolean; // commander negation: --no-cache → cache=false
   signals?: boolean;
-  orgId?: string;
   sync?: boolean;
+  cutoffDate?: string;
 };
 
 export function attachLinkedinSubcommand(parent: Command): void {
   parent
     .command("linkedin [url-or-slug]")
     .description(
-      "With no URL, connect LinkedIn through Agent CRM's hosted sync engine. With a LinkedIn profile URL (or `/in/<slug>`), import one person locally via Apify. For a LinkedIn post URL instead, use `acrm import post`.",
+      "With no URL, import existing LinkedIn contacts from the connected account. With a LinkedIn profile URL (or `/in/<slug>`), import one person locally via Apify. For a LinkedIn post URL instead, use `acrm import post`.",
     )
-    .option("--org-id <org-id>", "Cluster organization id for hosted LinkedIn sync")
     .option("--sync", "pull LinkedIn messages from Agent CRM's hosted sync engine into this workspace")
+    .option("--cutoff-date <YYYY-MM-DD>", "only import LinkedIn contacts connected on or after this date")
     .option("--refresh", "bypass cache and re-fetch from Apify")
     .option("--no-cache", "do not write the response to cache")
     .option("--no-signals", "skip local signals after importing records")
@@ -49,6 +51,9 @@ export function attachLinkedinSubcommand(parent: Command): void {
           if (urlOrSlug) {
             throw new AcrmError("--sync does not accept a LinkedIn profile URL", ERR.INVALID_INPUT);
           }
+          if (opts.cutoffDate) {
+            throw new AcrmError("--sync does not accept --cutoff-date", ERR.INVALID_INPUT);
+          }
           const result = await runSyncLinkedin({
             workspace: root?.workspace,
           });
@@ -56,24 +61,15 @@ export function attachLinkedinSubcommand(parent: Command): void {
           return;
         }
         if (!urlOrSlug) {
-          const result = await runConnectLinkedin({
+          const result = await runImportLinkedinNetwork({
             workspace: root?.workspace,
-            orgId: opts.orgId,
+            cutoffDate: opts.cutoffDate,
           });
-          if (!isJson()) {
-            process.stdout.write(
-              [
-                "Open this URL to connect LinkedIn:",
-                result.auth_url,
-                "",
-                "After login, LinkedIn sync runs in the background through Agent CRM's hosted sync engine.",
-                "",
-              ].join("\n")
-            );
-            return;
-          }
           ok(result);
           return;
+        }
+        if (opts.cutoffDate) {
+          throw new AcrmError("--cutoff-date does not accept a LinkedIn profile URL", ERR.INVALID_INPUT);
         }
         const result = await runImportLinkedin(urlOrSlug, {
           workspace: root?.workspace,
@@ -99,11 +95,10 @@ export function attachLinkedinSubcommand(parent: Command): void {
     });
 }
 
-async function runConnectLinkedin(opts: { workspace?: string; orgId?: string }): Promise<{
-  auth_url: string;
+async function runImportLinkedinNetwork(opts: { workspace?: string; cutoffDate?: string }): Promise<{
   workspace_id: string;
-  cluster_org_id: string | null;
   sync_engine_url: string;
+  stats: ImportLinkedinRelationsResult["stats"];
 }> {
   const workspaceFile = resolveWorkspacePath(opts.workspace);
   const workspaceDir = path.dirname(workspaceFile);
@@ -113,26 +108,26 @@ async function runConnectLinkedin(opts: { workspace?: string; orgId?: string }):
   const metadata = ensureCloudWorkspaceMetadata(workspaceDir, {
     workspaceId: process.env.ACRM_CLOUD_WORKSPACE_ID,
     clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,
-    clusterOrgId: opts.orgId ?? process.env.ACRM_CLOUD_CLUSTER_ORG_ID,
+    clusterOrgId: process.env.ACRM_CLOUD_CLUSTER_ORG_ID,
   });
   const syncEngineUrl = process.env.ACRM_SYNC_ENGINE_URL ?? DEFAULT_SYNC_ENGINE_URL;
-  await registerCloudWorkspace({
+  const { relations } = await fetchCloudLinkedinRelationsExport({
     syncEngineUrl,
     workspaceId: metadata.workspaceId,
     clientToken: metadata.clientToken,
-    workspaceName: path.basename(workspaceDir),
+    cutoffDate: opts.cutoffDate,
   });
-  return {
-    auth_url: linkedinConnectUrl({
-      syncEngineUrl,
-      workspaceId: metadata.workspaceId,
-      clusterOrgId: metadata.clusterOrgId,
-      workspaceName: path.basename(workspaceDir),
-    }),
-    workspace_id: metadata.workspaceId,
-    cluster_org_id: metadata.clusterOrgId ?? null,
-    sync_engine_url: syncEngineUrl,
-  };
+  const ws = await Workspace.open(workspaceFile);
+  try {
+    const result = await importLinkedinRelations(ws, { relations });
+    return {
+      workspace_id: metadata.workspaceId,
+      sync_engine_url: syncEngineUrl,
+      stats: result.stats,
+    };
+  } finally {
+    await ws.close();
+  }
 }
 
 async function runSyncLinkedin(opts: { workspace?: string }): Promise<{
@@ -223,19 +218,6 @@ async function runImportLinkedin(
   };
 }
 
-function linkedinConnectUrl(input: {
-  syncEngineUrl: string;
-  workspaceId: string;
-  clusterOrgId?: string;
-  workspaceName: string;
-}): string {
-  const url = new URL("/integrations/linkedin/connect", input.syncEngineUrl);
-  url.searchParams.set("workspace_id", input.workspaceId);
-  if (input.clusterOrgId) url.searchParams.set("cluster_org_id", input.clusterOrgId);
-  url.searchParams.set("workspace_name", input.workspaceName || "Agent CRM workspace");
-  return url.toString();
-}
-
 export const __test = {
-  linkedinConnectUrl,
+  runImportLinkedinNetwork,
 };

--- a/packages/cli/src/lib/cloud-workspace.test.ts
+++ b/packages/cli/src/lib/cloud-workspace.test.ts
@@ -5,8 +5,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ensureCloudWorkspaceMetadata,
   fetchCloudCommunicationExport,
+  fetchCloudLinkedinRelationsExport,
+  LINKEDIN_NOT_CONNECTED_HINT,
+  LINKEDIN_NOT_CONNECTED_MESSAGE,
   registerCloudWorkspace
 } from "./cloud-workspace.js";
+import { ERR } from "@agent-crm/sdk";
 
 describe("cloud workspace metadata", () => {
   afterEach(() => {
@@ -80,5 +84,51 @@ describe("cloud workspace metadata", () => {
         },
       },
     );
+  });
+
+  it("fetches LinkedIn relations export data with a cutoff date", async () => {
+    const relations = [
+      {
+        object: "UserRelation",
+        member_id: "member-1",
+        public_profile_url: "https://www.linkedin.com/in/member-1/",
+      },
+    ];
+    const fetchMock = vi.fn(async () => Response.json({ ok: true, data: { relations } }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchCloudLinkedinRelationsExport({
+      syncEngineUrl: "https://sync.example.com",
+      workspaceId: "workspace-1",
+      clientToken: "client-token-1",
+      cutoffDate: "2026-04-25",
+    })).resolves.toEqual({ relations });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://sync.example.com/workspaces/workspace-1/integrations/linkedin/relations/export?cutoff_date=2026-04-25",
+      {
+        headers: {
+          authorization: "Bearer client-token-1",
+        },
+      },
+    );
+  });
+
+  it("turns LinkedIn not-connected export responses into an actionable error", async () => {
+    const fetchMock = vi.fn(async () => Response.json({
+      ok: false,
+      error: { code: "linkedin_not_connected" },
+    }, { status: 409 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchCloudLinkedinRelationsExport({
+      syncEngineUrl: "https://sync.example.com",
+      workspaceId: "workspace-1",
+      clientToken: "client-token-1",
+    })).rejects.toMatchObject({
+      message: LINKEDIN_NOT_CONNECTED_MESSAGE,
+      code: ERR.INVALID_INPUT,
+      hint: LINKEDIN_NOT_CONNECTED_HINT,
+    });
   });
 });

--- a/packages/cli/src/lib/cloud-workspace.ts
+++ b/packages/cli/src/lib/cloud-workspace.ts
@@ -1,9 +1,23 @@
 import { randomUUID } from "node:crypto";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { AcrmError, ERR, type CommunicationImportBatch } from "@agent-crm/sdk";
+import {
+  AcrmError,
+  ERR,
+  type CommunicationImportBatch,
+  type LinkedinRelation,
+} from "@agent-crm/sdk";
 
 export const DEFAULT_SYNC_ENGINE_URL = "https://agent-crm-sync-engine.onrender.com";
+export const LINKEDIN_NOT_CONNECTED_MESSAGE = "LinkedIn is not connected for this workspace.";
+export const LINKEDIN_NOT_CONNECTED_HINT = [
+  "Run:",
+  "  acrm connect linkedin",
+  "",
+  "Then re-run:",
+  "  acrm import linkedin",
+].join("\n");
+
 const CLOUD_METADATA_FILENAME = ".agent-crm-cloud.json";
 
 export type CloudMetadata = {
@@ -109,4 +123,76 @@ export async function fetchCloudCommunicationExport(input: {
     );
   }
   return payload.data as CommunicationImportBatch;
+}
+
+export async function fetchCloudLinkedinRelationsExport(input: {
+  syncEngineUrl: string;
+  workspaceId: string;
+  clientToken: string;
+  cutoffDate?: string;
+}): Promise<{ relations: LinkedinRelation[] }> {
+  const url = new URL(
+    `/workspaces/${encodeURIComponent(input.workspaceId)}/integrations/linkedin/relations/export`,
+    input.syncEngineUrl,
+  );
+  if (input.cutoffDate) url.searchParams.set("cutoff_date", input.cutoffDate);
+  const response = await fetch(url.toString(), {
+    headers: {
+      authorization: `Bearer ${input.clientToken}`,
+    },
+  });
+  const payload = await response.json().catch(() => undefined) as
+    | { ok?: unknown; data?: unknown; error?: unknown; code?: unknown }
+    | undefined;
+  if (isLinkedinNotConnected(payload)) {
+    throw new AcrmError(
+      LINKEDIN_NOT_CONNECTED_MESSAGE,
+      ERR.INVALID_INPUT,
+      LINKEDIN_NOT_CONNECTED_HINT,
+    );
+  }
+  if (!response.ok || payload?.ok !== true || !payload.data || typeof payload.data !== "object") {
+    throw new AcrmError(
+      "failed to export LinkedIn relations",
+      ERR.IMPORT,
+      payloadError(payload) ?? `sync engine returned HTTP ${response.status}`,
+    );
+  }
+  const data = payload.data as { relations?: unknown };
+  if (!Array.isArray(data.relations)) {
+    throw new AcrmError(
+      "failed to export LinkedIn relations",
+      ERR.IMPORT,
+      "sync engine response did not include a relations array",
+    );
+  }
+  return { relations: data.relations as LinkedinRelation[] };
+}
+
+function isLinkedinNotConnected(payload: { error?: unknown; code?: unknown } | undefined): boolean {
+  const candidates = [
+    payload?.code,
+    typeof payload?.error === "object" && payload.error !== null
+      ? (payload.error as { code?: unknown }).code
+      : undefined,
+    typeof payload?.error === "string" ? payload.error : undefined,
+  ];
+  return candidates.some((candidate) => {
+    if (typeof candidate !== "string") return false;
+    const normalized = candidate.toLowerCase().replace(/[^a-z0-9]+/g, "_");
+    return (
+      normalized === "linkedin_not_connected" ||
+      normalized === "not_connected" ||
+      (normalized.includes("linkedin") && normalized.includes("not_connected"))
+    );
+  });
+}
+
+function payloadError(payload: { error?: unknown } | undefined): string | undefined {
+  if (typeof payload?.error === "string") return payload.error;
+  if (typeof payload?.error === "object" && payload.error !== null) {
+    const message = (payload.error as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  return undefined;
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -38,6 +38,7 @@ export * from "./operations/import-csv.js";
 export * from "./operations/import-communication.js";
 export * from "./operations/import-google.js";
 export * from "./operations/import-linkedin.js";
+export * from "./operations/import-linkedin-relations.js";
 export * from "./operations/import-post.js";
 export * from "./operations/import-transcript.js";
 export * from "./operations/import-x.js";

--- a/packages/sdk/src/operations/import-linkedin-relations.ts
+++ b/packages/sdk/src/operations/import-linkedin-relations.ts
@@ -1,0 +1,507 @@
+import type { LixRuntimeValue } from "@lix-js/sdk";
+import { exec } from "../db/execute.js";
+import {
+  prepareValueInsert,
+  type PreparedValueInsert,
+} from "../db/value-row.js";
+import {
+  encode,
+  normalizeLinkedinUrl,
+  type AttributeType,
+  type ValueJson,
+} from "../domain/values.js";
+import { uuidv7 } from "../lib/uuidv7.js";
+import { nowIso } from "../lib/time.js";
+import type { Workspace } from "../workspace.js";
+import { seedAttributes, seedObjects } from "../workspace/seeds.js";
+
+export type LinkedinRelation = {
+  object?: string;
+  connection_urn?: string | null;
+  created_at?: number | string | null;
+  first_name?: string | null;
+  last_name?: string | null;
+  member_id?: string | null;
+  member_urn?: string | null;
+  headline?: string | null;
+  public_identifier?: string | null;
+  public_profile_url?: string | null;
+  profile_picture_url?: string | null;
+};
+
+export type ImportLinkedinRelationsArgs = {
+  relations: Iterable<LinkedinRelation>;
+};
+
+export type ImportLinkedinRelationsResult = {
+  stats: {
+    relations_seen: number;
+    people_created: number;
+    people_updated: number;
+    relations_skipped_no_key: number;
+  };
+};
+
+type NormalizedRelation = {
+  relation: LinkedinRelation;
+  sourceKey: string;
+  linkedinUrl: string | null;
+  fullName: string | null;
+  headline: string | null;
+  connectedAt: string | null;
+};
+
+type RecordPlan = {
+  recordId: string;
+  created: boolean;
+};
+
+type ExistingValues = {
+  singleValues: Map<string, ValueJson>;
+  multiValues: Set<string>;
+};
+
+type ValueInput = {
+  record_id: string;
+  attribute_slug: string;
+  attribute_type: AttributeType;
+  value: ValueJson;
+  provenance: Record<string, unknown>;
+};
+
+const SOURCE = "linkedin-relations-import";
+const MAX_BATCH_ROWS = 5000;
+const SELECT_CHUNK_SIZE = 500;
+
+export async function importLinkedinRelations(
+  workspace: Workspace,
+  args: ImportLinkedinRelationsArgs,
+): Promise<ImportLinkedinRelationsResult> {
+  await ensurePeopleSchema(workspace);
+
+  const stats: ImportLinkedinRelationsResult["stats"] = {
+    relations_seen: 0,
+    people_created: 0,
+    people_updated: 0,
+    relations_skipped_no_key: 0,
+  };
+
+  const relations: NormalizedRelation[] = [];
+  for (const relation of args.relations) {
+    stats.relations_seen++;
+    const normalized = normalizeRelation(relation);
+    if (!normalized) {
+      stats.relations_skipped_no_key++;
+      continue;
+    }
+    relations.push(normalized);
+  }
+
+  const lix = workspace.lix;
+  const sourceIndex = await loadPeopleBySourceKeys(lix, relations.map((relation) => relation.sourceKey));
+  const plannedSourceIndex = new Map(sourceIndex);
+  const linkedinIndex = await loadPeopleByLinkedinUrl(
+    lix,
+    relations.map((relation) => relation.linkedinUrl).filter((url): url is string => Boolean(url)),
+  );
+  const plannedLinkedinIndex = new Map(linkedinIndex);
+
+  const recordsToCreate: Array<{ object_slug: "people"; record_id: string }> = [];
+  const plans: Array<{ relation: NormalizedRelation; plan: RecordPlan }> = [];
+  const touchedRecordIds = new Set<string>();
+  const createdRecordIds = new Set<string>();
+
+  for (const relation of relations) {
+    const existingRecordId =
+      (relation.linkedinUrl ? plannedLinkedinIndex.get(relation.linkedinUrl) : undefined) ??
+      plannedSourceIndex.get(relation.sourceKey);
+    const recordId = existingRecordId ?? uuidv7();
+    const created = existingRecordId == null;
+    if (created) {
+      recordsToCreate.push({ object_slug: "people", record_id: recordId });
+      createdRecordIds.add(recordId);
+    }
+    plannedSourceIndex.set(relation.sourceKey, recordId);
+    if (relation.linkedinUrl) plannedLinkedinIndex.set(relation.linkedinUrl, recordId);
+    touchedRecordIds.add(recordId);
+    plans.push({ relation, plan: { recordId, created } });
+  }
+
+  stats.people_created = createdRecordIds.size;
+
+  const existingValues = await loadExistingValues(lix, [...touchedRecordIds]);
+  const writer = new LinkedinRelationWriteBatcher(lix);
+  const changedExistingRecordIds = new Set<string>();
+
+  for (const record of recordsToCreate) {
+    writer.enqueueRecord(record);
+  }
+
+  for (const { relation, plan } of plans) {
+    const provenance = relationProvenance(relation.relation);
+    let changed = false;
+    changed = enqueueMulti(writer, existingValues, plan, "source_keys", "text", relation.sourceKey, provenance) || changed;
+    if (relation.linkedinUrl) {
+      changed = enqueueSingleIfMissing(writer, existingValues, plan, "linkedin_url", "url", relation.linkedinUrl, provenance) || changed;
+    }
+    if (relation.fullName) {
+      changed = enqueueSingleIfMissing(writer, existingValues, plan, "name", "personal-name", relation.fullName, provenance) || changed;
+    }
+    if (relation.headline) {
+      changed = enqueueSingleIfMissing(writer, existingValues, plan, "job_title", "text", relation.headline, provenance) || changed;
+    }
+    if (relation.connectedAt) {
+      changed = enqueueSingleIfMissing(
+        writer,
+        existingValues,
+        plan,
+        "linkedin_connected_at",
+        "timestamp",
+        relation.connectedAt,
+        provenance,
+      ) || changed;
+    }
+    if (!createdRecordIds.has(plan.recordId) && changed) {
+      changedExistingRecordIds.add(plan.recordId);
+    }
+  }
+
+  stats.people_updated = changedExistingRecordIds.size;
+  await writer.flush();
+  return { stats };
+}
+
+async function ensurePeopleSchema(workspace: Workspace): Promise<void> {
+  await seedObjects(workspace.lix);
+  await seedAttributes(workspace.lix);
+}
+
+function normalizeRelation(relation: LinkedinRelation): NormalizedRelation | null {
+  const sourceKey = relationSourceKey(relation);
+  if (!sourceKey) return null;
+  return {
+    relation,
+    sourceKey,
+    linkedinUrl: relationLinkedinUrl(relation),
+    fullName: relationFullName(relation),
+    headline: cleanString(relation.headline),
+    connectedAt: relationConnectedAt(relation.created_at),
+  };
+}
+
+function relationSourceKey(relation: LinkedinRelation): string | null {
+  const key =
+    cleanString(relation.member_id) ??
+    cleanString(relation.member_urn) ??
+    cleanString(relation.connection_urn) ??
+    cleanString(relation.public_profile_url) ??
+    cleanString(relation.public_identifier);
+  return key ? `linkedin:relation:${key}` : null;
+}
+
+function relationLinkedinUrl(relation: LinkedinRelation): string | null {
+  const explicit = cleanString(relation.public_profile_url);
+  if (explicit) return normalizeLinkedinUrl(explicit);
+  const publicIdentifier = cleanString(relation.public_identifier);
+  return publicIdentifier
+    ? normalizeLinkedinUrl(`https://www.linkedin.com/in/${publicIdentifier}/`)
+    : null;
+}
+
+function relationFullName(relation: LinkedinRelation): string | null {
+  const full = [cleanString(relation.first_name), cleanString(relation.last_name)]
+    .filter((part): part is string => Boolean(part))
+    .join(" ")
+    .trim();
+  return full || null;
+}
+
+function relationConnectedAt(value: LinkedinRelation["created_at"]): string | null {
+  if (value == null) return null;
+  if (typeof value === "number") {
+    const millis = value < 1_000_000_000_000 ? value * 1000 : value;
+    const date = new Date(millis);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  }
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (/^\d+$/.test(trimmed)) return relationConnectedAt(Number(trimmed));
+  const millis = Date.parse(trimmed);
+  if (Number.isNaN(millis)) return null;
+  return new Date(millis).toISOString();
+}
+
+function relationProvenance(relation: LinkedinRelation): Record<string, unknown> {
+  return {
+    provider: "unipile",
+    imported_at: nowIso(),
+    member_id: relation.member_id ?? null,
+    member_urn: relation.member_urn ?? null,
+    connection_urn: relation.connection_urn ?? null,
+    public_identifier: relation.public_identifier ?? null,
+    profile_picture_url: relation.profile_picture_url ?? null,
+    raw_relation: relation,
+  };
+}
+
+async function loadPeopleBySourceKeys(
+  lix: Workspace["lix"],
+  sourceKeys: string[],
+): Promise<Map<string, string>> {
+  const index = new Map<string, string>();
+  for (const chunk of chunks(unique(sourceKeys), SELECT_CHUNK_SIZE)) {
+    const placeholders = chunk.map((_, index) => `$${index + 1}`).join(", ");
+    const result = await exec(
+      lix,
+      `SELECT record_id, normalized_key
+       FROM acrm_value
+       WHERE active_until IS NULL
+         AND object_slug = 'people'
+         AND attribute_slug = 'source_keys'
+         AND normalized_key IN (${placeholders})`,
+      chunk,
+    );
+    for (const row of result.rows) {
+      if (typeof row.record_id === "string" && typeof row.normalized_key === "string") {
+        index.set(row.normalized_key, row.record_id);
+      }
+    }
+  }
+  return index;
+}
+
+async function loadPeopleByLinkedinUrl(
+  lix: Workspace["lix"],
+  linkedinUrls: string[],
+): Promise<Map<string, string>> {
+  const index = new Map<string, string>();
+  for (const chunk of chunks(unique(linkedinUrls), SELECT_CHUNK_SIZE)) {
+    const placeholders = chunk.map((_, index) => `$${index + 1}`).join(", ");
+    const result = await exec(
+      lix,
+      `SELECT record_id, normalized_key
+       FROM acrm_value
+       WHERE active_until IS NULL
+         AND object_slug = 'people'
+         AND attribute_slug = 'linkedin_url'
+         AND normalized_key IN (${placeholders})`,
+      chunk,
+    );
+    for (const row of result.rows) {
+      if (typeof row.record_id === "string" && typeof row.normalized_key === "string") {
+        index.set(row.normalized_key, row.record_id);
+      }
+    }
+  }
+  return index;
+}
+
+async function loadExistingValues(
+  lix: Workspace["lix"],
+  recordIds: string[],
+): Promise<ExistingValues> {
+  const existing: ExistingValues = {
+    singleValues: new Map(),
+    multiValues: new Set(),
+  };
+  for (const chunk of chunks(recordIds, SELECT_CHUNK_SIZE)) {
+    const placeholders = chunk.map((_, index) => `$${index + 1}`).join(", ");
+    const result = await exec(
+      lix,
+      `SELECT record_id, attribute_slug, value_json, normalized_key
+       FROM acrm_value
+       WHERE active_until IS NULL
+         AND object_slug = 'people'
+         AND record_id IN (${placeholders})`,
+      chunk,
+    );
+    for (const row of result.rows) {
+      if (typeof row.record_id !== "string" || typeof row.attribute_slug !== "string") continue;
+      const valueJson = parseValueJson(row.value_json);
+      if (valueJson) {
+        existing.singleValues.set(singleValueKey(row.record_id, row.attribute_slug), valueJson);
+      }
+      if (typeof row.normalized_key === "string") {
+        existing.multiValues.add(normalizedValueKey(row.record_id, row.attribute_slug, row.normalized_key));
+      }
+    }
+  }
+  return existing;
+}
+
+function enqueueSingleIfMissing(
+  writer: LinkedinRelationWriteBatcher,
+  existing: ExistingValues,
+  plan: RecordPlan,
+  attributeSlug: string,
+  attributeType: AttributeType,
+  rawValue: unknown,
+  provenance: Record<string, unknown>,
+): boolean {
+  const key = singleValueKey(plan.recordId, attributeSlug);
+  if (!plan.created && existing.singleValues.has(key)) return false;
+  if (existing.singleValues.has(key)) return false;
+  const valueJson = encode(attributeType, rawValue);
+  existing.singleValues.set(key, valueJson);
+  writer.enqueueValue({
+    record_id: plan.recordId,
+    attribute_slug: attributeSlug,
+    attribute_type: attributeType,
+    value: valueJson,
+    provenance,
+  });
+  return true;
+}
+
+function enqueueMulti(
+  writer: LinkedinRelationWriteBatcher,
+  existing: ExistingValues,
+  plan: RecordPlan,
+  attributeSlug: string,
+  attributeType: AttributeType,
+  rawValue: unknown,
+  provenance: Record<string, unknown>,
+): boolean {
+  const valueJson = encode(attributeType, rawValue);
+  const prepared = writer.prepareValue({
+    record_id: plan.recordId,
+    attribute_slug: attributeSlug,
+    attribute_type: attributeType,
+    value: valueJson,
+    provenance,
+  });
+  const key = prepared.normalized_key
+    ? normalizedValueKey(plan.recordId, attributeSlug, prepared.normalized_key)
+    : null;
+  if (key) {
+    if (existing.multiValues.has(key)) return false;
+    existing.multiValues.add(key);
+  }
+  writer.enqueuePreparedValue(prepared);
+  return true;
+}
+
+class LinkedinRelationWriteBatcher {
+  private records: Array<{ object_slug: "people"; record_id: string }> = [];
+  private values: PreparedValueInsert[] = [];
+
+  constructor(private readonly lix: Workspace["lix"]) {}
+
+  enqueueRecord(record: { object_slug: "people"; record_id: string }): void {
+    this.records.push(record);
+  }
+
+  prepareValue(input: ValueInput): PreparedValueInsert {
+    return prepareValueInsert(uuidv7(), {
+      object_slug: "people",
+      record_id: input.record_id,
+      attribute_slug: input.attribute_slug,
+      attribute_type: input.attribute_type,
+      value_json: input.value,
+      source: SOURCE,
+      provenance: input.provenance,
+    });
+  }
+
+  enqueueValue(input: ValueInput): void {
+    this.values.push(this.prepareValue(input));
+  }
+
+  enqueuePreparedValue(value: PreparedValueInsert): void {
+    this.values.push(value);
+  }
+
+  async flush(): Promise<void> {
+    if (this.records.length > 0) await this.flushRecords();
+    if (this.values.length > 0) await this.flushValues();
+  }
+
+  private async flushRecords(): Promise<void> {
+    for (const chunk of chunks(this.records, MAX_BATCH_ROWS)) {
+      const placeholders = chunk
+        .map((_, index) => `($${index * 2 + 1}, $${index * 2 + 2})`)
+        .join(", ");
+      const params: LixRuntimeValue[] = chunk.flatMap((record) => [record.object_slug, record.record_id]);
+      await exec(
+        this.lix,
+        `INSERT INTO acrm_record (object_slug, record_id) VALUES ${placeholders}`,
+        params,
+      );
+    }
+    this.records = [];
+  }
+
+  private async flushValues(): Promise<void> {
+    const COLS = 10;
+    for (const chunk of chunks(this.values, MAX_BATCH_ROWS)) {
+      const placeholders = chunk
+        .map((_, index) => {
+          const base = index * COLS;
+          return `(${Array.from({ length: COLS }, (_, offset) => `$${base + offset + 1}`).join(", ")})`;
+        })
+        .join(", ");
+      const params: LixRuntimeValue[] = chunk.flatMap((value) => [
+        value.id,
+        value.object_slug,
+        value.record_id,
+        value.attribute_slug,
+        value.value_json,
+        value.normalized_key,
+        value.ref_object,
+        value.ref_record_id,
+        value.source,
+        value.provenance_json,
+      ]);
+      await exec(
+        this.lix,
+        `INSERT INTO acrm_value
+          (id, object_slug, record_id, attribute_slug, value_json,
+           normalized_key, ref_object, ref_record_id, source, provenance_json)
+         VALUES ${placeholders}`,
+        params,
+      );
+    }
+    this.values = [];
+  }
+}
+
+function cleanString(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function singleValueKey(recordId: string, attributeSlug: string): string {
+  return `${recordId}\0${attributeSlug}`;
+}
+
+function normalizedValueKey(recordId: string, attributeSlug: string, normalizedKey: string): string {
+  return `${singleValueKey(recordId, attributeSlug)}\0normalized\0${normalizedKey}`;
+}
+
+function parseValueJson(value: unknown): ValueJson | null {
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      return isObject(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+  return isObject(value) ? value : null;
+}
+
+function isObject(value: unknown): value is ValueJson {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function chunks<T>(values: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let index = 0; index < values.length; index += size) {
+    result.push(values.slice(index, index + size));
+  }
+  return result;
+}

--- a/packages/sdk/src/workspace/seeds.ts
+++ b/packages/sdk/src/workspace/seeds.ts
@@ -43,6 +43,7 @@ const ATTRIBUTES: AttributeSeed[] = [
   { object_slug: "people", attribute_slug: "phone_numbers", title: "Phone numbers", attribute_type: "phone-number", is_multivalued: true, is_unique: true },
   { object_slug: "people", attribute_slug: "job_title", title: "Job title", attribute_type: "text", is_multivalued: false, is_unique: false },
   { object_slug: "people", attribute_slug: "linkedin_url", title: "LinkedIn", attribute_type: "url", is_multivalued: false, is_unique: false },
+  { object_slug: "people", attribute_slug: "linkedin_connected_at", title: "LinkedIn connected at", attribute_type: "timestamp", is_multivalued: false, is_unique: false },
   { object_slug: "people", attribute_slug: "twitter_url", title: "Twitter / X", attribute_type: "url", is_multivalued: false, is_unique: false },
   { object_slug: "people", attribute_slug: "source_keys", title: "Source keys", attribute_type: "text", is_multivalued: true, is_unique: true },
   { object_slug: "people", attribute_slug: "company", title: "Company", attribute_type: "record-reference", is_multivalued: false, is_unique: false, config: { target_object: "companies", inverse: "team" } },


### PR DESCRIPTION
## Summary
- add explicit `acrm connect linkedin` for hosted LinkedIn auth
- make no-arg `acrm import linkedin` import lightweight existing LinkedIn relations from the sync engine
- add SDK relation import with batching, `linkedin_connected_at`, and updated LinkedIn skill/docs

## Tests
- `npm run test --workspace @agent-crm/cli -- src/commands/import-linkedin.test.ts src/commands/import-linkedin-relations.test.ts src/commands/connect.test.ts src/lib/cloud-workspace.test.ts`
- `npm run build`
- `npm test`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `acrm connect linkedin` command and `acrm import linkedin` network import
> - Adds a new `acrm connect linkedin` CLI command ([connect.ts](https://github.com/cluster-software/agent-crm/pull/126/files#diff-e3f1e3ab4a99c7f0f1db00244fa6131196fba90403a20122f9d2933eae850843)) that registers the workspace with the sync engine and returns a hosted LinkedIn auth URL.
> - Reworks `acrm import linkedin` to fetch 1st-degree LinkedIn relations from the sync engine and import them as people records, replacing the previous connect flow; supports an optional `--cutoff-date` flag.
> - Implements `importLinkedinRelations` in the SDK ([import-linkedin-relations.ts](https://github.com/cluster-software/agent-crm/pull/126/files#diff-6d5bd513e5b1fba289340cc24796b080d5d017b91744330c5804404f9be7083e)) with idempotent deduplication (by LinkedIn URL, then source key), minimal field writes, and stats reporting.
> - Adds a `linkedin_connected_at` timestamp attribute to the people schema seed.
> - Behavioral Change: `acrm import linkedin` without a URL no longer launches the connect flow — it imports existing connections instead. `--cutoff-date` and `--sync` cannot be used together.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d70bdf3. 11 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->