### PR TITLE
Harden communication imports against duplicate sync rows

### DIFF
--- a/packages/cli/skills/connect-linkedin-to-acrm.md
+++ b/packages/cli/skills/connect-linkedin-to-acrm.md
@@ -15,7 +15,7 @@ This is the hosted LinkedIn sync flow:
 2. The user opens Agent CRM's hosted LinkedIn connect page.
 3. Future LinkedIn messages and contacts sync automatically after connection.
 4. The user chooses whether to import existing 1st-degree LinkedIn relations.
-5. Existing relations import as lightweight `people` and `companies` records without bulk profile enrichment.
+5. Existing relations import `people` first, then enrich structured company records from LinkedIn profile URLs.
 
 ## Run
 
@@ -81,6 +81,11 @@ If they choose `Recent connections`, ask for a cutoff date. Default to 30 days a
 ```sh
 acrm --json import linkedin --cutoff-date <YYYY-MM-DD>
 ```
+
+Existing people are written before the company enrichment pass. For a few
+hundred contacts, the final JSON can take another 1-2 minutes while company
+LinkedIn URLs fill in; run this as a background/long-timeout command and do not
+cancel it just because the people already appeared.
 
 If `acrm import linkedin` says LinkedIn is not connected, send the user back to the connect flow above.
 

--- a/packages/cli/src/commands/import-communication.test.ts
+++ b/packages/cli/src/commands/import-communication.test.ts
@@ -93,6 +93,49 @@ describe("importCommunicationBatch", () => {
     await lix.close();
   });
 
+  it("dedupes repeated communication source keys within one batch", async () => {
+    const lix = await openTestWorkspace();
+    const ws = Workspace.fromLix(lix);
+    const thread = {
+      sourceKey: "gmail:me@example.com:thread:thread-1",
+      provider: "gmail",
+      channel: "email" as const,
+      providerAccountId: "acct-1",
+      providerThreadId: "thread-1",
+      subject: "Hello",
+      messageCount: 1,
+      participantSourceKeys: []
+    };
+    const message = {
+      sourceKey: "gmail:me@example.com:message:msg-1",
+      provider: "gmail",
+      channel: "email" as const,
+      providerAccountId: "acct-1",
+      providerMessageId: "msg-1",
+      providerThreadId: "thread-1",
+      threadSourceKey: "gmail:me@example.com:thread:thread-1",
+      subject: "Hello",
+      direction: "inbound" as const,
+      participantSourceKeys: []
+    };
+
+    const result = await importCommunicationBatch(ws, {
+      people: [],
+      companies: [],
+      communicationThreads: [thread, thread],
+      communicationMessages: [message, message]
+    });
+
+    expect(result.stats.communication_threads_seen).toBe(1);
+    expect(result.stats.communication_messages_seen).toBe(1);
+    await expect(countRecords(lix, "communication_threads")).resolves.toBe(1);
+    await expect(countRecords(lix, "communication_messages")).resolves.toBe(1);
+    await expect(countValuesFor(lix, "communication_threads", "provider")).resolves.toBe(1);
+    await expect(countValuesFor(lix, "communication_messages", "provider")).resolves.toBe(1);
+
+    await lix.close();
+  });
+
   it("imports LinkedIn communication people with linkedin_url and dedupes by it", async () => {
     const lix = await openTestWorkspace();
     const ws = Workspace.fromLix(lix);

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import path from "node:path";
 import type { Command } from "commander";
 import { AcrmError, ERR, Workspace, generateUuid } from "@agent-crm/sdk";
@@ -14,6 +15,10 @@ export function registerInit(program: Command): void {
         const workspacePath = path.resolve(
           name.endsWith(".acrm") ? name : name + ".acrm",
         );
+        const cloudMetadataPath = path.join(path.dirname(workspacePath), ".agent-crm-cloud.json");
+        const cloudBindingWarning = existsSync(cloudMetadataPath)
+          ? `Existing cloud binding found at ${cloudMetadataPath}; hosted integrations in that binding will still apply to this workspace. Delete it first if you want a fresh cloud workspace.`
+          : undefined;
         const workspace = await Workspace.create(workspacePath);
         const workspaceId = await generateUuid(workspace.lix);
         try {
@@ -21,6 +26,7 @@ export function registerInit(program: Command): void {
             initialized: true,
             workspace_id: workspaceId,
             workspace_path: workspacePath,
+            ...(cloudBindingWarning ? { cloud_binding_warning: cloudBindingWarning } : {}),
           });
           if (!isJson()) {
             const bold = process.env.NO_COLOR ? "" : "\x1b[1m";
@@ -28,6 +34,9 @@ export function registerInit(program: Command): void {
             process.stdout.write(
               `\nCreated ${workspacePath}\nNext steps:\n  ${bold}acrm import csv <path>${reset}     load your leads\n  ${bold}/setup-transcripts${reset}         connect a transcript provider to enable /post-call (optional)\n`,
             );
+            if (cloudBindingWarning) {
+              process.stdout.write(`\nNote: ${cloudBindingWarning}\n`);
+            }
           }
         } finally {
           await workspace.close();

--- a/packages/sdk/src/operations/import-communication.ts
+++ b/packages/sdk/src/operations/import-communication.ts
@@ -129,26 +129,33 @@ export async function importCommunicationBatch(
 ): Promise<CommunicationImportResult> {
   await ensureCommunicationSchema(workspace);
 
+  const normalizedBatch: CommunicationImportBatch = {
+    people: uniqueBySourceKey(batch.people),
+    companies: uniqueBySourceKey(batch.companies ?? []),
+    communicationThreads: uniqueBySourceKey(batch.communicationThreads),
+    communicationMessages: uniqueBySourceKey(batch.communicationMessages),
+  };
+
   const lix = workspace.lix;
   const stats: CommunicationImportResult["stats"] = {
-    people_seen: batch.people.length,
+    people_seen: normalizedBatch.people.length,
     people_created: 0,
-    companies_seen: batch.companies?.length ?? 0,
+    companies_seen: normalizedBatch.companies?.length ?? 0,
     companies_created: 0,
-    communication_threads_seen: batch.communicationThreads.length,
+    communication_threads_seen: normalizedBatch.communicationThreads.length,
     communication_threads_created: 0,
-    communication_messages_seen: batch.communicationMessages.length,
+    communication_messages_seen: normalizedBatch.communicationMessages.length,
     communication_messages_created: 0,
   };
 
-  const sourceKeys = collectSourceKeys(batch);
+  const sourceKeys = collectSourceKeys(normalizedBatch);
   const sourceIndex = await loadSourceKeyIndex(lix, sourceKeys);
   const plannedSourceIndex = new Map(sourceIndex);
-  const emailIndex = await loadPeopleByEmail(lix, batch.people);
+  const emailIndex = await loadPeopleByEmail(lix, normalizedBatch.people);
   const plannedEmailIndex = new Map(emailIndex);
-  const linkedinIndex = await loadPeopleByLinkedinUrl(lix, batch.people);
+  const linkedinIndex = await loadPeopleByLinkedinUrl(lix, normalizedBatch.people);
   const plannedLinkedinIndex = new Map(linkedinIndex);
-  const companies = batch.companies ?? [];
+  const companies = normalizedBatch.companies ?? [];
   const domainIndex = await loadCompaniesByDomain(lix, companies);
   const plannedDomainIndex = new Map(domainIndex);
 
@@ -169,7 +176,7 @@ export async function importCommunicationBatch(
     if (plan.created) stats.companies_created++;
   }
 
-  for (const person of batch.people) {
+  for (const person of normalizedBatch.people) {
     if (personPlans.has(person.sourceKey)) continue;
     const email = normalizeEmail(person.email);
     const linkedinUrl = normalizeLinkedinUrlValue(person.linkedinUrl);
@@ -183,7 +190,7 @@ export async function importCommunicationBatch(
     if (plan.created) stats.people_created++;
   }
 
-  for (const thread of batch.communicationThreads) {
+  for (const thread of normalizedBatch.communicationThreads) {
     if (threadPlans.has(thread.sourceKey)) continue;
     const existingRecordId = plannedSourceIndex.get(sourceIndexKey("communication_threads", thread.sourceKey));
     const plan = planRecord("communication_threads", thread.sourceKey, existingRecordId, recordsToCreate, plannedSourceIndex);
@@ -191,7 +198,7 @@ export async function importCommunicationBatch(
     if (plan.created) stats.communication_threads_created++;
   }
 
-  for (const message of batch.communicationMessages) {
+  for (const message of normalizedBatch.communicationMessages) {
     if (messagePlans.has(message.sourceKey)) continue;
     const existingRecordId = plannedSourceIndex.get(sourceIndexKey("communication_messages", message.sourceKey));
     const plan = planRecord("communication_messages", message.sourceKey, existingRecordId, recordsToCreate, plannedSourceIndex);
@@ -200,10 +207,10 @@ export async function importCommunicationBatch(
   }
 
   const threadSourceByProviderId = new Map(
-    batch.communicationThreads.map((thread) => [thread.providerThreadId, thread.sourceKey]),
+    normalizedBatch.communicationThreads.map((thread) => [thread.providerThreadId, thread.sourceKey]),
   );
   const touchedRecords = collectTouchedRecords(
-    batch,
+    normalizedBatch,
     personPlans,
     companyPlans,
     threadPlans,
@@ -221,7 +228,7 @@ export async function importCommunicationBatch(
     });
   }
 
-  for (const person of batch.people) {
+  for (const person of normalizedBatch.people) {
     const plan = personPlans.get(person.sourceKey);
     if (!plan) continue;
     enqueueMulti(writer, existingValues, plan, "source_keys", "text", person.sourceKey);
@@ -260,7 +267,7 @@ export async function importCommunicationBatch(
     }
   }
 
-  for (const thread of batch.communicationThreads) {
+  for (const thread of normalizedBatch.communicationThreads) {
     const plan = threadPlans.get(thread.sourceKey);
     if (!plan) continue;
     enqueueMulti(writer, existingValues, plan, "source_keys", "text", thread.sourceKey);
@@ -275,7 +282,7 @@ export async function importCommunicationBatch(
     if (thread.messageCount != null) enqueueSingle(writer, existingValues, plan, "message_count", "number", thread.messageCount);
   }
 
-  for (const message of batch.communicationMessages) {
+  for (const message of normalizedBatch.communicationMessages) {
     const plan = messagePlans.get(message.sourceKey);
     if (!plan) continue;
     enqueueMulti(writer, existingValues, plan, "source_keys", "text", message.sourceKey);
@@ -294,7 +301,7 @@ export async function importCommunicationBatch(
     }
   }
 
-  for (const thread of batch.communicationThreads) {
+  for (const thread of normalizedBatch.communicationThreads) {
     const threadPlan = threadPlans.get(thread.sourceKey);
     if (!threadPlan) continue;
     for (const personSourceKey of thread.participantSourceKeys ?? []) {
@@ -309,7 +316,7 @@ export async function importCommunicationBatch(
     }
   }
 
-  for (const message of batch.communicationMessages) {
+  for (const message of normalizedBatch.communicationMessages) {
     const messagePlan = messagePlans.get(message.sourceKey);
     if (!messagePlan) continue;
 
@@ -405,6 +412,12 @@ function collectSourceKeys(batch: CommunicationImportBatch): string[] {
     for (const participant of message.participantSourceKeys ?? []) keys.add(participant);
   }
   return [...keys];
+}
+
+function uniqueBySourceKey<T extends { sourceKey: string }>(items: T[]): T[] {
+  const bySourceKey = new Map<string, T>();
+  for (const item of items) bySourceKey.set(item.sourceKey, item);
+  return [...bySourceKey.values()];
 }
 
 async function loadSourceKeyIndex(


### PR DESCRIPTION
## Summary
- Deduplicate communication import DTOs by source key before planning local writes
- Warn during acrm init when an existing .agent-crm-cloud.json sidecar will keep hosted integrations attached
- Update the LinkedIn connection skill to expect the post-people company enrichment latency

## Tests
- npm run build --workspace @agent-crm/sdk
- npm run build --workspace @agent-crm/cli
- npm run test --workspace @agent-crm/cli -- src/commands/import-communication.test.ts src/commands/import-linkedin.test.ts src/commands/import-linkedin-relations.test.ts src/lib/cloud-workspace.test.ts

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deduplicate communication imports by `sourceKey` within a single batch
> - Adds a `uniqueBySourceKey` helper in [`import-communication.ts`](https://github.com/cluster-software/agent-crm/pull/142/files#diff-661a21cea325c42d9744840a31f3f1b84f30ce87c2bacb33724e77dd96f84221) that collapses duplicate entries sharing the same `sourceKey` before any writes occur.
> - Stats now reflect deduplicated counts, so repeated entries in a batch no longer inflate seen/created metrics or trigger multiple writes.
> - Behavioral Change: batches with duplicate `sourceKey` values for people, companies, threads, or messages will now silently drop the duplicates rather than attempting to write them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b29880b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->