### PR TITLE
Update onboarding source options

### DIFF
--- a/.changeset/fresh-gmail-links.md
+++ b/.changeset/fresh-gmail-links.md
@@ -1,0 +1,5 @@
+---
+"@agent-crm/cli": patch
+---
+
+Make the Gmail onboarding fallback URL instruction use a bare URL instead of Markdown link syntax, and add LinkedIn account sync as an onboarding option.

--- a/packages/cli/skills/acrm-onboarding.md
+++ b/packages/cli/skills/acrm-onboarding.md
@@ -1,6 +1,6 @@
 ---
 name: acrm-onboarding
-description: Onboard a new Agent CRM user — initialize a `.acrm` workspace (if needed), then walk them through picking a first data source (Gmail / CSV / LinkedIn or X profile) and importing it. Trigger phrasings — "onboard me", "set up agent crm", "get started with acrm", "I'm new to acrm", or a bare `/acrm-onboarding`.
+description: Onboard a new Agent CRM user — initialize a `.acrm` workspace (if needed), then walk them through picking a first data source (Gmail / LinkedIn sync / CSV / LinkedIn or X profile) and importing it. Trigger phrasings — "onboard me", "set up agent crm", "get started with acrm", "I'm new to acrm", or a bare `/acrm-onboarding`.
 ---
 
 # acrm-onboarding
@@ -42,8 +42,9 @@ Use `AskUserQuestion` with this exact question and options (single-select, multi
 - **Question**: `What data source do you want to plug into?`
 - **Options**:
   1. `Sync from Gmail` — connects Gmail through Agent CRM's hosted sync engine
-  2. `Import a leads CSV` — load a file of leads
-  3. `Import a LinkedIn or X profile` — add one person at a time from a profile URL
+  2. `Sync from LinkedIn` — connects LinkedIn through Agent CRM's hosted sync engine
+  3. `Import a leads CSV` — load a file of leads
+  4. `Import a LinkedIn or X profile` — add one person at a time from a profile URL
 
 ### 3. Run the branch they chose
 
@@ -60,7 +61,8 @@ acrm import gmail --json
 
 This opens the Google OAuth URL in the user's browser automatically. Do
 not print `data.auth_url` unless the command fails to open the browser and
-the user needs the fallback URL.
+the user needs the fallback URL. If you do need to show the fallback URL,
+print it as a bare URL on its own line, not as a Markdown link.
 
 ```md
 Your browser should now be open to connect Gmail.
@@ -92,7 +94,12 @@ communication_messages
 Do not wait for a local CLI import to finish; there is no local Gmail
 import process anymore.
 
-#### 3b. CSV
+#### 3b. LinkedIn
+
+Use the `connect-linkedin-to-acrm` skill now and follow it end-to-end. Do
+not duplicate the LinkedIn connect/import flow in this onboarding skill.
+
+#### 3c. CSV
 
 Ask the user for the path to the CSV. Then run:
 
@@ -102,7 +109,7 @@ acrm import csv <path>
 
 If the user is in another country, pass `--default-country=<ISO>` (e.g. `GB`, `DE`) so locally-formatted phone numbers parse correctly. See `acrm import csv --help` for the full list of recognized column names.
 
-#### 3c. LinkedIn or X profile
+#### 3d. LinkedIn or X profile
 
 Ask the user for the URL (or `@handle` for X). Sniff the platform from the URL and run the right command:
 


### PR DESCRIPTION
## Summary
- Add LinkedIn account sync to the onboarding data-source picker
- Delegate the LinkedIn onboarding branch to the existing connect-linkedin-to-acrm skill
- Clarify Gmail OAuth fallback URLs should be printed as bare links
- Add a patch changeset for @agent-crm/cli

## Verification
- git diff --check

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add LinkedIn sync as an onboarding source option in the `acrm-onboarding` skill
> - Adds 'Sync from LinkedIn' as a new selectable option in the onboarding data source prompt, delegating to the `connect-linkedin-to-acrm` skill rather than duplicating its flow.
> - Renumbers subsequent options (CSV becomes 3c, LinkedIn/X profile becomes 3d) in [acrm-onboarding.md](https://github.com/cluster-software/agent-crm/pull/133/files#diff-62c6a245c0067c368907b06da492d53a7808aedf9a47d02a16704ed93f5688c8).
> - In the Gmail OAuth flow, changes fallback URL output from Markdown link syntax to a bare URL printed on its own line.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4498cc2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->