### PR TITLE
Add changeset for LinkedIn message URL fix

### DIFF
--- a/.changeset/linkedin-message-url-backfill.md
+++ b/.changeset/linkedin-message-url-backfill.md
@@ -1,0 +1,6 @@
+---
+"@agent-crm/cli": patch
+"@agent-crm/sdk": patch
+---
+
+Publish the LinkedIn message sync fix that imports and dedupes people by LinkedIn URL.


### PR DESCRIPTION
## Summary
- add missing patch changeset for the merged LinkedIn message sync URL backfill
- release both `@agent-crm/cli` and `@agent-crm/sdk` so the npm packages pick up #128

## Tests
- not run; changeset-only PR

Context: #128 merged the code but did not include release metadata.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add changeset for LinkedIn message URL sync fix in `@agent-crm/cli` and `@agent-crm/sdk`
> Adds a patch-level changeset file documenting a LinkedIn message sync fix that imports and deduplicates people by LinkedIn URL.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bc02704.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->