### PR TITLE
Backfill LinkedIn URLs from message sync

### DIFF
--- a/packages/cli/skills/connect-linkedin-to-acrm.md
+++ b/packages/cli/skills/connect-linkedin-to-acrm.md
@@ -19,7 +19,7 @@ This is the hosted LinkedIn sync flow:
 
 ## Run
 
-First confirm the workspace path. If the user did not provide one, use the current directory and run:
+First resolve the workspace. Prefer the user's active/open `.acrm` workspace or the current working directory. If the workspace is unclear, run:
 
 ```sh
 find . -maxdepth 2 -name '*.acrm' -print
@@ -31,16 +31,14 @@ If no workspace is found, ask which `.acrm` file to use or initialize one:
 acrm init workspace.acrm
 ```
 
-Set the workspace path:
+Run commands from the directory containing the active `.acrm` file and omit `-w` when there is a single obvious workspace. If you must run from a different directory or there are multiple `.acrm` files, pass the absolute path directly with `-w /path/to/workspace.acrm`.
 
-```sh
-export WORKSPACE=/path/to/workspace.acrm
-```
+Do not set or re-export a `WORKSPACE` shell variable. Tool calls usually run in fresh shells, so repeated exports add noise without preserving useful state.
 
 Start the connect flow:
 
 ```sh
-CONNECT_JSON=$(acrm --json -w "$WORKSPACE" connect linkedin)
+CONNECT_JSON=$(acrm --json connect linkedin)
 echo "$CONNECT_JSON"
 open "$(echo "$CONNECT_JSON" | jq -r '.data.auth_url')"
 ```
@@ -62,13 +60,13 @@ If they choose `Future messages only`, stop after confirming LinkedIn is connect
 If they choose `All existing contacts`, run:
 
 ```sh
-acrm --json -w "$WORKSPACE" import linkedin
+acrm --json import linkedin
 ```
 
 If they choose `Recent connections`, ask for a cutoff date. Default to 30 days ago, but accept any `YYYY-MM-DD` date the user chooses. Then run:
 
 ```sh
-acrm --json -w "$WORKSPACE" import linkedin --cutoff-date <YYYY-MM-DD>
+acrm --json import linkedin --cutoff-date <YYYY-MM-DD>
 ```
 
 If `acrm import linkedin` says LinkedIn is not connected, send the user back to the connect flow above.
@@ -78,13 +76,13 @@ If `acrm import linkedin` says LinkedIn is not connected, send the user back to 
 After the browser flow completes, pull any available LinkedIn messages:
 
 ```sh
-acrm --json -w "$WORKSPACE" import linkedin --sync
+acrm --json import linkedin --sync
 ```
 
 Verify recent imported message bodies:
 
 ```sh
-acrm --json -w "$WORKSPACE" execute "
+acrm --json execute "
 SELECT value_json, active_from
 FROM acrm_value
 WHERE object_slug = 'communication_messages'

--- a/packages/cli/src/commands/import-communication.test.ts
+++ b/packages/cli/src/commands/import-communication.test.ts
@@ -92,7 +92,75 @@ describe("importCommunicationBatch", () => {
 
     await lix.close();
   });
+
+  it("imports LinkedIn communication people with linkedin_url and dedupes by it", async () => {
+    const lix = await openTestWorkspace();
+    const ws = Workspace.fromLix(lix);
+
+    const first = await importCommunicationBatch(ws, linkedinMessageBatch({
+      personSourceKey: "linkedin_unipile:acct-1:profile:https://www.linkedin.com/in/enrique-goudet",
+      threadSourceKey: "linkedin_unipile:acct-1:thread:thread-1",
+      messageSourceKey: "linkedin_unipile:acct-1:message:msg-1",
+      messageId: "msg-1",
+    }));
+    const second = await importCommunicationBatch(ws, linkedinMessageBatch({
+      personSourceKey: "linkedin_unipile:acct-1:profile:enrique-goudet",
+      threadSourceKey: "linkedin_unipile:acct-1:thread:thread-2",
+      messageSourceKey: "linkedin_unipile:acct-1:message:msg-2",
+      messageId: "msg-2",
+    }));
+
+    expect(first.stats.people_created).toBe(1);
+    expect(second.stats.people_created).toBe(0);
+    await expect(countRecords(lix, "people")).resolves.toBe(1);
+    await expect(singleValue(lix, "people", "linkedin_url")).resolves.toBe("linkedin.com/in/enrique-goudet");
+    await expect(countValuesFor(lix, "people", "linkedin_url")).resolves.toBe(1);
+    await expect(countValuesFor(lix, "people", "source_keys")).resolves.toBe(2);
+
+    await lix.close();
+  });
 });
+
+function linkedinMessageBatch(input: {
+  personSourceKey: string;
+  threadSourceKey: string;
+  messageSourceKey: string;
+  messageId: string;
+}) {
+  return {
+    people: [
+      {
+        sourceKey: input.personSourceKey,
+        displayName: "Enrique Goudet",
+        linkedinUrl: "https://www.linkedin.com/in/enrique-goudet/",
+      },
+    ],
+    communicationThreads: [
+      {
+        sourceKey: input.threadSourceKey,
+        provider: "linkedin_unipile",
+        channel: "linkedin" as const,
+        providerAccountId: "acct-1",
+        providerThreadId: input.threadSourceKey,
+        participantSourceKeys: [input.personSourceKey],
+      },
+    ],
+    communicationMessages: [
+      {
+        sourceKey: input.messageSourceKey,
+        provider: "linkedin_unipile",
+        channel: "linkedin" as const,
+        providerAccountId: "acct-1",
+        providerMessageId: input.messageId,
+        providerThreadId: input.threadSourceKey,
+        threadSourceKey: input.threadSourceKey,
+        bodyText: "yo",
+        direction: "inbound" as const,
+        participantSourceKeys: [input.personSourceKey],
+      },
+    ],
+  };
+}
 
 async function countRecords(lix: Awaited<ReturnType<typeof openTestWorkspace>>, objectSlug: string) {
   const result = await exec(
@@ -106,6 +174,46 @@ async function countRecords(lix: Awaited<ReturnType<typeof openTestWorkspace>>, 
 async function countValues(lix: Awaited<ReturnType<typeof openTestWorkspace>>) {
   const result = await exec(lix, "SELECT COUNT(*) AS n FROM acrm_value", []);
   return Number(result.rows[0]?.n ?? 0);
+}
+
+async function countValuesFor(
+  lix: Awaited<ReturnType<typeof openTestWorkspace>>,
+  objectSlug: string,
+  attributeSlug: string,
+) {
+  const result = await exec(
+    lix,
+    `SELECT COUNT(*) AS n
+     FROM acrm_value
+     WHERE object_slug = $1 AND attribute_slug = $2 AND active_until IS NULL`,
+    [objectSlug, attributeSlug],
+  );
+  return Number(result.rows[0]?.n ?? 0);
+}
+
+async function singleValue(
+  lix: Awaited<ReturnType<typeof openTestWorkspace>>,
+  objectSlug: string,
+  attributeSlug: string,
+) {
+  const result = await exec(
+    lix,
+    `SELECT value_json
+     FROM acrm_value
+     WHERE object_slug = $1 AND attribute_slug = $2 AND active_until IS NULL
+     LIMIT 1`,
+    [objectSlug, attributeSlug],
+  );
+  const value = result.rows[0]?.value_json;
+  if (typeof value === "string") {
+    const parsed = JSON.parse(value) as { value?: unknown };
+    return typeof parsed.value === "string" ? parsed.value : null;
+  }
+  if (value && typeof value === "object" && "value" in value) {
+    const raw = (value as { value?: unknown }).value;
+    return typeof raw === "string" ? raw : null;
+  }
+  return null;
 }
 
 async function hasAttribute(

--- a/packages/sdk/src/operations/import-communication.ts
+++ b/packages/sdk/src/operations/import-communication.ts
@@ -6,6 +6,7 @@ import {
 } from "../db/value-row.js";
 import {
   encode,
+  normalizeLinkedinUrl,
   normalizeDomain as normalizeDomainValue,
   type AttributeConfig,
   type AttributeType,
@@ -20,6 +21,7 @@ export type CommunicationImportPerson = {
   sourceKey: string;
   email?: string;
   displayName?: string;
+  linkedinUrl?: string;
   companySourceKey?: string;
 };
 
@@ -144,6 +146,8 @@ export async function importCommunicationBatch(
   const plannedSourceIndex = new Map(sourceIndex);
   const emailIndex = await loadPeopleByEmail(lix, batch.people);
   const plannedEmailIndex = new Map(emailIndex);
+  const linkedinIndex = await loadPeopleByLinkedinUrl(lix, batch.people);
+  const plannedLinkedinIndex = new Map(linkedinIndex);
   const companies = batch.companies ?? [];
   const domainIndex = await loadCompaniesByDomain(lix, companies);
   const plannedDomainIndex = new Map(domainIndex);
@@ -168,11 +172,14 @@ export async function importCommunicationBatch(
   for (const person of batch.people) {
     if (personPlans.has(person.sourceKey)) continue;
     const email = normalizeEmail(person.email);
+    const linkedinUrl = normalizeLinkedinUrlValue(person.linkedinUrl);
     const existingRecordId = plannedSourceIndex.get(sourceIndexKey("people", person.sourceKey)) ??
-      (email ? plannedEmailIndex.get(email) : undefined);
+      (email ? plannedEmailIndex.get(email) : undefined) ??
+      (linkedinUrl ? plannedLinkedinIndex.get(linkedinUrl) : undefined);
     const plan = planRecord("people", person.sourceKey, existingRecordId, recordsToCreate, plannedSourceIndex);
     personPlans.set(person.sourceKey, plan);
     if (email) plannedEmailIndex.set(email, plan.recordId);
+    if (linkedinUrl) plannedLinkedinIndex.set(linkedinUrl, plan.recordId);
     if (plan.created) stats.people_created++;
   }
 
@@ -220,6 +227,10 @@ export async function importCommunicationBatch(
     enqueueMulti(writer, existingValues, plan, "source_keys", "text", person.sourceKey);
     if (person.email) {
       enqueueMulti(writer, existingValues, plan, "email_addresses", "email-address", person.email);
+    }
+    const linkedinUrl = normalizeLinkedinUrlValue(person.linkedinUrl);
+    if (linkedinUrl) {
+      enqueueSingleIfMissing(writer, existingValues, plan, "linkedin_url", "url", linkedinUrl);
     }
     if (person.displayName) {
       enqueueSingle(writer, existingValues, plan, "name", "personal-name", person.displayName);
@@ -449,6 +460,33 @@ async function loadPeopleByEmail(
   return index;
 }
 
+async function loadPeopleByLinkedinUrl(
+  lix: Workspace["lix"],
+  people: CommunicationImportPerson[],
+): Promise<Map<string, string>> {
+  const urls = unique(people.map((person) => normalizeLinkedinUrlValue(person.linkedinUrl)).filter((url): url is string => Boolean(url)));
+  const index = new Map<string, string>();
+  for (const chunk of chunks(urls, SELECT_CHUNK_SIZE)) {
+    const placeholders = chunk.map((_, index) => `$${index + 1}`).join(", ");
+    const result = await exec(
+      lix,
+      `SELECT record_id, normalized_key
+       FROM acrm_value
+       WHERE active_until IS NULL
+         AND object_slug = 'people'
+         AND attribute_slug = 'linkedin_url'
+         AND normalized_key IN (${placeholders})`,
+      chunk,
+    );
+    for (const row of result.rows) {
+      if (typeof row.record_id === "string" && typeof row.normalized_key === "string") {
+        index.set(row.normalized_key, row.record_id);
+      }
+    }
+  }
+  return index;
+}
+
 async function loadCompaniesByDomain(
   lix: Workspace["lix"],
   companies: CommunicationImportCompany[],
@@ -588,6 +626,19 @@ function enqueueSingle(
   }
   existing.singleValues.set(key, valueJson);
   writer.enqueueValue(valueInput(plan.objectSlug, plan.recordId, attributeSlug, attributeType, valueJson));
+}
+
+function enqueueSingleIfMissing(
+  writer: CommunicationWriteBatcher,
+  existing: ExistingValues,
+  plan: RecordPlan,
+  attributeSlug: string,
+  attributeType: AttributeType,
+  rawValue: unknown,
+): void {
+  const key = singleValueKey(plan.objectSlug, plan.recordId, attributeSlug);
+  if (!plan.created && existing.singleValues.has(key)) return;
+  enqueueSingle(writer, existing, plan, attributeSlug, attributeType, rawValue);
 }
 
 function enqueueSingleReference(
@@ -860,6 +911,10 @@ function normalizeEmail(email: string | undefined): string | undefined {
 function normalizeDomain(domain: string | undefined): string | undefined {
   const normalized = domain ? normalizeDomainValue(domain) : undefined;
   return normalized || undefined;
+}
+
+function normalizeLinkedinUrlValue(url: string | undefined): string | undefined {
+  return url ? normalizeLinkedinUrl(url) ?? undefined : undefined;
 }
 
 function unique(values: string[]): string[] {


### PR DESCRIPTION
## Summary
- teach communication imports to read `linkedinUrl` from sync-engine people
- dedupe LinkedIn message-created people by normalized LinkedIn URL
- backfill `people.linkedin_url` without overwriting an existing value
- update the LinkedIn skill to prefer the active workspace/cwd instead of repeated `WORKSPACE` exports

## Verification
- npm run build
- npm run test --workspace @agent-crm/cli -- import-communication
- npm test

Also verified `/Users/luiscosta/agent-crm/linkedin-test`: rerunning `import linkedin --sync` with this branch backfilled Enrique Goudet with `linkedin.com/in/enrique-goudet`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add LinkedIn URL deduplication and backfill to communication person import
> - Extends `CommunicationImportPerson` with an optional `linkedinUrl` field and uses it to deduplicate people by normalized LinkedIn URL alongside existing `sourceKey` and email lookups.
> - Adds `loadPeopleByLinkedinUrl` to query existing `linkedin_url` attribute values and build a lookup map, and `enqueueSingleIfMissing` to write the value only on newly created records (never overwriting existing ones).
> - Behavioral Change: people imported via LinkedIn message sync can now be matched to existing records by LinkedIn URL, which may reduce duplicate person records where previously separate records would have been created.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f92acc7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->