### PR TITLE
Clarify LinkedIn import company enrichment timing

### DIFF
--- a/.changeset/slow-linkedin-company-enrichment.md
+++ b/.changeset/slow-linkedin-company-enrichment.md
@@ -1,0 +1,5 @@
+---
+"@agent-crm/cli": patch
+---
+
+Clarify in the LinkedIn connection skill that existing contact imports write people before the slower company enrichment pass finishes.

--- a/packages/cli/skills/connect-linkedin-to-acrm.md
+++ b/packages/cli/skills/connect-linkedin-to-acrm.md
@@ -15,7 +15,7 @@ This is the hosted LinkedIn sync flow:
 2. The user opens Agent CRM's hosted LinkedIn connect page.
 3. Future LinkedIn messages and contacts sync automatically after connection.
 4. The user chooses whether to import existing 1st-degree LinkedIn relations.
-5. Existing relations import as lightweight `people` and `companies` records without bulk profile enrichment.
+5. Existing relations import `people` first, then enrich structured company records from LinkedIn profile URLs.
 
 ## Run
 
@@ -81,6 +81,11 @@ If they choose `Recent connections`, ask for a cutoff date. Default to 30 days a
 ```sh
 acrm --json import linkedin --cutoff-date <YYYY-MM-DD>
 ```
+
+Existing people are written before the company enrichment pass. For a few
+hundred contacts, the final JSON can take another 1-2 minutes while company
+LinkedIn URLs fill in; run this as a background/long-timeout command and do not
+cancel it just because the people already appeared.
 
 If `acrm import linkedin` says LinkedIn is not connected, send the user back to the connect flow above.
 


### PR DESCRIPTION
## Summary
- Update the LinkedIn connection skill to explain that existing contact imports write people first, then finish the slower company enrichment pass
- Tell agents to use a background/long-timeout command for a few hundred contacts so they do not cancel after people appear
- Add a CLI patch changeset for the packaged skill update

## Tests
- npm run build --workspace @agent-crm/cli

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clarify LinkedIn import company enrichment timing in CLI docs
> Updates [connect-linkedin-to-acrm.md](https://github.com/cluster-software/agent-crm/pull/143/files#diff-b969a2be9eded716d7c83777adc64e3813af3bfc9f1bb352f2a6e1438ab5e35f) to explain that people are written before the company enrichment pass completes. Adds a note that enriching a few hundred contacts can take 1–2 extra minutes and advises running the command with a long timeout without cancelling once people start appearing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 367507d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->