### PR TITLE
Open Gmail OAuth URL automatically

### DIFF
--- a/.changeset/open-gmail-oauth-browser.md
+++ b/.changeset/open-gmail-oauth-browser.md
@@ -1,0 +1,5 @@
+---
+"@agent-crm/cli": patch
+---
+
+Open the Gmail OAuth URL automatically from `acrm import gmail`, with `--no-open` available for scripts that only need the URL.

--- a/packages/cli/skills/acrm-onboarding.md
+++ b/packages/cli/skills/acrm-onboarding.md
@@ -58,13 +58,12 @@ Run:
 acrm import gmail --json
 ```
 
-Extract `data.auth_url` from the JSON response. Show it as a Markdown
-link so it is clickable:
+This opens the Google OAuth URL in the user's browser automatically. Do
+not print `data.auth_url` unless the command fails to open the browser and
+the user needs the fallback URL.
 
 ```md
-Open this URL to connect Gmail:
-
-[<auth_url>](<auth_url>)
+Your browser should now be open to connect Gmail.
 
 Pick your Google account and click Allow.
 
@@ -77,7 +76,8 @@ What `acrm import gmail` does now:
 
 1. Reads or creates `.agent-crm-cloud.json` next to the local workspace.
 2. Starts a hosted sync-engine OAuth attempt.
-3. Returns the Google OAuth URL immediately.
+3. Opens the Google OAuth URL in the user's browser and returns it as
+   `data.auth_url` for fallback/debugging.
 
 After OAuth, the sync engine redirects to a "Gmail sync started" page and
 imports Gmail in the background. Gmail data is written to the cloud
@@ -114,7 +114,7 @@ Both require `APIFY_API_TOKEN` in `.env` next to the workspace. If missing, the 
 ### 4. Confirm + next step
 
 For Gmail, do not add a separate confirmation or next-step message after
-the OAuth link copy above. Do not suggest `/prep-call`,
+the OAuth browser-open copy above. Do not suggest `/prep-call`,
 `/setup-transcripts`, or any other next step. The user still needs to
 finish OAuth first.
 

--- a/packages/cli/src/commands/import-gmail.test.ts
+++ b/packages/cli/src/commands/import-gmail.test.ts
@@ -40,6 +40,21 @@ describe("importGoogleContacts", () => {
     );
   });
 
+  it("selects the platform browser opener command", () => {
+    expect(gmailCommandTest.browserOpenCommand("darwin", "https://example.com")).toEqual({
+      command: "open",
+      args: ["https://example.com"],
+    });
+    expect(gmailCommandTest.browserOpenCommand("win32", "https://example.com")).toEqual({
+      command: "cmd",
+      args: ["/c", "start", "", "https://example.com"],
+    });
+    expect(gmailCommandTest.browserOpenCommand("linux", "https://example.com")).toEqual({
+      command: "xdg-open",
+      args: ["https://example.com"],
+    });
+  });
+
   it("creates person + company from a connection with email + organization", async () => {
     const lix = await openTestWorkspace();
     const ws = Workspace.fromLix(lix);

--- a/packages/cli/src/commands/import-gmail.ts
+++ b/packages/cli/src/commands/import-gmail.ts
@@ -1,9 +1,14 @@
 import type { Command } from "commander";
+import { spawn } from "node:child_process";
 import { basename, dirname } from "node:path";
 import { AcrmError, ERR } from "@agent-crm/sdk";
 import { resolveWorkspacePath } from "../workspace-resolve.js";
 import { fail, isJson, ok, setJsonMode } from "../output/json.js";
 import { DEFAULT_SYNC_ENGINE_URL, ensureCloudWorkspaceMetadata } from "../lib/cloud-workspace.js";
+
+type Opts = {
+  open?: boolean;
+};
 
 export function attachGmailSubcommand(parent: Command): void {
   parent
@@ -11,7 +16,8 @@ export function attachGmailSubcommand(parent: Command): void {
     .description(
       "Connect Gmail through Agent CRM's hosted sync engine. Opens hosted Google OAuth and syncs people, email threads, and email messages into the cloud workspace.",
     )
-    .action(async () => {
+    .option("--no-open", "print the OAuth URL without opening it in a browser")
+    .action(async (opts: Opts) => {
       const root = parent.parent?.opts() as
         | { workspace?: string; json?: boolean }
         | undefined;
@@ -32,10 +38,14 @@ export function attachGmailSubcommand(parent: Command): void {
           workspaceName: basename(workspaceDir),
         });
 
+        if (opts.open !== false) openInBrowser(authUrl);
+
         if (!isJson()) {
           process.stdout.write(
             [
-              "Open this URL to connect Gmail:",
+              opts.open === false
+                ? "Open this URL to connect Gmail:"
+                : "Opening browser to connect Gmail. If it doesn't open, paste this URL:",
               authUrl,
               "",
               "After OAuth, Gmail sync runs in the background through Agent CRM's hosted sync engine.",
@@ -99,7 +109,30 @@ function gmailConnectUrl(input: {
   return url.toString();
 }
 
+function browserOpenCommand(
+  platform: NodeJS.Platform,
+  url: string,
+): { command: string; args: string[] } {
+  if (platform === "darwin") return { command: "open", args: [url] };
+  if (platform === "win32") {
+    return { command: "cmd", args: ["/c", "start", "", url] };
+  }
+  return { command: "xdg-open", args: [url] };
+}
+
+function openInBrowser(url: string): void {
+  const { command, args } = browserOpenCommand(process.platform, url);
+  try {
+    const child = spawn(command, args, { detached: true, stdio: "ignore" });
+    child.on("error", () => {});
+    child.unref();
+  } catch {
+    // The printed URL remains the fallback when the shell cannot open a browser.
+  }
+}
+
 export const __test = {
   createGmailConnectUrl,
-  gmailConnectUrl
+  browserOpenCommand,
+  gmailConnectUrl,
 };


### PR DESCRIPTION
## Summary
- open the Gmail OAuth URL automatically from `acrm import gmail`
- keep `data.auth_url` in JSON output and add `--no-open` for scripts
- update the onboarding skill copy and add a CLI patch changeset

## Verification
- `npm run build --workspace @agent-crm/sdk`
- `npm run test --workspace @agent-crm/cli -- import-gmail.test.ts`
- `npm run build --workspace @agent-crm/cli`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open Gmail OAuth URL automatically in the system browser from `acrm import gmail`
> - `acrm import gmail` now spawns the system browser to open the OAuth URL by default, using OS-specific commands (`open` on macOS, `xdg-open` on Linux, `cmd /c start` on Windows).
> - The URL is still printed as a fallback if the browser fails to open.
> - A `--no-open` flag suppresses browser launching and prints only the URL, for use in scripts.
> - Behavioral Change: the default console output message changes from "Open this URL" to "Opening browser… If it doesn't open, paste this URL".
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 125ba95.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->