### PR TITLE
Import LinkedIn companies and poll connection status

### DIFF
--- a/.changeset/smooth-linkedin-companies.md
+++ b/.changeset/smooth-linkedin-companies.md
@@ -1,0 +1,6 @@
+---
+"@agent-crm/cli": patch
+"@agent-crm/sdk": patch
+---
+
+Import companies from hosted LinkedIn relation imports and add a LinkedIn connection status command for polling hosted connect completion.

--- a/packages/cli/skills/connect-linkedin-to-acrm.md
+++ b/packages/cli/skills/connect-linkedin-to-acrm.md
@@ -15,7 +15,7 @@ This is the hosted LinkedIn sync flow:
 2. The user opens Agent CRM's hosted LinkedIn connect page.
 3. The sync engine can receive post-connection LinkedIn message events from Unipile.
 4. The user chooses whether to import existing 1st-degree LinkedIn relations.
-5. Existing relations import as lightweight `people` records without bulk profile enrichment.
+5. Existing relations import as lightweight `people` and `companies` records without bulk profile enrichment.
 
 ## Run
 
@@ -43,11 +43,24 @@ echo "$CONNECT_JSON"
 open "$(echo "$CONNECT_JSON" | jq -r '.data.auth_url')"
 ```
 
-Have the user finish Cluster auth and LinkedIn verification in the browser. If they belong to multiple Cluster organizations, the hosted page will ask which one to use. LinkedIn may ask for an email, SMS, or authenticator-app code.
+Have the user finish Cluster auth and LinkedIn verification in the browser. If they belong to multiple Cluster organizations, the hosted page will ask which one to use. LinkedIn may ask for an email, SMS, authenticator-app code, or in-app sign-in approval.
+
+After opening the browser, keep the agent turn active and poll for completion every 2 seconds. Do not surface import options until the status command verifies LinkedIn is connected:
+
+```sh
+while true; do
+  STATUS_JSON=$(acrm --json connect linkedin --status 2>/dev/null || true)
+  if echo "$STATUS_JSON" | jq -e '.ok == true and .data.linkedin.connected == true' >/dev/null; then
+    echo "$STATUS_JSON"
+    break
+  fi
+  sleep 2
+done
+```
 
 ## Choose import behavior
 
-After the browser flow completes, use `AskUserQuestion` with this exact question and options (single-select, multipleChoice off):
+After the polling loop verifies completion, use `AskUserQuestion` with this exact question and options (single-select, multipleChoice off):
 
 - **Question**: `How should Agent CRM import LinkedIn contacts?`
 - **Options**:

--- a/packages/cli/src/commands/connect.test.ts
+++ b/packages/cli/src/commands/connect.test.ts
@@ -1,7 +1,19 @@
-import { describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Workspace } from "@agent-crm/sdk";
 import { __test as connectCommandTest } from "./connect.js";
 
 describe("connect linkedin command", () => {
+  const oldSyncEngineUrl = process.env.ACRM_SYNC_ENGINE_URL;
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (oldSyncEngineUrl === undefined) delete process.env.ACRM_SYNC_ENGINE_URL;
+    else process.env.ACRM_SYNC_ENGINE_URL = oldSyncEngineUrl;
+  });
+
   it("builds a hosted sync-engine LinkedIn connect URL", () => {
     const url = connectCommandTest.linkedinConnectUrl({
       syncEngineUrl: "https://sync.example.com",
@@ -25,5 +37,46 @@ describe("connect linkedin command", () => {
     expect(url).toBe(
       "https://sync.example.com/integrations/linkedin/connect?workspace_id=workspace-1&workspace_name=pipeline",
     );
+  });
+
+  it("requires an active LinkedIn account before reporting connected status", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "acrm-linkedin-status-"));
+    const workspacePath = join(dir, "workspace.acrm");
+    const ws = await Workspace.create(workspacePath);
+    await ws.close();
+    process.env.ACRM_SYNC_ENGINE_URL = "https://sync.example.com";
+    const fetchMock = vi.fn(async () => Response.json({
+      ok: true,
+      integrations: {
+        gmail: { connected: false },
+        linkedin: {
+          connected: true,
+          displayName: "Luis on LinkedIn",
+          providerAccountId: "unipile-account-1",
+          accounts: [
+            {
+              id: "acct-1",
+              providerAccountId: "unipile-account-1",
+              displayName: "Luis on LinkedIn",
+              status: "paused",
+            },
+          ],
+        },
+      },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const result = await connectCommandTest.runConnectLinkedinStatus({
+        workspace: workspacePath,
+      });
+
+      expect(result.linkedin.connected).toBe(false);
+      expect(result.linkedin.accounts?.[0]?.status).toBe("paused");
+      const [url] = fetchMock.mock.calls[0] as [string];
+      expect(url).toContain("/integrations/status");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -5,13 +5,16 @@ import { resolveWorkspacePath } from "../workspace-resolve.js";
 import { fail, isJson, ok, setJsonMode } from "../output/json.js";
 import { loadDotenv } from "../lib/dotenv.js";
 import {
+  type CloudIntegrationProviderStatus,
   DEFAULT_SYNC_ENGINE_URL,
   ensureCloudWorkspaceMetadata,
+  fetchCloudIntegrationStatus,
   registerCloudWorkspace,
 } from "../lib/cloud-workspace.js";
 
 type LinkedinConnectOpts = {
   orgId?: string;
+  status?: boolean;
 };
 
 export function registerConnect(program: Command): void {
@@ -20,10 +23,22 @@ export function registerConnect(program: Command): void {
     .command("linkedin")
     .description("connect LinkedIn through Agent CRM's hosted sync engine")
     .option("--org-id <org-id>", "Cluster organization id for hosted LinkedIn sync")
+    .option("--status", "show LinkedIn connection status without starting a new connect flow")
     .action(async (opts: LinkedinConnectOpts) => {
       const root = program.opts() as { workspace?: string; json?: boolean };
       setJsonMode(root.json);
       try {
+        if (opts.status) {
+          const result = await runConnectLinkedinStatus({
+            workspace: root.workspace,
+          });
+          if (!isJson()) {
+            process.stdout.write(linkedinStatusMessage(result.linkedin));
+            return;
+          }
+          ok(result);
+          return;
+        }
         const result = await runConnectLinkedin({
           workspace: root.workspace,
           orgId: opts.orgId,
@@ -93,6 +108,36 @@ async function runConnectLinkedin(opts: { workspace?: string; orgId?: string }):
   };
 }
 
+async function runConnectLinkedinStatus(opts: { workspace?: string }): Promise<{
+  workspace_id: string;
+  sync_engine_url: string;
+  linkedin: CliProviderStatus;
+}> {
+  const workspaceFile = resolveWorkspacePath(opts.workspace);
+  const workspaceDir = path.dirname(workspaceFile);
+  loadDotenv(workspaceDir);
+  loadDotenv(process.cwd());
+
+  const metadata = ensureCloudWorkspaceMetadata(workspaceDir, {
+    workspaceId: process.env.ACRM_CLOUD_WORKSPACE_ID,
+    clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,
+    clusterOrgId: process.env.ACRM_CLOUD_CLUSTER_ORG_ID,
+  });
+  const syncEngineUrl = process.env.ACRM_SYNC_ENGINE_URL ?? DEFAULT_SYNC_ENGINE_URL;
+  const status = await fetchCloudIntegrationStatus({
+    syncEngineUrl,
+    workspaceId: metadata.workspaceId,
+    clientToken: metadata.clientToken,
+  });
+  return {
+    workspace_id: metadata.workspaceId,
+    sync_engine_url: syncEngineUrl,
+    linkedin: toCliProviderStatus(status.linkedin, {
+      requireActiveAccount: true,
+    }),
+  };
+}
+
 function linkedinConnectUrl(input: {
   syncEngineUrl: string;
   workspaceId: string;
@@ -106,7 +151,56 @@ function linkedinConnectUrl(input: {
   return url.toString();
 }
 
+type CliProviderStatus = {
+  connected: boolean;
+  account_email?: string;
+  display_name?: string;
+  provider_account_id?: string;
+  last_synced_at?: string;
+  accounts?: Array<{
+    id: string;
+    provider_account_id: string;
+    account_email?: string;
+    display_name?: string;
+    status: string;
+    last_synced_at?: string;
+  }>;
+};
+
+function toCliProviderStatus(
+  provider: CloudIntegrationProviderStatus,
+  options: { requireActiveAccount?: boolean } = {},
+): CliProviderStatus {
+  const accounts = provider.accounts?.map((account) => ({
+    id: account.id,
+    provider_account_id: account.providerAccountId,
+    ...(account.accountEmail ? { account_email: account.accountEmail } : {}),
+    ...(account.displayName ? { display_name: account.displayName } : {}),
+    status: account.status,
+    ...(account.lastSyncedAt ? { last_synced_at: account.lastSyncedAt } : {}),
+  }));
+  const hasActiveAccount = accounts?.some((account) => account.status === "active") ?? false;
+  return {
+    connected: options.requireActiveAccount && accounts
+      ? hasActiveAccount
+      : provider.connected,
+    ...(provider.accountEmail ? { account_email: provider.accountEmail } : {}),
+    ...(provider.displayName ? { display_name: provider.displayName } : {}),
+    ...(provider.providerAccountId ? { provider_account_id: provider.providerAccountId } : {}),
+    ...(provider.lastSyncedAt ? { last_synced_at: provider.lastSyncedAt } : {}),
+    ...(accounts && accounts.length > 0 ? { accounts } : {}),
+  };
+}
+
+function linkedinStatusMessage(status: CliProviderStatus): string {
+  if (!status.connected) return "LinkedIn is not connected yet.\n";
+  const label = status.display_name ?? status.account_email ?? status.provider_account_id;
+  return label ? `LinkedIn is connected: ${label}\n` : "LinkedIn is connected.\n";
+}
+
 export const __test = {
   linkedinConnectUrl,
   runConnectLinkedin,
+  runConnectLinkedinStatus,
+  toCliProviderStatus,
 };

--- a/packages/cli/src/commands/import-linkedin-relations.test.ts
+++ b/packages/cli/src/commands/import-linkedin-relations.test.ts
@@ -30,11 +30,42 @@ describe("importLinkedinRelations", () => {
     });
 
     expect(result.stats.people_created).toBe(1);
-    await expect(valueFor(ws, "linkedin_url")).resolves.toBe("linkedin.com/in/ada-lovelace");
-    await expect(valueFor(ws, "name")).resolves.toBe("Ada Lovelace");
-    await expect(valueFor(ws, "job_title")).resolves.toBe("Founder at Analytical Engines");
-    await expect(valueFor(ws, "linkedin_connected_at")).resolves.toBe("2025-03-15T15:16:09.000Z");
+    await expect(valueFor(ws, "people", "linkedin_url")).resolves.toBe("linkedin.com/in/ada-lovelace");
+    await expect(valueFor(ws, "people", "name")).resolves.toBe("Ada Lovelace");
+    await expect(valueFor(ws, "people", "job_title")).resolves.toBe("Founder at Analytical Engines");
+    await expect(valueFor(ws, "people", "linkedin_connected_at")).resolves.toBe("2025-03-15T15:16:09.000Z");
     await expect(countValues(ws, "source_keys")).resolves.toBe(1);
+    await lix.close();
+  });
+
+  it("imports companies from LinkedIn relation rows and links people", async () => {
+    const lix = await openTestWorkspace();
+    const ws = Workspace.fromLix(lix);
+
+    const relations = [
+      relation({
+        member_id: "member-1",
+        first_name: "Ada",
+        last_name: "Lovelace",
+        company_name: "Analytical Engines",
+        company_linkedin_url: "https://www.linkedin.com/company/analytical-engines/",
+        public_profile_url: "https://www.linkedin.com/in/ada-lovelace/",
+      }),
+    ];
+
+    const result = await importLinkedinRelations(ws, { relations });
+    const second = await importLinkedinRelations(ws, { relations });
+
+    expect(result.stats.people_created).toBe(1);
+    expect(result.stats.companies_created).toBe(1);
+    expect(second.stats.people_created).toBe(0);
+    expect(second.stats.companies_created).toBe(0);
+    expect(second.stats.people_updated).toBe(0);
+    expect(second.stats.companies_updated).toBe(0);
+    await expect(valueFor(ws, "companies", "name")).resolves.toBe("Analytical Engines");
+    await expect(valueFor(ws, "companies", "linkedin_url")).resolves.toBe("linkedin.com/company/analytical-engines");
+    await expect(referenceCount(ws, "people", "company", "companies")).resolves.toBe(1);
+    await expect(referenceCount(ws, "companies", "team", "people")).resolves.toBe(1);
     await lix.close();
   });
 
@@ -142,9 +173,9 @@ describe("importLinkedinRelations", () => {
     });
 
     expect(result.stats.people_created).toBe(0);
-    await expect(valueFor(ws, "name")).resolves.toBe("Augusta Ada King");
-    await expect(valueFor(ws, "job_title")).resolves.toBe("Mathematician");
-    await expect(valueFor(ws, "linkedin_connected_at")).resolves.toBe("2025-03-15T15:16:09.000Z");
+    await expect(valueFor(ws, "people", "name")).resolves.toBe("Augusta Ada King");
+    await expect(valueFor(ws, "people", "job_title")).resolves.toBe("Mathematician");
+    await expect(valueFor(ws, "people", "linkedin_connected_at")).resolves.toBe("2025-03-15T15:16:09.000Z");
     await expect(countValues(ws, "source_keys")).resolves.toBe(2);
     await lix.close();
   });
@@ -160,23 +191,42 @@ function relation(overrides: Partial<LinkedinRelation>): LinkedinRelation {
   };
 }
 
-async function valueFor(ws: Workspace, attributeSlug: string): Promise<string | null> {
+async function valueFor(ws: Workspace, objectSlug: string, attributeSlug: string): Promise<string | null> {
   const result = await exec(
     ws.lix,
     `SELECT value_json
      FROM acrm_value
-     WHERE object_slug = 'people'
-       AND attribute_slug = $1
+     WHERE object_slug = $1
+       AND attribute_slug = $2
        AND active_until IS NULL
      ORDER BY active_from DESC
      LIMIT 1`,
-    [attributeSlug],
+    [objectSlug, attributeSlug],
   );
   const raw = result.rows[0]?.value_json;
   const parsed = typeof raw === "string"
     ? JSON.parse(raw) as { value?: string; full_name?: string; timestamp?: string }
     : raw as { value?: string; full_name?: string; timestamp?: string } | undefined;
   return parsed?.value ?? parsed?.full_name ?? parsed?.timestamp ?? null;
+}
+
+async function referenceCount(
+  ws: Workspace,
+  objectSlug: string,
+  attributeSlug: string,
+  refObject: string,
+): Promise<number> {
+  const result = await exec(
+    ws.lix,
+    `SELECT COUNT(*) AS n
+     FROM acrm_value
+     WHERE object_slug = $1
+       AND attribute_slug = $2
+       AND ref_object = $3
+       AND active_until IS NULL`,
+    [objectSlug, attributeSlug, refObject],
+  );
+  return Number(result.rows[0]?.n ?? 0);
 }
 
 async function countRecords(ws: Workspace): Promise<number> {

--- a/packages/cli/src/lib/cloud-workspace.test.ts
+++ b/packages/cli/src/lib/cloud-workspace.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ensureCloudWorkspaceMetadata,
   fetchCloudCommunicationExport,
+  fetchCloudIntegrationStatus,
   fetchCloudLinkedinRelationsExport,
   LINKEDIN_NOT_CONNECTED_HINT,
   LINKEDIN_NOT_CONNECTED_MESSAGE,
@@ -53,6 +54,42 @@ describe("cloud workspace metadata", () => {
       "https://sync.example.com/workspaces/workspace-1/register?workspace_name=pipeline",
       {
         method: "POST",
+        headers: {
+          authorization: "Bearer client-token-1",
+        },
+      },
+    );
+  });
+
+  it("fetches integration status", async () => {
+    const integrations = {
+      gmail: { connected: false },
+      linkedin: {
+        connected: true,
+        displayName: "Luis on LinkedIn",
+        providerAccountId: "unipile-account-1",
+        accounts: [
+          {
+            id: "acct-1",
+            providerAccountId: "unipile-account-1",
+            displayName: "Luis on LinkedIn",
+            status: "active",
+          },
+        ],
+      },
+    };
+    const fetchMock = vi.fn(async () => Response.json({ ok: true, integrations }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchCloudIntegrationStatus({
+      syncEngineUrl: "https://sync.example.com",
+      workspaceId: "workspace-1",
+      clientToken: "client-token-1",
+    })).resolves.toEqual(integrations);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://sync.example.com/workspaces/workspace-1/integrations/status",
+      {
         headers: {
           authorization: "Bearer client-token-1",
         },

--- a/packages/cli/src/lib/cloud-workspace.ts
+++ b/packages/cli/src/lib/cloud-workspace.ts
@@ -27,6 +27,29 @@ export type CloudMetadata = {
   createdAt?: string;
 };
 
+export type CloudIntegrationAccountStatus = {
+  id: string;
+  providerAccountId: string;
+  accountEmail?: string;
+  displayName?: string;
+  status: string;
+  lastSyncedAt?: string;
+};
+
+export type CloudIntegrationProviderStatus = {
+  connected: boolean;
+  accountEmail?: string;
+  displayName?: string;
+  providerAccountId?: string;
+  lastSyncedAt?: string;
+  accounts?: CloudIntegrationAccountStatus[];
+};
+
+export type CloudIntegrationStatus = {
+  gmail: CloudIntegrationProviderStatus;
+  linkedin: CloudIntegrationProviderStatus;
+};
+
 export function ensureCloudWorkspaceMetadata(
   workspaceDir: string,
   preferred: { workspaceId?: string; clientToken?: string; clusterOrgId?: string } = {},
@@ -125,6 +148,37 @@ export async function fetchCloudCommunicationExport(input: {
   return payload.data as CommunicationImportBatch;
 }
 
+export async function fetchCloudIntegrationStatus(input: {
+  syncEngineUrl: string;
+  workspaceId: string;
+  clientToken: string;
+}): Promise<CloudIntegrationStatus> {
+  const url = new URL(
+    `/workspaces/${encodeURIComponent(input.workspaceId)}/integrations/status`,
+    input.syncEngineUrl,
+  );
+  const response = await fetch(url.toString(), {
+    headers: {
+      authorization: `Bearer ${input.clientToken}`,
+    },
+  });
+  const payload = await response.json().catch(() => undefined) as
+    | { ok?: unknown; integrations?: unknown; error?: unknown }
+    | undefined;
+  if (!response.ok || payload?.ok !== true || !payload.integrations || typeof payload.integrations !== "object") {
+    throw new AcrmError(
+      "failed to fetch integration status",
+      ERR.IMPORT,
+      payloadError(payload) ?? `sync engine returned HTTP ${response.status}`,
+    );
+  }
+  const integrations = payload.integrations as { gmail?: unknown; linkedin?: unknown };
+  return {
+    gmail: parseProviderStatus(integrations.gmail),
+    linkedin: parseProviderStatus(integrations.linkedin),
+  };
+}
+
 export async function fetchCloudLinkedinRelationsExport(input: {
   syncEngineUrl: string;
   workspaceId: string;
@@ -169,6 +223,43 @@ export async function fetchCloudLinkedinRelationsExport(input: {
   return { relations: data.relations as LinkedinRelation[] };
 }
 
+function parseProviderStatus(value: unknown): CloudIntegrationProviderStatus {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { connected: false };
+  }
+  const status = value as Record<string, unknown>;
+  const accounts = Array.isArray(status.accounts)
+    ? status.accounts
+      .map(parseAccountStatus)
+      .filter((account): account is CloudIntegrationAccountStatus => Boolean(account))
+    : undefined;
+  return {
+    connected: status.connected === true,
+    ...(stringValue(status.accountEmail) ? { accountEmail: stringValue(status.accountEmail) } : {}),
+    ...(stringValue(status.displayName) ? { displayName: stringValue(status.displayName) } : {}),
+    ...(stringValue(status.providerAccountId) ? { providerAccountId: stringValue(status.providerAccountId) } : {}),
+    ...(stringValue(status.lastSyncedAt) ? { lastSyncedAt: stringValue(status.lastSyncedAt) } : {}),
+    ...(accounts && accounts.length > 0 ? { accounts } : {}),
+  };
+}
+
+function parseAccountStatus(value: unknown): CloudIntegrationAccountStatus | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const account = value as Record<string, unknown>;
+  const id = stringValue(account.id);
+  const providerAccountId = stringValue(account.providerAccountId);
+  const status = stringValue(account.status);
+  if (!id || !providerAccountId || !status) return null;
+  return {
+    id,
+    providerAccountId,
+    status,
+    ...(stringValue(account.accountEmail) ? { accountEmail: stringValue(account.accountEmail) } : {}),
+    ...(stringValue(account.displayName) ? { displayName: stringValue(account.displayName) } : {}),
+    ...(stringValue(account.lastSyncedAt) ? { lastSyncedAt: stringValue(account.lastSyncedAt) } : {}),
+  };
+}
+
 function isLinkedinNotConnected(payload: { error?: unknown; code?: unknown } | undefined): boolean {
   const candidates = [
     payload?.code,
@@ -186,6 +277,10 @@ function isLinkedinNotConnected(payload: { error?: unknown; code?: unknown } | u
       (normalized.includes("linkedin") && normalized.includes("not_connected"))
     );
   });
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
 }
 
 function payloadError(payload: { error?: unknown } | undefined): string | undefined {

--- a/packages/sdk/src/operations/import-linkedin-relations.ts
+++ b/packages/sdk/src/operations/import-linkedin-relations.ts
@@ -27,6 +27,7 @@ export type LinkedinRelation = {
   public_identifier?: string | null;
   public_profile_url?: string | null;
   profile_picture_url?: string | null;
+  [key: string]: unknown;
 };
 
 export type ImportLinkedinRelationsArgs = {
@@ -38,8 +39,18 @@ export type ImportLinkedinRelationsResult = {
     relations_seen: number;
     people_created: number;
     people_updated: number;
+    companies_created: number;
+    companies_updated: number;
     relations_skipped_no_key: number;
   };
+};
+
+type ObjectSlug = "people" | "companies";
+
+type NormalizedCompany = {
+  sourceKey: string;
+  name: string;
+  linkedinUrl: string | null;
 };
 
 type NormalizedRelation = {
@@ -49,9 +60,11 @@ type NormalizedRelation = {
   fullName: string | null;
   headline: string | null;
   connectedAt: string | null;
+  company: NormalizedCompany | null;
 };
 
 type RecordPlan = {
+  objectSlug: ObjectSlug;
   recordId: string;
   created: boolean;
 };
@@ -62,6 +75,7 @@ type ExistingValues = {
 };
 
 type ValueInput = {
+  object_slug: ObjectSlug;
   record_id: string;
   attribute_slug: string;
   attribute_type: AttributeType;
@@ -83,6 +97,8 @@ export async function importLinkedinRelations(
     relations_seen: 0,
     people_created: 0,
     people_updated: 0,
+    companies_created: 0,
+    companies_updated: 0,
     relations_skipped_no_key: 0,
   };
 
@@ -105,11 +121,45 @@ export async function importLinkedinRelations(
     relations.map((relation) => relation.linkedinUrl).filter((url): url is string => Boolean(url)),
   );
   const plannedLinkedinIndex = new Map(linkedinIndex);
+  const companies = uniqueCompanies(relations.map((relation) => relation.company).filter((company): company is NormalizedCompany => Boolean(company)));
+  const companySourceIndex = await loadCompaniesBySourceKeys(lix, companies.map((company) => company.sourceKey));
+  const plannedCompanySourceIndex = new Map(companySourceIndex);
+  const companyLinkedinIndex = await loadCompaniesByLinkedinUrl(
+    lix,
+    companies.map((company) => company.linkedinUrl).filter((url): url is string => Boolean(url)),
+  );
+  const plannedCompanyLinkedinIndex = new Map(companyLinkedinIndex);
+  const companyNameIndex = await loadCompaniesByName(lix, companies.map((company) => company.name));
+  const plannedCompanyNameIndex = new Map(companyNameIndex);
 
-  const recordsToCreate: Array<{ object_slug: "people"; record_id: string }> = [];
+  const recordsToCreate: Array<{ object_slug: ObjectSlug; record_id: string }> = [];
+  const companyPlans = new Map<string, { company: NormalizedCompany; plan: RecordPlan }>();
   const plans: Array<{ relation: NormalizedRelation; plan: RecordPlan }> = [];
   const touchedRecordIds = new Set<string>();
+  const touchedCompanyIds = new Set<string>();
   const createdRecordIds = new Set<string>();
+  const createdCompanyIds = new Set<string>();
+
+  for (const company of companies) {
+    const existingRecordId =
+      (company.linkedinUrl ? plannedCompanyLinkedinIndex.get(company.linkedinUrl) : undefined) ??
+      plannedCompanySourceIndex.get(company.sourceKey) ??
+      plannedCompanyNameIndex.get(company.name.toLowerCase());
+    const recordId = existingRecordId ?? uuidv7();
+    const created = existingRecordId == null;
+    if (created) {
+      recordsToCreate.push({ object_slug: "companies", record_id: recordId });
+      createdCompanyIds.add(recordId);
+    }
+    plannedCompanySourceIndex.set(company.sourceKey, recordId);
+    if (company.linkedinUrl) plannedCompanyLinkedinIndex.set(company.linkedinUrl, recordId);
+    plannedCompanyNameIndex.set(company.name.toLowerCase(), recordId);
+    touchedCompanyIds.add(recordId);
+    companyPlans.set(company.sourceKey, {
+      company,
+      plan: { objectSlug: "companies", recordId, created },
+    });
+  }
 
   for (const relation of relations) {
     const existingRecordId =
@@ -124,17 +174,35 @@ export async function importLinkedinRelations(
     plannedSourceIndex.set(relation.sourceKey, recordId);
     if (relation.linkedinUrl) plannedLinkedinIndex.set(relation.linkedinUrl, recordId);
     touchedRecordIds.add(recordId);
-    plans.push({ relation, plan: { recordId, created } });
+    plans.push({ relation, plan: { objectSlug: "people", recordId, created } });
   }
 
   stats.people_created = createdRecordIds.size;
+  stats.companies_created = createdCompanyIds.size;
 
-  const existingValues = await loadExistingValues(lix, [...touchedRecordIds]);
+  const existingValues = await loadExistingValues(lix, {
+    people: [...touchedRecordIds],
+    companies: [...touchedCompanyIds],
+  });
   const writer = new LinkedinRelationWriteBatcher(lix);
   const changedExistingRecordIds = new Set<string>();
+  const changedExistingCompanyIds = new Set<string>();
 
   for (const record of recordsToCreate) {
     writer.enqueueRecord(record);
+  }
+
+  for (const { company, plan } of companyPlans.values()) {
+    const provenance = companyProvenance(company);
+    let changed = false;
+    changed = enqueueMulti(writer, existingValues, plan, "source_keys", "text", company.sourceKey, provenance) || changed;
+    changed = enqueueSingleIfMissing(writer, existingValues, plan, "name", "text", company.name, provenance) || changed;
+    if (company.linkedinUrl) {
+      changed = enqueueSingleIfMissing(writer, existingValues, plan, "linkedin_url", "url", company.linkedinUrl, provenance) || changed;
+    }
+    if (!createdCompanyIds.has(plan.recordId) && changed) {
+      changedExistingCompanyIds.add(plan.recordId);
+    }
   }
 
   for (const { relation, plan } of plans) {
@@ -161,12 +229,39 @@ export async function importLinkedinRelations(
         provenance,
       ) || changed;
     }
+    if (relation.company) {
+      const companyPlan = companyPlans.get(relation.company.sourceKey)?.plan;
+      if (companyPlan) {
+        changed = enqueueSingleReferenceIfMissing(
+          writer,
+          existingValues,
+          plan,
+          "company",
+          "companies",
+          companyPlan.recordId,
+          provenance,
+        ) || changed;
+        const companyChanged = enqueueReference(
+          writer,
+          existingValues,
+          companyPlan,
+          "team",
+          "people",
+          plan.recordId,
+          provenance,
+        );
+        if (!createdCompanyIds.has(companyPlan.recordId) && companyChanged) {
+          changedExistingCompanyIds.add(companyPlan.recordId);
+        }
+      }
+    }
     if (!createdRecordIds.has(plan.recordId) && changed) {
       changedExistingRecordIds.add(plan.recordId);
     }
   }
 
   stats.people_updated = changedExistingRecordIds.size;
+  stats.companies_updated = changedExistingCompanyIds.size;
   await writer.flush();
   return { stats };
 }
@@ -186,6 +281,7 @@ function normalizeRelation(relation: LinkedinRelation): NormalizedRelation | nul
     fullName: relationFullName(relation),
     headline: cleanString(relation.headline),
     connectedAt: relationConnectedAt(relation.created_at),
+    company: relationCompany(relation),
   };
 }
 
@@ -231,6 +327,72 @@ function relationConnectedAt(value: LinkedinRelation["created_at"]): string | nu
   return new Date(millis).toISOString();
 }
 
+function relationCompany(relation: LinkedinRelation): NormalizedCompany | null {
+  const nested =
+    objectField(relation, ["company", "organization", "current_company", "currentCompany", "employer"]) ??
+    positionObject(relation);
+  const explicitName =
+    stringField(relation, ["company_name", "companyName", "organization_name", "organizationName", "employer_name", "employerName"]) ??
+    (typeof relation.company === "string" ? relation.company : null) ??
+    (typeof relation.organization === "string" ? relation.organization : null);
+  const name =
+    cleanString(explicitName) ??
+    stringField(nested, ["name", "company_name", "companyName", "organization_name", "organizationName", "title"]) ??
+    companyNameFromHeadline(relation.headline);
+  if (!name) return null;
+
+  const explicitLinkedinUrl = stringField(relation, [
+    "company_linkedin_url",
+    "companyLinkedinUrl",
+    "company_url",
+    "companyUrl",
+    "organization_url",
+    "organizationUrl",
+  ]);
+  const nestedLinkedinUrl = stringField(nested, [
+    "linkedin_url",
+    "linkedinUrl",
+    "company_linkedin_url",
+    "companyLinkedinUrl",
+    "public_profile_url",
+    "publicProfileUrl",
+    "url",
+  ]);
+  const publicIdentifier = stringField(nested, ["public_identifier", "publicIdentifier"]);
+  const linkedinUrl = normalizeLinkedinUrl(
+    explicitLinkedinUrl ??
+    nestedLinkedinUrl ??
+    (publicIdentifier ? `https://www.linkedin.com/company/${publicIdentifier}/` : ""),
+  );
+  const id = stringField(nested, ["id", "company_id", "companyId", "urn", "entity_urn", "entityUrn"]);
+  const sourceKey = id
+    ? `linkedin:company:${id}`
+    : linkedinUrl
+      ? `linkedin:company:${linkedinUrl}`
+      : `linkedin:company_name:${name.toLowerCase()}`;
+
+  return {
+    sourceKey,
+    name,
+    linkedinUrl,
+  };
+}
+
+function positionObject(relation: LinkedinRelation): Record<string, unknown> | null {
+  return objectField(relation, ["current_position", "currentPosition", "position"]) ??
+    firstObjectItem(relation.currentPosition) ??
+    firstObjectItem(relation.current_position) ??
+    firstObjectItem(relation.positions) ??
+    firstObjectItem(relation.experience);
+}
+
+function companyNameFromHeadline(headline: string | null | undefined): string | null {
+  const value = cleanString(headline);
+  if (!value) return null;
+  const match = value.match(/\b(?:at|@)\s+([^|,;()]+)/i);
+  return cleanString(match?.[1]);
+}
+
 function relationProvenance(relation: LinkedinRelation): Record<string, unknown> {
   return {
     provider: "unipile",
@@ -241,6 +403,14 @@ function relationProvenance(relation: LinkedinRelation): Record<string, unknown>
     public_identifier: relation.public_identifier ?? null,
     profile_picture_url: relation.profile_picture_url ?? null,
     raw_relation: relation,
+  };
+}
+
+function companyProvenance(company: NormalizedCompany): Record<string, unknown> {
+  return {
+    provider: "unipile",
+    imported_at: nowIso(),
+    source_key: company.sourceKey,
   };
 }
 
@@ -296,33 +466,119 @@ async function loadPeopleByLinkedinUrl(
   return index;
 }
 
+async function loadCompaniesBySourceKeys(
+  lix: Workspace["lix"],
+  sourceKeys: string[],
+): Promise<Map<string, string>> {
+  const index = new Map<string, string>();
+  for (const chunk of chunks(unique(sourceKeys), SELECT_CHUNK_SIZE)) {
+    const placeholders = chunk.map((_, index) => `$${index + 1}`).join(", ");
+    const result = await exec(
+      lix,
+      `SELECT record_id, normalized_key
+       FROM acrm_value
+       WHERE active_until IS NULL
+         AND object_slug = 'companies'
+         AND attribute_slug = 'source_keys'
+         AND normalized_key IN (${placeholders})`,
+      chunk,
+    );
+    for (const row of result.rows) {
+      if (typeof row.record_id === "string" && typeof row.normalized_key === "string") {
+        index.set(row.normalized_key, row.record_id);
+      }
+    }
+  }
+  return index;
+}
+
+async function loadCompaniesByLinkedinUrl(
+  lix: Workspace["lix"],
+  linkedinUrls: string[],
+): Promise<Map<string, string>> {
+  const index = new Map<string, string>();
+  for (const chunk of chunks(unique(linkedinUrls), SELECT_CHUNK_SIZE)) {
+    const placeholders = chunk.map((_, index) => `$${index + 1}`).join(", ");
+    const result = await exec(
+      lix,
+      `SELECT record_id, normalized_key
+       FROM acrm_value
+       WHERE active_until IS NULL
+         AND object_slug = 'companies'
+         AND attribute_slug = 'linkedin_url'
+         AND normalized_key IN (${placeholders})`,
+      chunk,
+    );
+    for (const row of result.rows) {
+      if (typeof row.record_id === "string" && typeof row.normalized_key === "string") {
+        index.set(row.normalized_key, row.record_id);
+      }
+    }
+  }
+  return index;
+}
+
+async function loadCompaniesByName(
+  lix: Workspace["lix"],
+  names: string[],
+): Promise<Map<string, string>> {
+  const index = new Map<string, string>();
+  for (const chunk of chunks(unique(names.map((name) => name.toLowerCase())), SELECT_CHUNK_SIZE)) {
+    const placeholders = chunk.map((_, index) => `$${index + 1}`).join(", ");
+    const result = await exec(
+      lix,
+      `SELECT record_id, LOWER(normalized_key) AS normalized_key
+       FROM acrm_value
+       WHERE active_until IS NULL
+         AND object_slug = 'companies'
+         AND attribute_slug = 'name'
+         AND LOWER(normalized_key) IN (${placeholders})`,
+      chunk,
+    );
+    for (const row of result.rows) {
+      if (typeof row.record_id === "string" && typeof row.normalized_key === "string") {
+        index.set(row.normalized_key, row.record_id);
+      }
+    }
+  }
+  return index;
+}
+
 async function loadExistingValues(
   lix: Workspace["lix"],
-  recordIds: string[],
+  records: Record<ObjectSlug, string[]>,
 ): Promise<ExistingValues> {
   const existing: ExistingValues = {
     singleValues: new Map(),
     multiValues: new Set(),
   };
-  for (const chunk of chunks(recordIds, SELECT_CHUNK_SIZE)) {
-    const placeholders = chunk.map((_, index) => `$${index + 1}`).join(", ");
-    const result = await exec(
-      lix,
-      `SELECT record_id, attribute_slug, value_json, normalized_key
-       FROM acrm_value
-       WHERE active_until IS NULL
-         AND object_slug = 'people'
-         AND record_id IN (${placeholders})`,
-      chunk,
-    );
-    for (const row of result.rows) {
-      if (typeof row.record_id !== "string" || typeof row.attribute_slug !== "string") continue;
-      const valueJson = parseValueJson(row.value_json);
-      if (valueJson) {
-        existing.singleValues.set(singleValueKey(row.record_id, row.attribute_slug), valueJson);
-      }
-      if (typeof row.normalized_key === "string") {
-        existing.multiValues.add(normalizedValueKey(row.record_id, row.attribute_slug, row.normalized_key));
+  for (const objectSlug of Object.keys(records) as ObjectSlug[]) {
+    for (const chunk of chunks(records[objectSlug], SELECT_CHUNK_SIZE)) {
+      const placeholders = chunk.map((_, index) => `$${index + 2}`).join(", ");
+      const result = await exec(
+        lix,
+        `SELECT object_slug, record_id, attribute_slug, value_json,
+                normalized_key, ref_object, ref_record_id
+         FROM acrm_value
+         WHERE active_until IS NULL
+           AND object_slug = $1
+           AND record_id IN (${placeholders})`,
+        [objectSlug, ...chunk],
+      );
+      for (const row of result.rows) {
+        if (typeof row.object_slug !== "string" || typeof row.record_id !== "string" || typeof row.attribute_slug !== "string") {
+          continue;
+        }
+        const valueJson = parseValueJson(row.value_json);
+        if (valueJson) {
+          existing.singleValues.set(singleValueKey(row.object_slug, row.record_id, row.attribute_slug), valueJson);
+        }
+        if (typeof row.normalized_key === "string") {
+          existing.multiValues.add(normalizedValueKey(row.object_slug, row.record_id, row.attribute_slug, row.normalized_key));
+        }
+        if (typeof row.ref_object === "string" && typeof row.ref_record_id === "string") {
+          existing.multiValues.add(referenceValueKey(row.object_slug, row.record_id, row.attribute_slug, row.ref_object, row.ref_record_id));
+        }
       }
     }
   }
@@ -338,12 +594,13 @@ function enqueueSingleIfMissing(
   rawValue: unknown,
   provenance: Record<string, unknown>,
 ): boolean {
-  const key = singleValueKey(plan.recordId, attributeSlug);
+  const key = singleValueKey(plan.objectSlug, plan.recordId, attributeSlug);
   if (!plan.created && existing.singleValues.has(key)) return false;
   if (existing.singleValues.has(key)) return false;
   const valueJson = encode(attributeType, rawValue);
   existing.singleValues.set(key, valueJson);
   writer.enqueueValue({
+    object_slug: plan.objectSlug,
     record_id: plan.recordId,
     attribute_slug: attributeSlug,
     attribute_type: attributeType,
@@ -351,6 +608,26 @@ function enqueueSingleIfMissing(
     provenance,
   });
   return true;
+}
+
+function enqueueSingleReferenceIfMissing(
+  writer: LinkedinRelationWriteBatcher,
+  existing: ExistingValues,
+  plan: RecordPlan,
+  attributeSlug: string,
+  targetObject: ObjectSlug,
+  targetRecordId: string,
+  provenance: Record<string, unknown>,
+): boolean {
+  return enqueueSingleIfMissing(
+    writer,
+    existing,
+    plan,
+    attributeSlug,
+    "record-reference",
+    { target_object: targetObject, target_record_id: targetRecordId },
+    provenance,
+  );
 }
 
 function enqueueMulti(
@@ -364,15 +641,14 @@ function enqueueMulti(
 ): boolean {
   const valueJson = encode(attributeType, rawValue);
   const prepared = writer.prepareValue({
+    object_slug: plan.objectSlug,
     record_id: plan.recordId,
     attribute_slug: attributeSlug,
     attribute_type: attributeType,
     value: valueJson,
     provenance,
   });
-  const key = prepared.normalized_key
-    ? normalizedValueKey(plan.recordId, attributeSlug, prepared.normalized_key)
-    : null;
+  const key = preparedValueKey(prepared);
   if (key) {
     if (existing.multiValues.has(key)) return false;
     existing.multiValues.add(key);
@@ -381,19 +657,39 @@ function enqueueMulti(
   return true;
 }
 
+function enqueueReference(
+  writer: LinkedinRelationWriteBatcher,
+  existing: ExistingValues,
+  plan: RecordPlan,
+  attributeSlug: string,
+  targetObject: ObjectSlug,
+  targetRecordId: string,
+  provenance: Record<string, unknown>,
+): boolean {
+  return enqueueMulti(
+    writer,
+    existing,
+    plan,
+    attributeSlug,
+    "record-reference",
+    { target_object: targetObject, target_record_id: targetRecordId },
+    provenance,
+  );
+}
+
 class LinkedinRelationWriteBatcher {
-  private records: Array<{ object_slug: "people"; record_id: string }> = [];
+  private records: Array<{ object_slug: ObjectSlug; record_id: string }> = [];
   private values: PreparedValueInsert[] = [];
 
   constructor(private readonly lix: Workspace["lix"]) {}
 
-  enqueueRecord(record: { object_slug: "people"; record_id: string }): void {
+  enqueueRecord(record: { object_slug: ObjectSlug; record_id: string }): void {
     this.records.push(record);
   }
 
   prepareValue(input: ValueInput): PreparedValueInsert {
     return prepareValueInsert(uuidv7(), {
-      object_slug: "people",
+      object_slug: input.object_slug,
       record_id: input.record_id,
       attribute_slug: input.attribute_slug,
       attribute_type: input.attribute_type,
@@ -465,17 +761,31 @@ class LinkedinRelationWriteBatcher {
   }
 }
 
+function preparedValueKey(value: PreparedValueInsert): string | null {
+  if (value.ref_object && value.ref_record_id) {
+    return referenceValueKey(value.object_slug, value.record_id, value.attribute_slug, value.ref_object, value.ref_record_id);
+  }
+  if (value.normalized_key) {
+    return normalizedValueKey(value.object_slug, value.record_id, value.attribute_slug, value.normalized_key);
+  }
+  return null;
+}
+
 function cleanString(value: string | null | undefined): string | null {
   const trimmed = value?.trim();
   return trimmed ? trimmed : null;
 }
 
-function singleValueKey(recordId: string, attributeSlug: string): string {
-  return `${recordId}\0${attributeSlug}`;
+function singleValueKey(objectSlug: string, recordId: string, attributeSlug: string): string {
+  return `${objectSlug}\0${recordId}\0${attributeSlug}`;
 }
 
-function normalizedValueKey(recordId: string, attributeSlug: string, normalizedKey: string): string {
-  return `${singleValueKey(recordId, attributeSlug)}\0normalized\0${normalizedKey}`;
+function normalizedValueKey(objectSlug: string, recordId: string, attributeSlug: string, normalizedKey: string): string {
+  return `${singleValueKey(objectSlug, recordId, attributeSlug)}\0normalized\0${normalizedKey}`;
+}
+
+function referenceValueKey(objectSlug: string, recordId: string, attributeSlug: string, refObject: string, refRecordId: string): string {
+  return `${singleValueKey(objectSlug, recordId, attributeSlug)}\0ref\0${refObject}\0${refRecordId}`;
 }
 
 function parseValueJson(value: unknown): ValueJson | null {
@@ -492,6 +802,41 @@ function parseValueJson(value: unknown): ValueJson | null {
 
 function isObject(value: unknown): value is ValueJson {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function objectField(source: Record<string, unknown> | null | undefined, keys: string[]): Record<string, unknown> | null {
+  if (!source) return null;
+  for (const key of keys) {
+    const value = source[key];
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      return value as Record<string, unknown>;
+    }
+  }
+  return null;
+}
+
+function firstObjectItem(value: unknown): Record<string, unknown> | null {
+  if (!Array.isArray(value)) return null;
+  const first = value[0];
+  return first && typeof first === "object" && !Array.isArray(first)
+    ? first as Record<string, unknown>
+    : null;
+}
+
+function stringField(source: Record<string, unknown> | null | undefined, keys: string[]): string | null {
+  if (!source) return null;
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed) return trimmed;
+    }
+  }
+  return null;
+}
+
+function uniqueCompanies(companies: NormalizedCompany[]): NormalizedCompany[] {
+  return [...new Map(companies.map((company) => [company.sourceKey, company])).values()];
 }
 
 function unique(values: string[]): string[] {


### PR DESCRIPTION
## Summary
- import company records and person-company links from hosted LinkedIn relation exports
- add `acrm connect linkedin --status` for polling hosted LinkedIn connection completion
- update the LinkedIn connect skill to wait for verified completion before surfacing import options

## Tests
- `npm run build --workspace @agent-crm/cli`
- `npm run test --workspace @agent-crm/cli -- import-linkedin-relations.test.ts connect.test.ts cloud-workspace.test.ts`
- `npm run test --workspace @agent-crm/cli -- --maxWorkers=1`

Note: plain `npm test` hit existing parallel Vitest 30s timeouts in the CLI workspace, but the SDK tests passed and the full CLI suite passed serially.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Import LinkedIn companies and add `acrm connect linkedin --status` polling command
> - Extends `importLinkedinRelations` in the SDK to create company records from LinkedIn relation imports, link people to their company, and record reverse `team` references on companies with idempotent de-duplication.
> - Adds a `--status` flag to `acrm connect linkedin` that fetches LinkedIn integration status from the sync engine and reports whether an active account is connected, suitable for polling every 2 seconds.
> - Introduces `fetchCloudIntegrationStatus` in the cloud workspace lib, which calls `/workspaces/{id}/integrations/status` with Bearer auth and returns structured `CloudIntegrationProviderStatus` for Gmail and LinkedIn.
> - Updates the CLI skill documentation to instruct agents to poll `--status` before asking import questions.
> - Behavioral Change: `connected: true` is only returned when at least one account has `status: 'active'`; paused or missing accounts return `connected: false`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 96d1ef1. 5 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->