### PR TITLE
Add LinkedIn company enrichment import pass

### DIFF
--- a/.changeset/clean-linkedin-company-import.md
+++ b/.changeset/clean-linkedin-company-import.md
@@ -1,0 +1,6 @@
+---
+"@agent-crm/cli": patch
+"@agent-crm/sdk": patch
+---
+
+Stop inferring LinkedIn relation companies from free-text profile headlines, and run the hosted structured company enrichment pass after importing LinkedIn relation people.

--- a/packages/cli/skills/connect-linkedin-to-acrm.md
+++ b/packages/cli/skills/connect-linkedin-to-acrm.md
@@ -13,7 +13,7 @@ This is the hosted LinkedIn sync flow:
 
 1. The local workspace gets a cloud workspace binding in `.agent-crm-cloud.json`.
 2. The user opens Agent CRM's hosted LinkedIn connect page.
-3. The sync engine can receive post-connection LinkedIn message events from Unipile.
+3. Future LinkedIn messages and contacts sync automatically after connection.
 4. The user chooses whether to import existing 1st-degree LinkedIn relations.
 5. Existing relations import as lightweight `people` and `companies` records without bulk profile enrichment.
 
@@ -62,13 +62,13 @@ done
 
 After the polling loop verifies completion, use `AskUserQuestion` with this exact question and options (single-select, multipleChoice off):
 
-- **Question**: `How should Agent CRM import LinkedIn contacts?`
+- **Question**: `Future LinkedIn messages and contacts sync automatically. Import existing contacts now?`
 - **Options**:
-  1. `Future messages only` — do not import existing contacts; only new message sync creates people later
-  2. `All existing contacts` — import all current 1st-degree LinkedIn connections
-  3. `Recent connections` — import connections after a cutoff date
+  1. `No existing contacts` — skip current connections
+  2. `All existing contacts` — import every current 1st-degree connection
+  3. `Recent connections` — import only after a cutoff date
 
-If they choose `Future messages only`, stop after confirming LinkedIn is connected.
+If they choose `No existing contacts`, stop after confirming LinkedIn is connected.
 
 If they choose `All existing contacts`, run:
 
@@ -84,27 +84,13 @@ acrm --json import linkedin --cutoff-date <YYYY-MM-DD>
 
 If `acrm import linkedin` says LinkedIn is not connected, send the user back to the connect flow above.
 
-## Sync messages
+## Message sync note
 
-After the browser flow completes, pull any available LinkedIn messages:
-
-```sh
-acrm --json import linkedin --sync
-```
-
-Verify recent imported message bodies:
-
-```sh
-acrm --json execute "
-SELECT value_json, active_from
-FROM acrm_value
-WHERE object_slug = 'communication_messages'
-  AND attribute_slug = 'body_text'
-  AND active_until IS NULL
-ORDER BY active_from DESC
-LIMIT 5
-"
-```
+Do not run `acrm --json import linkedin --sync` in the normal connect/import
+flow. Future LinkedIn messages and contacts sync automatically. Use `--sync`
+only for debugging or backfilling already-stored hosted message events, and
+check `communication_messages_seen` / `communication_messages_created` before
+claiming messages were imported.
 
 ## Hard rules
 

--- a/packages/cli/src/commands/import-linkedin-relations.test.ts
+++ b/packages/cli/src/commands/import-linkedin-relations.test.ts
@@ -35,6 +35,8 @@ describe("importLinkedinRelations", () => {
     await expect(valueFor(ws, "people", "job_title")).resolves.toBe("Founder at Analytical Engines");
     await expect(valueFor(ws, "people", "linkedin_connected_at")).resolves.toBe("2025-03-15T15:16:09.000Z");
     await expect(countValues(ws, "source_keys")).resolves.toBe(1);
+    await expect(countRecords(ws, "companies")).resolves.toBe(0);
+    await expect(referenceCount(ws, "people", "company", "companies")).resolves.toBe(0);
     await lix.close();
   });
 
@@ -88,7 +90,7 @@ describe("importLinkedinRelations", () => {
     expect(first.stats.people_created).toBe(1);
     expect(second.stats.people_created).toBe(0);
     expect(second.stats.people_updated).toBe(0);
-    await expect(countRecords(ws)).resolves.toBe(1);
+    await expect(countRecords(ws, "people")).resolves.toBe(1);
     await expect(countAllValues(ws)).resolves.toBe(valuesAfterFirstImport);
     await lix.close();
   });
@@ -112,7 +114,7 @@ describe("importLinkedinRelations", () => {
       ],
     });
 
-    await expect(countRecords(ws)).resolves.toBe(1);
+    await expect(countRecords(ws, "people")).resolves.toBe(1);
     await expect(countValues(ws, "source_keys")).resolves.toBe(2);
     await lix.close();
   });
@@ -229,10 +231,11 @@ async function referenceCount(
   return Number(result.rows[0]?.n ?? 0);
 }
 
-async function countRecords(ws: Workspace): Promise<number> {
+async function countRecords(ws: Workspace, objectSlug: string): Promise<number> {
   const result = await exec(
     ws.lix,
-    "SELECT COUNT(*) AS n FROM acrm_record WHERE object_slug = 'people'",
+    "SELECT COUNT(*) AS n FROM acrm_record WHERE object_slug = $1",
+    [objectSlug],
   );
   return Number(result.rows[0]?.n ?? 0);
 }

--- a/packages/cli/src/commands/import-linkedin.test.ts
+++ b/packages/cli/src/commands/import-linkedin.test.ts
@@ -24,23 +24,34 @@ describe("import linkedin command", () => {
     const ws = await Workspace.create(workspacePath);
     await ws.close();
     process.env.ACRM_SYNC_ENGINE_URL = "https://sync.example.com";
-    const fetchMock = vi.fn(async () => Response.json({
-      ok: true,
-      data: {
-        relations: [
-          {
-            object: "UserRelation",
-            member_id: "member-1",
-            created_at: 1742051769000,
-            first_name: "Ada",
-            last_name: "Lovelace",
-            headline: "Founder at Analytical Engines",
-            public_identifier: "ada-lovelace",
-            public_profile_url: "https://www.linkedin.com/in/ada-lovelace/",
-          },
-        ],
-      },
-    }));
+    const baseRelation = {
+      object: "UserRelation",
+      member_id: "member-1",
+      created_at: 1742051769000,
+      first_name: "Ada",
+      last_name: "Lovelace",
+      headline: "Founder at Analytical Engines",
+      public_identifier: "ada-lovelace",
+      public_profile_url: "https://www.linkedin.com/in/ada-lovelace/",
+    };
+    const fetchMock = vi.fn(async (url: string) => {
+      const enrichCompanies = new URL(url).searchParams.get("enrich_companies") === "1";
+      return Response.json({
+        ok: true,
+        data: {
+          relations: [
+            enrichCompanies
+              ? {
+                ...baseRelation,
+                company_name: "Analytical Engines",
+                company_linkedin_url: "https://www.linkedin.com/company/analytical-engines/",
+              }
+              : baseRelation,
+          ],
+          ...(enrichCompanies ? { company_enrichment: { requested: true, provider: "fiber" } } : {}),
+        },
+      });
+    });
     vi.stubGlobal("fetch", fetchMock);
 
     try {
@@ -49,13 +60,18 @@ describe("import linkedin command", () => {
       });
 
       expect(result.stats.people_created).toBe(1);
-      expect(fetchMock).toHaveBeenCalledOnce();
+      expect(result.stats.companies_created).toBe(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
       const [url] = fetchMock.mock.calls[0] as [string];
+      const [enrichedUrl] = fetchMock.mock.calls[1] as [string];
       expect(url).toContain("/integrations/linkedin/relations/export");
+      expect(url).not.toContain("enrich_companies=1");
+      expect(enrichedUrl).toContain("enrich_companies=1");
       const reopened = await Workspace.open(workspacePath);
       try {
         await expect(singleValue(reopened, "linkedin_url")).resolves.toBe("linkedin.com/in/ada-lovelace");
         await expect(singleValue(reopened, "linkedin_connected_at")).resolves.toBe("2025-03-15T15:16:09.000Z");
+        await expect(singleValue(reopened, "linkedin_url", "companies")).resolves.toBe("linkedin.com/company/analytical-engines");
       } finally {
         await reopened.close();
       }
@@ -119,16 +135,20 @@ describe("import linkedin command", () => {
   });
 });
 
-async function singleValue(ws: Workspace, attributeSlug: string): Promise<string | null> {
+async function singleValue(
+  ws: Workspace,
+  attributeSlug: string,
+  objectSlug = "people",
+): Promise<string | null> {
   const result = await exec(
     ws.lix,
     `SELECT value_json
      FROM acrm_value
-     WHERE object_slug = 'people'
+     WHERE object_slug = $2
        AND attribute_slug = $1
        AND active_until IS NULL
      LIMIT 1`,
-    [attributeSlug],
+    [attributeSlug, objectSlug],
   );
   const raw = result.rows[0]?.value_json;
   const parsed = typeof raw === "string" ? JSON.parse(raw) as { value?: string; timestamp?: string } : raw as { value?: string; timestamp?: string } | undefined;

--- a/packages/cli/src/commands/import-linkedin.ts
+++ b/packages/cli/src/commands/import-linkedin.ts
@@ -99,6 +99,8 @@ async function runImportLinkedinNetwork(opts: { workspace?: string; cutoffDate?:
   workspace_id: string;
   sync_engine_url: string;
   stats: ImportLinkedinRelationsResult["stats"];
+  company_enrichment?: unknown;
+  company_enrichment_warning?: string;
 }> {
   const workspaceFile = resolveWorkspacePath(opts.workspace);
   const workspaceDir = path.dirname(workspaceFile);
@@ -120,14 +122,49 @@ async function runImportLinkedinNetwork(opts: { workspace?: string; cutoffDate?:
   const ws = await Workspace.open(workspaceFile);
   try {
     const result = await importLinkedinRelations(ws, { relations });
+    let stats = result.stats;
+    let companyEnrichment: unknown;
+    let companyEnrichmentWarning: string | undefined;
+    if (relations.length > 0) {
+      try {
+        const enriched = await fetchCloudLinkedinRelationsExport({
+          syncEngineUrl,
+          workspaceId: metadata.workspaceId,
+          clientToken: metadata.clientToken,
+          cutoffDate: opts.cutoffDate,
+          enrichCompanies: true,
+        });
+        companyEnrichment = enriched.company_enrichment;
+        const enrichedResult = await importLinkedinRelations(ws, { relations: enriched.relations });
+        stats = mergeLinkedinRelationStats(stats, enrichedResult.stats);
+      } catch (error) {
+        companyEnrichmentWarning = error instanceof Error ? error.message : String(error);
+      }
+    }
     return {
       workspace_id: metadata.workspaceId,
       sync_engine_url: syncEngineUrl,
-      stats: result.stats,
+      stats,
+      ...(companyEnrichment ? { company_enrichment: companyEnrichment } : {}),
+      ...(companyEnrichmentWarning ? { company_enrichment_warning: companyEnrichmentWarning } : {}),
     };
   } finally {
     await ws.close();
   }
+}
+
+function mergeLinkedinRelationStats(
+  left: ImportLinkedinRelationsResult["stats"],
+  right: ImportLinkedinRelationsResult["stats"],
+): ImportLinkedinRelationsResult["stats"] {
+  return {
+    relations_seen: left.relations_seen,
+    people_created: left.people_created + right.people_created,
+    people_updated: left.people_updated + right.people_updated,
+    companies_created: left.companies_created + right.companies_created,
+    companies_updated: left.companies_updated + right.companies_updated,
+    relations_skipped_no_key: left.relations_skipped_no_key,
+  };
 }
 
 async function runSyncLinkedin(opts: { workspace?: string }): Promise<{

--- a/packages/cli/src/lib/cloud-workspace.test.ts
+++ b/packages/cli/src/lib/cloud-workspace.test.ts
@@ -123,7 +123,7 @@ describe("cloud workspace metadata", () => {
     );
   });
 
-  it("fetches LinkedIn relations export data with a cutoff date", async () => {
+  it("fetches LinkedIn relations export data with a cutoff date and company enrichment", async () => {
     const relations = [
       {
         object: "UserRelation",
@@ -131,7 +131,8 @@ describe("cloud workspace metadata", () => {
         public_profile_url: "https://www.linkedin.com/in/member-1/",
       },
     ];
-    const fetchMock = vi.fn(async () => Response.json({ ok: true, data: { relations } }));
+    const company_enrichment = { requested: true, provider: "fiber" };
+    const fetchMock = vi.fn(async () => Response.json({ ok: true, data: { relations, company_enrichment } }));
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(fetchCloudLinkedinRelationsExport({
@@ -139,10 +140,11 @@ describe("cloud workspace metadata", () => {
       workspaceId: "workspace-1",
       clientToken: "client-token-1",
       cutoffDate: "2026-04-25",
-    })).resolves.toEqual({ relations });
+      enrichCompanies: true,
+    })).resolves.toEqual({ relations, company_enrichment });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://sync.example.com/workspaces/workspace-1/integrations/linkedin/relations/export?cutoff_date=2026-04-25",
+      "https://sync.example.com/workspaces/workspace-1/integrations/linkedin/relations/export?cutoff_date=2026-04-25&enrich_companies=1",
       {
         headers: {
           authorization: "Bearer client-token-1",

--- a/packages/cli/src/lib/cloud-workspace.ts
+++ b/packages/cli/src/lib/cloud-workspace.ts
@@ -184,12 +184,14 @@ export async function fetchCloudLinkedinRelationsExport(input: {
   workspaceId: string;
   clientToken: string;
   cutoffDate?: string;
-}): Promise<{ relations: LinkedinRelation[] }> {
+  enrichCompanies?: boolean;
+}): Promise<{ relations: LinkedinRelation[]; company_enrichment?: unknown }> {
   const url = new URL(
     `/workspaces/${encodeURIComponent(input.workspaceId)}/integrations/linkedin/relations/export`,
     input.syncEngineUrl,
   );
   if (input.cutoffDate) url.searchParams.set("cutoff_date", input.cutoffDate);
+  if (input.enrichCompanies) url.searchParams.set("enrich_companies", "1");
   const response = await fetch(url.toString(), {
     headers: {
       authorization: `Bearer ${input.clientToken}`,
@@ -212,7 +214,7 @@ export async function fetchCloudLinkedinRelationsExport(input: {
       payloadError(payload) ?? `sync engine returned HTTP ${response.status}`,
     );
   }
-  const data = payload.data as { relations?: unknown };
+  const data = payload.data as { relations?: unknown; company_enrichment?: unknown };
   if (!Array.isArray(data.relations)) {
     throw new AcrmError(
       "failed to export LinkedIn relations",
@@ -220,7 +222,10 @@ export async function fetchCloudLinkedinRelationsExport(input: {
       "sync engine response did not include a relations array",
     );
   }
-  return { relations: data.relations as LinkedinRelation[] };
+  return {
+    relations: data.relations as LinkedinRelation[],
+    ...(data.company_enrichment ? { company_enrichment: data.company_enrichment } : {}),
+  };
 }
 
 function parseProviderStatus(value: unknown): CloudIntegrationProviderStatus {

--- a/packages/sdk/src/operations/import-linkedin-relations.ts
+++ b/packages/sdk/src/operations/import-linkedin-relations.ts
@@ -337,8 +337,7 @@ function relationCompany(relation: LinkedinRelation): NormalizedCompany | null {
     (typeof relation.organization === "string" ? relation.organization : null);
   const name =
     cleanString(explicitName) ??
-    stringField(nested, ["name", "company_name", "companyName", "organization_name", "organizationName", "title"]) ??
-    companyNameFromHeadline(relation.headline);
+    stringField(nested, ["name", "company_name", "companyName", "organization_name", "organizationName"]);
   if (!name) return null;
 
   const explicitLinkedinUrl = stringField(relation, [
@@ -384,13 +383,6 @@ function positionObject(relation: LinkedinRelation): Record<string, unknown> | n
     firstObjectItem(relation.current_position) ??
     firstObjectItem(relation.positions) ??
     firstObjectItem(relation.experience);
-}
-
-function companyNameFromHeadline(headline: string | null | undefined): string | null {
-  const value = cleanString(headline);
-  if (!value) return null;
-  const match = value.match(/\b(?:at|@)\s+([^|,;()]+)/i);
-  return cleanString(match?.[1]);
 }
 
 function relationProvenance(relation: LinkedinRelation): Record<string, unknown> {


### PR DESCRIPTION
## Summary
- stop inferring LinkedIn companies from free-text profile headlines
- add a second, non-fatal hosted relations enrichment pass after importing LinkedIn people
- pass `enrich_companies=1` to the sync engine and import structured company names/LinkedIn URLs when returned
- update the packaged LinkedIn connect skill so agents do not run message sync after import and make clear future contacts/messages sync automatically

## Testing
- `npm run build --workspace @agent-crm/sdk`
- `npm run build --workspace @agent-crm/cli`
- `npm run test --workspace @agent-crm/cli -- src/commands/import-linkedin.test.ts src/commands/import-linkedin-relations.test.ts src/lib/cloud-workspace.test.ts`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add LinkedIn company enrichment import pass after importing relations
> - After importing LinkedIn relations, a second request is made to the sync engine with `enrich_companies=1` to fetch structured company data, which is then imported and merged with the first pass's stats.
> - `fetchCloudLinkedinRelationsExport` in [cloud-workspace.ts](https://github.com/cluster-software/agent-crm/pull/138/files#diff-dc6510de9617586a0aa8a79f5c9728fc7df1f39cd1bf1e4d708624e7fb8ccd20) accepts a new `enrichCompanies` flag and returns optional `company_enrichment` from the sync engine response.
> - Company records are no longer inferred from free-text headline strings in [import-linkedin-relations.ts](https://github.com/cluster-software/agent-crm/pull/138/files#diff-6d5bd513e5b1fba289340cc24796b080d5d017b91744330c5804404f9be7083e); only explicit structured company fields create company records.
> - A `mergeLinkedinRelationStats` helper sums people and companies created/updated across both import passes.
> - Behavioral Change: existing imports that previously created companies from headline text will no longer do so; company creation now requires structured data from the enrichment pass.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ec0cc8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->