### PR TITLE
Shard CLI tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Two parallel jobs (no `needs:` between them) so total wall clock is
-  # max(build-test, smoke-tarballs) instead of build-test + smoke-tarballs.
-  build-test:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -37,12 +35,61 @@ jobs:
         if: steps.nm.outputs.cache-hit != 'true'
         run: npm ci
       - run: npm run build
-      - run: npm test
+
+  test-cli:
+    name: CLI tests (${{ matrix.shard }}/3)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Restore node_modules
+        id: nm
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: nm-${{ runner.os }}-node20-${{ hashFiles('package-lock.json') }}
+      - name: Install
+        if: steps.nm.outputs.cache-hit != 'true'
+        run: npm ci
+      - name: Build SDK for CLI package imports
+        run: npm run build --workspace @agent-crm/sdk
+      - run: npm run test --workspace @agent-crm/cli -- --shard ${{ matrix.shard }}/3
+
+  test-sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Restore node_modules
+        id: nm
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: nm-${{ runner.os }}-node20-${{ hashFiles('package-lock.json') }}
+      - name: Install
+        if: steps.nm.outputs.cache-hit != 'true'
+        run: npm ci
+      - run: npm run build --workspace @agent-crm/sdk
+      - run: npm run test --workspace @agent-crm/sdk
 
   smoke-tarballs:
     # Pack the published-tarball shape of both packages and run the issue's
     # smoke-test gate (SDK alone exports its API; CLI+SDK install together
-    # and `acrm` works end to end). Runs in parallel with build-test.
+    # and `acrm` works end to end). Runs in parallel with build and tests.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- split the CI build/test job into separate build, CLI test, and SDK test jobs
- run CLI tests as a three-way Vitest shard matrix
- keep tarball smoke checks running in parallel with the other jobs

## Testing
- npm run build
- npm run test --workspace @agent-crm/cli -- --shard 1/3
- npm run test --workspace @agent-crm/cli -- --shard 2/3
- npm run test --workspace @agent-crm/cli -- --shard 3/3
- npm run test --workspace @agent-crm/sdk
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'workflow yaml ok'"

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Shard CLI tests into 3 parallel jobs in CI
> - Splits the former `build-test` job into separate `build`, `test-cli`, and `test-sdk` jobs in [ci.yml](.github/workflows/ci.yml).
> - The `test-cli` job runs the CLI test suite across 3 parallel matrix shards to reduce total CI time.
> - The `test-sdk` job runs the SDK test suite independently.
> - The `build` job now only builds the project; it no longer runs any tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 40d44bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->