### PR TITLE
Fix cloud workspace identity and communication import dedupe

### DIFF
--- a/.changeset/green-gmail-workspaces.md
+++ b/.changeset/green-gmail-workspaces.md
@@ -1,0 +1,6 @@
+---
+"@agent-crm/sdk": patch
+"@agent-crm/cli": patch
+---
+
+Bind cloud workspace sidecars to durable local `.acrm` identities and dedupe communication imports by source key.

--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -7,7 +7,7 @@ import { loadDotenv } from "../lib/dotenv.js";
 import {
   type CloudIntegrationProviderStatus,
   DEFAULT_SYNC_ENGINE_URL,
-  ensureCloudWorkspaceMetadata,
+  ensureCloudWorkspaceMetadataForWorkspace,
   fetchCloudIntegrationStatus,
   registerCloudWorkspace,
 } from "../lib/cloud-workspace.js";
@@ -83,7 +83,7 @@ async function runConnectLinkedin(opts: { workspace?: string; orgId?: string }):
   loadDotenv(workspaceDir);
   loadDotenv(process.cwd());
 
-  const metadata = ensureCloudWorkspaceMetadata(workspaceDir, {
+  const metadata = await ensureCloudWorkspaceMetadataForWorkspace(workspaceFile, {
     workspaceId: process.env.ACRM_CLOUD_WORKSPACE_ID,
     clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,
     clusterOrgId: opts.orgId ?? process.env.ACRM_CLOUD_CLUSTER_ORG_ID,
@@ -118,7 +118,7 @@ async function runConnectLinkedinStatus(opts: { workspace?: string }): Promise<{
   loadDotenv(workspaceDir);
   loadDotenv(process.cwd());
 
-  const metadata = ensureCloudWorkspaceMetadata(workspaceDir, {
+  const metadata = await ensureCloudWorkspaceMetadataForWorkspace(workspaceFile, {
     workspaceId: process.env.ACRM_CLOUD_WORKSPACE_ID,
     clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,
     clusterOrgId: process.env.ACRM_CLOUD_CLUSTER_ORG_ID,

--- a/packages/cli/src/commands/import-gmail.ts
+++ b/packages/cli/src/commands/import-gmail.ts
@@ -4,7 +4,7 @@ import { basename, dirname } from "node:path";
 import { AcrmError, ERR } from "@agent-crm/sdk";
 import { resolveWorkspacePath } from "../workspace-resolve.js";
 import { fail, isJson, ok, setJsonMode } from "../output/json.js";
-import { DEFAULT_SYNC_ENGINE_URL, ensureCloudWorkspaceMetadata } from "../lib/cloud-workspace.js";
+import { DEFAULT_SYNC_ENGINE_URL, ensureCloudWorkspaceMetadataForWorkspace } from "../lib/cloud-workspace.js";
 
 type Opts = {
   open?: boolean;
@@ -26,7 +26,7 @@ export function attachGmailSubcommand(parent: Command): void {
       try {
         const workspaceFile = resolveWorkspacePath(root?.workspace);
         const workspaceDir = dirname(workspaceFile);
-        const metadata = ensureCloudWorkspaceMetadata(workspaceDir, {
+        const metadata = await ensureCloudWorkspaceMetadataForWorkspace(workspaceFile, {
           workspaceId: process.env.ACRM_CLOUD_WORKSPACE_ID,
           clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,
         });

--- a/packages/cli/src/commands/import-linkedin.ts
+++ b/packages/cli/src/commands/import-linkedin.ts
@@ -16,7 +16,7 @@ import { fail, ok, setJsonMode } from "../output/json.js";
 import { loadDotenv } from "../lib/dotenv.js";
 import {
   DEFAULT_SYNC_ENGINE_URL,
-  ensureCloudWorkspaceMetadata,
+  ensureCloudWorkspaceMetadataForWorkspace,
   fetchCloudCommunicationExport,
   fetchCloudLinkedinRelationsExport,
 } from "../lib/cloud-workspace.js";
@@ -107,7 +107,7 @@ async function runImportLinkedinNetwork(opts: { workspace?: string; cutoffDate?:
   loadDotenv(workspaceDir);
   loadDotenv(process.cwd());
 
-  const metadata = ensureCloudWorkspaceMetadata(workspaceDir, {
+  const metadata = await ensureCloudWorkspaceMetadataForWorkspace(workspaceFile, {
     workspaceId: process.env.ACRM_CLOUD_WORKSPACE_ID,
     clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,
     clusterOrgId: process.env.ACRM_CLOUD_CLUSTER_ORG_ID,
@@ -177,7 +177,7 @@ async function runSyncLinkedin(opts: { workspace?: string }): Promise<{
   loadDotenv(workspaceDir);
   loadDotenv(process.cwd());
 
-  const metadata = ensureCloudWorkspaceMetadata(workspaceDir, {
+  const metadata = await ensureCloudWorkspaceMetadataForWorkspace(workspaceFile, {
     workspaceId: process.env.ACRM_CLOUD_WORKSPACE_ID,
     clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,
     clusterOrgId: process.env.ACRM_CLOUD_CLUSTER_ORG_ID,

--- a/packages/cli/src/lib/cloud-workspace.test.ts
+++ b/packages/cli/src/lib/cloud-workspace.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -34,6 +34,135 @@ describe("cloud workspace metadata", () => {
       expect(first.clusterOrgId).toBe("org-1");
       expect(second.clusterOrgId).toBe("org-1");
       expect(raw.clusterOrgId).toBe("org-1");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reuses a sidecar with a matching local workspace id", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "acrm-cloud-workspace-"));
+    try {
+      const first = ensureCloudWorkspaceMetadata(dir, {
+        workspaceId: "workspace-1",
+        clientToken: "client-token-1",
+        localWorkspaceId: "local-1",
+      });
+      const second = ensureCloudWorkspaceMetadata(dir, {
+        localWorkspaceId: "local-1",
+      });
+
+      expect(first.workspaceId).toBe("workspace-1");
+      expect(second.workspaceId).toBe("workspace-1");
+      expect(second.clientToken).toBe("client-token-1");
+      expect(second.localWorkspaceId).toBe("local-1");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("backfills a non-stale legacy sidecar with the local workspace id", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "acrm-cloud-workspace-"));
+    try {
+      const workspacePath = join(dir, "test.acrm");
+      await writeFile(workspacePath, "", "utf8");
+      await writeFile(join(dir, ".agent-crm-cloud.json"), `${JSON.stringify({
+        workspaceId: "workspace-1",
+        clientToken: "client-token-1",
+        createdAt: new Date(Date.now() + 60_000).toISOString(),
+      })}\n`, "utf8");
+
+      const metadata = ensureCloudWorkspaceMetadata(dir, {
+        localWorkspaceId: "local-1",
+        workspacePath,
+      });
+      const raw = JSON.parse(await readFile(join(dir, ".agent-crm-cloud.json"), "utf8")) as {
+        workspaceId?: string;
+        localWorkspaceId?: string;
+      };
+
+      expect(metadata.workspaceId).toBe("workspace-1");
+      expect(raw.localWorkspaceId).toBe("local-1");
+      expect((await readdir(dir)).filter((name) => name.includes(".stale-"))).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("archives a stale legacy sidecar when the .acrm file is newer", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "acrm-cloud-workspace-"));
+    try {
+      const workspacePath = join(dir, "test.acrm");
+      await writeFile(workspacePath, "", "utf8");
+      await writeFile(join(dir, ".agent-crm-cloud.json"), `${JSON.stringify({
+        workspaceId: "old-workspace",
+        clientToken: "old-token",
+        createdAt: "2000-01-01T00:00:00.000Z",
+      })}\n`, "utf8");
+
+      const metadata = ensureCloudWorkspaceMetadata(dir, {
+        workspaceId: "new-workspace",
+        clientToken: "new-token",
+        localWorkspaceId: "local-1",
+        workspacePath,
+      });
+      const entries = await readdir(dir);
+
+      expect(metadata.workspaceId).toBe("new-workspace");
+      expect(metadata.clientToken).toBe("new-token");
+      expect(entries.some((name) => name.startsWith(".agent-crm-cloud.json.stale-"))).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("archives a stale legacy sidecar without createdAt using file timestamps", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "acrm-cloud-workspace-"));
+    try {
+      const workspacePath = join(dir, "test.acrm");
+      await writeFile(workspacePath, "", "utf8");
+      await writeFile(join(dir, ".agent-crm-cloud.json"), `${JSON.stringify({
+        workspaceId: "old-workspace",
+        clientToken: "old-token",
+      })}\n`, "utf8");
+      const future = new Date(Date.now() + 60_000);
+      await utimes(workspacePath, future, future);
+
+      const metadata = ensureCloudWorkspaceMetadata(dir, {
+        workspaceId: "new-workspace",
+        clientToken: "new-token",
+        localWorkspaceId: "local-1",
+        workspacePath,
+      });
+      const entries = await readdir(dir);
+
+      expect(metadata.workspaceId).toBe("new-workspace");
+      expect(metadata.clientToken).toBe("new-token");
+      expect(entries.some((name) => name.startsWith(".agent-crm-cloud.json.stale-"))).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("archives a sidecar with a mismatched local workspace id", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "acrm-cloud-workspace-"));
+    try {
+      ensureCloudWorkspaceMetadata(dir, {
+        workspaceId: "old-workspace",
+        clientToken: "old-token",
+        localWorkspaceId: "local-1",
+      });
+
+      const metadata = ensureCloudWorkspaceMetadata(dir, {
+        workspaceId: "new-workspace",
+        clientToken: "new-token",
+        localWorkspaceId: "local-2",
+      });
+      const entries = await readdir(dir);
+
+      expect(metadata.workspaceId).toBe("new-workspace");
+      expect(metadata.clientToken).toBe("new-token");
+      expect(metadata.localWorkspaceId).toBe("local-2");
+      expect(entries.some((name) => name.startsWith(".agent-crm-cloud.json.stale-"))).toBe(true);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/cli/src/lib/cloud-workspace.ts
+++ b/packages/cli/src/lib/cloud-workspace.ts
@@ -1,9 +1,11 @@
 import { randomUUID } from "node:crypto";
-import { readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import {
   AcrmError,
   ERR,
+  Workspace,
+  ensureWorkspaceIdentity,
   type CommunicationImportBatch,
   type LinkedinRelation,
 } from "@agent-crm/sdk";
@@ -24,6 +26,7 @@ export type CloudMetadata = {
   workspaceId?: string;
   clientToken?: string;
   clusterOrgId?: string;
+  localWorkspaceId?: string;
   createdAt?: string;
 };
 
@@ -52,18 +55,38 @@ export type CloudIntegrationStatus = {
 
 export function ensureCloudWorkspaceMetadata(
   workspaceDir: string,
-  preferred: { workspaceId?: string; clientToken?: string; clusterOrgId?: string } = {},
-): { workspaceId: string; clientToken: string; clusterOrgId?: string } {
+  preferred: {
+    workspaceId?: string;
+    clientToken?: string;
+    clusterOrgId?: string;
+    localWorkspaceId?: string;
+    workspacePath?: string;
+  } = {},
+): { workspaceId: string; clientToken: string; clusterOrgId?: string; localWorkspaceId?: string } {
   const metadataPath = join(workspaceDir, CLOUD_METADATA_FILENAME);
-  const existing = readCloudMetadata(metadataPath);
+  let existing = readCloudMetadata(metadataPath);
+  const localWorkspaceId = preferred.localWorkspaceId || existing.localWorkspaceId;
+
+  if (existing.workspaceId && existing.clientToken && localWorkspaceId) {
+    if (existing.localWorkspaceId && existing.localWorkspaceId !== localWorkspaceId) {
+      archiveCloudMetadata(metadataPath);
+      existing = {};
+    } else if (!existing.localWorkspaceId && shouldRotateLegacySidecar(existing, metadataPath, preferred.workspacePath)) {
+      archiveCloudMetadata(metadataPath);
+      existing = {};
+    }
+  }
+
   const workspaceId = existing.workspaceId || preferred.workspaceId || randomUUID();
   const clientToken = existing.clientToken || preferred.clientToken || randomUUID();
   const clusterOrgId = preferred.clusterOrgId || existing.clusterOrgId;
+  const nextLocalWorkspaceId = localWorkspaceId || existing.localWorkspaceId;
 
   if (
     workspaceId !== existing.workspaceId ||
     clientToken !== existing.clientToken ||
-    clusterOrgId !== existing.clusterOrgId
+    clusterOrgId !== existing.clusterOrgId ||
+    nextLocalWorkspaceId !== existing.localWorkspaceId
   ) {
     writeFileSync(
       metadataPath,
@@ -72,6 +95,7 @@ export function ensureCloudWorkspaceMetadata(
         workspaceId,
         clientToken,
         ...(clusterOrgId ? { clusterOrgId } : {}),
+        ...(nextLocalWorkspaceId ? { localWorkspaceId: nextLocalWorkspaceId } : {}),
         createdAt: existing.createdAt ?? new Date().toISOString(),
       }, null, 2)}\n`,
       "utf8"
@@ -82,7 +106,25 @@ export function ensureCloudWorkspaceMetadata(
     workspaceId,
     clientToken,
     ...(clusterOrgId ? { clusterOrgId } : {}),
+    ...(nextLocalWorkspaceId ? { localWorkspaceId: nextLocalWorkspaceId } : {}),
   };
+}
+
+export async function ensureCloudWorkspaceMetadataForWorkspace(
+  workspacePath: string,
+  preferred: { workspaceId?: string; clientToken?: string; clusterOrgId?: string } = {},
+): Promise<{ workspaceId: string; clientToken: string; clusterOrgId?: string; localWorkspaceId?: string }> {
+  const workspace = await Workspace.open(workspacePath);
+  try {
+    const localWorkspaceId = await ensureWorkspaceIdentity(workspace);
+    return ensureCloudWorkspaceMetadata(dirname(workspacePath), {
+      ...preferred,
+      localWorkspaceId,
+      workspacePath,
+    });
+  } finally {
+    await workspace.close();
+  }
 }
 
 function readCloudMetadata(metadataPath: string): CloudMetadata {
@@ -92,6 +134,42 @@ function readCloudMetadata(metadataPath: string): CloudMetadata {
   } catch {
     return {};
   }
+}
+
+function shouldRotateLegacySidecar(
+  existing: CloudMetadata,
+  metadataPath: string,
+  workspacePath: string | undefined,
+): boolean {
+  if (existing.localWorkspaceId || !workspacePath || !existsSync(metadataPath) || !existsSync(workspacePath)) {
+    return false;
+  }
+  const sidecarCreatedAt = sidecarTimestamp(existing, metadataPath);
+  if (sidecarCreatedAt == null) return false;
+  const workspaceStat = statSync(workspacePath);
+  const workspaceCreatedAt = Math.max(workspaceStat.birthtimeMs, workspaceStat.mtimeMs);
+  return workspaceCreatedAt > sidecarCreatedAt;
+}
+
+function sidecarTimestamp(existing: CloudMetadata, metadataPath: string): number | null {
+  const createdAt = Date.parse(existing.createdAt ?? "");
+  if (!Number.isNaN(createdAt)) return createdAt;
+  const stat = statSync(metadataPath);
+  const timestamp = Math.max(stat.birthtimeMs, stat.mtimeMs);
+  return Number.isFinite(timestamp) && timestamp > 0 ? timestamp : null;
+}
+
+function archiveCloudMetadata(metadataPath: string): void {
+  if (!existsSync(metadataPath)) return;
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const base = `${metadataPath}.stale-${timestamp}`;
+  let target = base;
+  let suffix = 1;
+  while (existsSync(target)) {
+    target = `${base}-${suffix}`;
+    suffix++;
+  }
+  renameSync(metadataPath, target);
 }
 
 export async function registerCloudWorkspace(input: {
@@ -142,7 +220,7 @@ export async function fetchCloudCommunicationExport(input: {
     throw new AcrmError(
       `failed to export ${input.provider} communication data`,
       ERR.IMPORT,
-      typeof payload?.error === "string" ? payload.error : `sync engine returned HTTP ${response.status}`,
+      payloadError(payload) ?? `sync engine returned HTTP ${response.status}`,
     );
   }
   return payload.data as CommunicationImportBatch;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -31,6 +31,7 @@ export * from "./lib/token-cache.js";
 export * from "./lib/uuidv7.js";
 
 export * from "./workspace/schemas/index.js";
+export * from "./workspace/identity.js";
 export { seedAttributes, seedObjects } from "./workspace/seeds.js";
 export { Workspace } from "./workspace.js";
 

--- a/packages/sdk/src/operations/import-communication.test.ts
+++ b/packages/sdk/src/operations/import-communication.test.ts
@@ -1,0 +1,180 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { exec } from "../db/execute.js";
+import { Workspace } from "../workspace.js";
+import { importCommunicationBatch, type CommunicationImportBatch } from "./import-communication.js";
+
+describe("importCommunicationBatch", () => {
+  it("deduplicates duplicate fresh batch records by source key", async () => {
+    await withWorkspace(async (workspace) => {
+      const batch = duplicateCommunicationBatch();
+
+      const result = await importCommunicationBatch(workspace, batch);
+      await importCommunicationBatch(workspace, batch);
+
+      expect(result.stats).toMatchObject({
+        people_seen: 1,
+        people_created: 1,
+        companies_seen: 1,
+        companies_created: 1,
+        communication_threads_seen: 1,
+        communication_threads_created: 1,
+        communication_messages_seen: 1,
+        communication_messages_created: 1,
+      });
+      await expect(recordCount(workspace, "people")).resolves.toBe(1);
+      await expect(recordCount(workspace, "companies")).resolves.toBe(1);
+      await expect(recordCount(workspace, "communication_threads")).resolves.toBe(1);
+      await expect(recordCount(workspace, "communication_messages")).resolves.toBe(1);
+
+      await expect(activeValueCount(workspace, "communication_messages", "provider")).resolves.toBe(1);
+      await expect(activeValueCount(workspace, "communication_messages", "channel")).resolves.toBe(1);
+      await expect(activeValueCount(workspace, "communication_messages", "subject")).resolves.toBe(1);
+      await expect(activeValueCount(workspace, "communication_messages", "thread")).resolves.toBe(1);
+      await expect(activeValueCount(workspace, "communication_threads", "provider")).resolves.toBe(1);
+      await expect(activeValueCount(workspace, "communication_threads", "channel")).resolves.toBe(1);
+      await expect(activeValueCount(workspace, "communication_threads", "subject")).resolves.toBe(1);
+    });
+  });
+
+  it("keeps one active single value when different source keys resolve to one fresh record", async () => {
+    await withWorkspace(async (workspace) => {
+      await importCommunicationBatch(workspace, {
+        people: [
+          {
+            sourceKey: "gmail:me@example.com:email:alice@example.com",
+            email: "alice@example.com",
+            displayName: "Alice A",
+          },
+          {
+            sourceKey: "gmail:other@example.com:email:alice@example.com",
+            email: "alice@example.com",
+            displayName: "Alice B",
+          },
+        ],
+        communicationThreads: [],
+        communicationMessages: [],
+      });
+
+      await expect(recordCount(workspace, "people")).resolves.toBe(1);
+      await expect(activeValueCount(workspace, "people", "name")).resolves.toBe(1);
+      await expect(activeValueCount(workspace, "people", "source_keys")).resolves.toBe(2);
+      await expect(singleDisplayValue(workspace, "people", "name")).resolves.toBe("Alice B");
+    });
+  });
+});
+
+async function withWorkspace(run: (workspace: Workspace) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(path.join(tmpdir(), "acrm-import-communication-"));
+  try {
+    const workspacePath = path.join(dir, "test.acrm");
+    const workspace = await Workspace.create(workspacePath);
+    try {
+      await run(workspace);
+    } finally {
+      await workspace.close();
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+function duplicateCommunicationBatch(): CommunicationImportBatch {
+  const person = {
+    sourceKey: "gmail:me@example.com:email:alice@example.com",
+    email: "alice@example.com",
+    displayName: "Alice",
+    companySourceKey: "gmail:me@example.com:company_domain:example.com",
+  };
+  const company = {
+    sourceKey: "gmail:me@example.com:company_domain:example.com",
+    domain: "example.com",
+    name: "Example",
+  };
+  const thread = {
+    sourceKey: "gmail:me@example.com:thread:thread-1",
+    provider: "gmail",
+    channel: "email" as const,
+    providerAccountId: "me@example.com",
+    providerThreadId: "thread-1",
+    subject: "Hello",
+    participantSourceKeys: [person.sourceKey],
+  };
+  const message = {
+    sourceKey: "gmail:me@example.com:message:msg-1",
+    provider: "gmail",
+    channel: "email" as const,
+    providerAccountId: "me@example.com",
+    providerMessageId: "msg-1",
+    providerThreadId: "thread-1",
+    threadSourceKey: thread.sourceKey,
+    subject: "Hello",
+    senderSourceKey: person.sourceKey,
+    participantSourceKeys: [person.sourceKey],
+  };
+  return {
+    people: [person, { ...person }],
+    companies: [company, { ...company }],
+    communicationThreads: [thread, { ...thread }],
+    communicationMessages: [message, { ...message }],
+  };
+}
+
+async function recordCount(workspace: Workspace, objectSlug: string): Promise<number> {
+  const result = await exec(
+    workspace.lix,
+    "SELECT COUNT(*) AS count FROM acrm_record WHERE object_slug = $1",
+    [objectSlug],
+  );
+  return Number(result.rows[0]?.count ?? 0);
+}
+
+async function activeValueCount(
+  workspace: Workspace,
+  objectSlug: string,
+  attributeSlug: string,
+): Promise<number> {
+  const result = await exec(
+    workspace.lix,
+    `SELECT COUNT(*) AS count
+     FROM acrm_value
+     WHERE active_until IS NULL
+       AND object_slug = $1
+       AND attribute_slug = $2`,
+    [objectSlug, attributeSlug],
+  );
+  return Number(result.rows[0]?.count ?? 0);
+}
+
+async function singleDisplayValue(
+  workspace: Workspace,
+  objectSlug: string,
+  attributeSlug: string,
+): Promise<string | null> {
+  const result = await exec(
+    workspace.lix,
+    `SELECT value_json
+     FROM acrm_value
+     WHERE active_until IS NULL
+       AND object_slug = $1
+       AND attribute_slug = $2
+     LIMIT 1`,
+    [objectSlug, attributeSlug],
+  );
+  const value = result.rows[0]?.value_json;
+  if (typeof value === "string") {
+    const parsed = JSON.parse(value) as unknown;
+    if (parsed && typeof parsed === "object" && "full_name" in parsed) {
+      const fullName = (parsed as { full_name?: unknown }).full_name;
+      return typeof fullName === "string" ? fullName : null;
+    }
+    if (parsed && typeof parsed === "object" && "value" in parsed) {
+      const display = (parsed as { value?: unknown }).value;
+      return typeof display === "string" ? display : null;
+    }
+    return typeof parsed === "string" ? parsed : null;
+  }
+  return null;
+}

--- a/packages/sdk/src/operations/import-communication.ts
+++ b/packages/sdk/src/operations/import-communication.ts
@@ -92,6 +92,7 @@ type RecordPlan = {
 
 type ExistingValues = {
   singleValues: Map<string, ValueJson>;
+  plannedSingleValues: Set<string>;
   multiValues: Set<string>;
 };
 
@@ -129,26 +130,27 @@ export async function importCommunicationBatch(
 ): Promise<CommunicationImportResult> {
   await ensureCommunicationSchema(workspace);
 
+  const normalizedBatch = normalizeCommunicationBatch(batch);
   const lix = workspace.lix;
   const stats: CommunicationImportResult["stats"] = {
-    people_seen: batch.people.length,
+    people_seen: normalizedBatch.people.length,
     people_created: 0,
-    companies_seen: batch.companies?.length ?? 0,
+    companies_seen: normalizedBatch.companies?.length ?? 0,
     companies_created: 0,
-    communication_threads_seen: batch.communicationThreads.length,
+    communication_threads_seen: normalizedBatch.communicationThreads.length,
     communication_threads_created: 0,
-    communication_messages_seen: batch.communicationMessages.length,
+    communication_messages_seen: normalizedBatch.communicationMessages.length,
     communication_messages_created: 0,
   };
 
-  const sourceKeys = collectSourceKeys(batch);
+  const sourceKeys = collectSourceKeys(normalizedBatch);
   const sourceIndex = await loadSourceKeyIndex(lix, sourceKeys);
   const plannedSourceIndex = new Map(sourceIndex);
-  const emailIndex = await loadPeopleByEmail(lix, batch.people);
+  const emailIndex = await loadPeopleByEmail(lix, normalizedBatch.people);
   const plannedEmailIndex = new Map(emailIndex);
-  const linkedinIndex = await loadPeopleByLinkedinUrl(lix, batch.people);
+  const linkedinIndex = await loadPeopleByLinkedinUrl(lix, normalizedBatch.people);
   const plannedLinkedinIndex = new Map(linkedinIndex);
-  const companies = batch.companies ?? [];
+  const companies = normalizedBatch.companies ?? [];
   const domainIndex = await loadCompaniesByDomain(lix, companies);
   const plannedDomainIndex = new Map(domainIndex);
 
@@ -169,7 +171,7 @@ export async function importCommunicationBatch(
     if (plan.created) stats.companies_created++;
   }
 
-  for (const person of batch.people) {
+  for (const person of normalizedBatch.people) {
     if (personPlans.has(person.sourceKey)) continue;
     const email = normalizeEmail(person.email);
     const linkedinUrl = normalizeLinkedinUrlValue(person.linkedinUrl);
@@ -183,7 +185,7 @@ export async function importCommunicationBatch(
     if (plan.created) stats.people_created++;
   }
 
-  for (const thread of batch.communicationThreads) {
+  for (const thread of normalizedBatch.communicationThreads) {
     if (threadPlans.has(thread.sourceKey)) continue;
     const existingRecordId = plannedSourceIndex.get(sourceIndexKey("communication_threads", thread.sourceKey));
     const plan = planRecord("communication_threads", thread.sourceKey, existingRecordId, recordsToCreate, plannedSourceIndex);
@@ -191,7 +193,7 @@ export async function importCommunicationBatch(
     if (plan.created) stats.communication_threads_created++;
   }
 
-  for (const message of batch.communicationMessages) {
+  for (const message of normalizedBatch.communicationMessages) {
     if (messagePlans.has(message.sourceKey)) continue;
     const existingRecordId = plannedSourceIndex.get(sourceIndexKey("communication_messages", message.sourceKey));
     const plan = planRecord("communication_messages", message.sourceKey, existingRecordId, recordsToCreate, plannedSourceIndex);
@@ -200,10 +202,10 @@ export async function importCommunicationBatch(
   }
 
   const threadSourceByProviderId = new Map(
-    batch.communicationThreads.map((thread) => [thread.providerThreadId, thread.sourceKey]),
+    normalizedBatch.communicationThreads.map((thread) => [thread.providerThreadId, thread.sourceKey]),
   );
   const touchedRecords = collectTouchedRecords(
-    batch,
+    normalizedBatch,
     personPlans,
     companyPlans,
     threadPlans,
@@ -221,7 +223,7 @@ export async function importCommunicationBatch(
     });
   }
 
-  for (const person of batch.people) {
+  for (const person of normalizedBatch.people) {
     const plan = personPlans.get(person.sourceKey);
     if (!plan) continue;
     enqueueMulti(writer, existingValues, plan, "source_keys", "text", person.sourceKey);
@@ -260,7 +262,7 @@ export async function importCommunicationBatch(
     }
   }
 
-  for (const thread of batch.communicationThreads) {
+  for (const thread of normalizedBatch.communicationThreads) {
     const plan = threadPlans.get(thread.sourceKey);
     if (!plan) continue;
     enqueueMulti(writer, existingValues, plan, "source_keys", "text", thread.sourceKey);
@@ -275,7 +277,7 @@ export async function importCommunicationBatch(
     if (thread.messageCount != null) enqueueSingle(writer, existingValues, plan, "message_count", "number", thread.messageCount);
   }
 
-  for (const message of batch.communicationMessages) {
+  for (const message of normalizedBatch.communicationMessages) {
     const plan = messagePlans.get(message.sourceKey);
     if (!plan) continue;
     enqueueMulti(writer, existingValues, plan, "source_keys", "text", message.sourceKey);
@@ -294,7 +296,7 @@ export async function importCommunicationBatch(
     }
   }
 
-  for (const thread of batch.communicationThreads) {
+  for (const thread of normalizedBatch.communicationThreads) {
     const threadPlan = threadPlans.get(thread.sourceKey);
     if (!threadPlan) continue;
     for (const personSourceKey of thread.participantSourceKeys ?? []) {
@@ -309,7 +311,7 @@ export async function importCommunicationBatch(
     }
   }
 
-  for (const message of batch.communicationMessages) {
+  for (const message of normalizedBatch.communicationMessages) {
     const messagePlan = messagePlans.get(message.sourceKey);
     if (!messagePlan) continue;
 
@@ -366,6 +368,25 @@ async function ensureCommunicationSchema(workspace: Workspace): Promise<void> {
 
   await seedObjects(workspace.lix);
   await seedAttributes(workspace.lix);
+}
+
+function normalizeCommunicationBatch(batch: CommunicationImportBatch): CommunicationImportBatch {
+  return {
+    people: uniqueBySourceKey(batch.people),
+    companies: uniqueBySourceKey(batch.companies ?? []),
+    communicationThreads: uniqueBySourceKey(batch.communicationThreads),
+    communicationMessages: uniqueBySourceKey(batch.communicationMessages),
+  };
+}
+
+function uniqueBySourceKey<Item extends { sourceKey: string }>(items: Item[]): Item[] {
+  const bySourceKey = new Map<string, Item>();
+  for (const item of items) {
+    if (!bySourceKey.has(item.sourceKey)) {
+      bySourceKey.set(item.sourceKey, item);
+    }
+  }
+  return [...bySourceKey.values()];
 }
 
 function planRecord(
@@ -571,6 +592,7 @@ async function loadExistingValues(
 ): Promise<ExistingValues> {
   const existing: ExistingValues = {
     singleValues: new Map(),
+    plannedSingleValues: new Set(),
     multiValues: new Set(),
   };
 
@@ -620,12 +642,14 @@ function enqueueSingle(
   const valueJson = encode(attributeType, rawValue, attributeConfig(plan.objectSlug, attributeSlug));
   const key = singleValueKey(plan.objectSlug, plan.recordId, attributeSlug);
   const current = existing.singleValues.get(key);
-  if (!plan.created && current && sameValueJson(current, valueJson)) return;
-  if (!plan.created && current) {
+  const planned = existing.plannedSingleValues.has(key);
+  if (current && sameValueJson(current, valueJson)) return;
+  if (!planned && !plan.created && current) {
     writer.retireSingle(plan.objectSlug, plan.recordId, attributeSlug);
   }
   existing.singleValues.set(key, valueJson);
-  writer.enqueueValue(valueInput(plan.objectSlug, plan.recordId, attributeSlug, attributeType, valueJson));
+  existing.plannedSingleValues.add(key);
+  writer.enqueueSingleValue(valueInput(plan.objectSlug, plan.recordId, attributeSlug, attributeType, valueJson));
 }
 
 function enqueueSingleIfMissing(
@@ -752,6 +776,27 @@ class CommunicationWriteBatcher {
       source: input.source,
       provenance: input.provenance,
     }));
+  }
+
+  enqueueSingleValue(input: ValueInput): void {
+    const prepared = prepareValueInsert(uuidv7(), {
+      object_slug: input.object_slug,
+      record_id: input.record_id,
+      attribute_slug: input.attribute_slug,
+      attribute_type: input.attribute_type,
+      value_json: input.value as ValueJson,
+      source: input.source,
+      provenance: input.provenance,
+    });
+    const key = singleValueKey(prepared.object_slug, prepared.record_id, prepared.attribute_slug);
+    const existingIndex = this.values.findIndex((value) =>
+      singleValueKey(value.object_slug, value.record_id, value.attribute_slug) === key
+    );
+    if (existingIndex >= 0) {
+      this.values[existingIndex] = prepared;
+      return;
+    }
+    this.values.push(prepared);
   }
 
   enqueueValueIfMissing(existing: ExistingValues, isFreshRecord: boolean, input: ValueInput): void {

--- a/packages/sdk/src/workspace.test.ts
+++ b/packages/sdk/src/workspace.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import { exec } from "./db/execute.js";
 import { AcrmError, ERR } from "./lib/errors.js";
 import { Workspace } from "./workspace.js";
+import { ensureWorkspaceIdentity } from "./workspace/identity.js";
 
 describe("Workspace", () => {
   it("rejects relative paths before opening a workspace", async () => {
@@ -59,6 +60,9 @@ describe("Workspace", () => {
           "SELECT attribute_type FROM acrm_attribute WHERE object_slug = 'people' AND attribute_slug = 'email_addresses'",
         );
         expect(emailAttr.rows[0]?.attribute_type).toBe("email-address");
+
+        const identity = await ensureWorkspaceIdentity(workspace);
+        expect(identity).toMatch(/^[0-9a-f-]{36}$/);
       } finally {
         await workspace.close();
       }
@@ -78,6 +82,25 @@ describe("Workspace", () => {
         exec(owner.lix, "SELECT object_slug FROM acrm_object LIMIT 1"),
       ).resolves.toMatchObject({ rowsAffected: 0 });
       await owner.close();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves the local workspace identity when reopening", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "acrm-sdk-workspace-"));
+    try {
+      const workspacePath = path.join(dir, "test.acrm");
+      const created = await Workspace.create(workspacePath);
+      const firstIdentity = await ensureWorkspaceIdentity(created);
+      await created.close();
+
+      const reopened = await Workspace.open(workspacePath);
+      try {
+        await expect(ensureWorkspaceIdentity(reopened)).resolves.toBe(firstIdentity);
+      } finally {
+        await reopened.close();
+      }
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/sdk/src/workspace.ts
+++ b/packages/sdk/src/workspace.ts
@@ -4,6 +4,7 @@ import { isAbsolute } from "node:path";
 import { openLix, type Lix } from "@lix-js/sdk";
 import { createBetterSqlite3Backend } from "@lix-js/sdk/sqlite";
 import { AcrmError, ERR } from "./lib/errors.js";
+import { ensureWorkspaceIdentity } from "./workspace/identity.js";
 import { initializeWorkspace } from "./workspace/initialize.js";
 
 // Opaque handle wrapping a Lix. Workspaces created by open/create own the
@@ -31,7 +32,9 @@ export class Workspace {
         ERR.NO_WORKSPACE,
       );
     }
-    return new Workspace(await openWorkspaceLix(absolutePath), true);
+    const workspace = new Workspace(await openWorkspaceLix(absolutePath), true);
+    await ensureWorkspaceIdentity(workspace);
+    return workspace;
   }
 
   // Wrap an existing Lix in a Workspace handle without taking ownership by

--- a/packages/sdk/src/workspace/identity.ts
+++ b/packages/sdk/src/workspace/identity.ts
@@ -1,0 +1,42 @@
+import { randomUUID } from "node:crypto";
+import type { Lix } from "@lix-js/sdk";
+import { exec } from "../db/execute.js";
+import type { Workspace } from "../workspace.js";
+import { registerAllSchemas } from "./schemas/index.js";
+
+const LOCAL_WORKSPACE_ID_KEY = "local_workspace_id";
+
+export async function ensureWorkspaceIdentity(workspace: Workspace): Promise<string> {
+  return ensureWorkspaceIdentityForLix(workspace.lix);
+}
+
+export async function ensureWorkspaceIdentityForLix(lix: Lix): Promise<string> {
+  await registerAllSchemas(lix);
+
+  const existing = await readMetadataValue(lix, LOCAL_WORKSPACE_ID_KEY);
+  if (existing) return existing;
+
+  const localWorkspaceId = randomUUID();
+  try {
+    await exec(
+      lix,
+      "INSERT INTO acrm_metadata (key, value) VALUES ($1, $2)",
+      [LOCAL_WORKSPACE_ID_KEY, localWorkspaceId],
+    );
+    return localWorkspaceId;
+  } catch (error) {
+    const reread = await readMetadataValue(lix, LOCAL_WORKSPACE_ID_KEY);
+    if (reread) return reread;
+    throw error;
+  }
+}
+
+async function readMetadataValue(lix: Lix, key: string): Promise<string | null> {
+  const result = await exec(
+    lix,
+    "SELECT value FROM acrm_metadata WHERE key = $1 LIMIT 1",
+    [key],
+  ).catch(() => ({ rows: [] as Array<Record<string, unknown>> }));
+  const value = result.rows[0]?.value;
+  return typeof value === "string" && value.length > 0 ? value : null;
+}

--- a/packages/sdk/src/workspace/initialize.ts
+++ b/packages/sdk/src/workspace/initialize.ts
@@ -1,4 +1,5 @@
 import type { Lix } from "@lix-js/sdk";
+import { ensureWorkspaceIdentityForLix } from "./identity.js";
 import { registerAllSchemas } from "./schemas/index.js";
 import { seedAttributes, seedObjects } from "./seeds.js";
 
@@ -8,4 +9,5 @@ export async function initializeWorkspace(lix: Lix): Promise<void> {
   await registerAllSchemas(lix);
   await seedObjects(lix);
   await seedAttributes(lix);
+  await ensureWorkspaceIdentityForLix(lix);
 }

--- a/packages/sdk/src/workspace/schemas/index.ts
+++ b/packages/sdk/src/workspace/schemas/index.ts
@@ -102,11 +102,25 @@ export const SCHEMA_VALUE: LixSchema = {
   additionalProperties: false,
 };
 
+export const SCHEMA_METADATA: LixSchema = {
+  $schema: draft,
+  "x-lix-key": "acrm_metadata",
+  "x-lix-primary-key": ["/key"],
+  type: "object",
+  required: ["key", "value"],
+  properties: {
+    key: { type: "string" },
+    value: { type: "string" },
+  },
+  additionalProperties: false,
+};
+
 export const ALL_SCHEMAS: LixSchema[] = [
   SCHEMA_OBJECT,
   SCHEMA_ATTRIBUTE,
   SCHEMA_RECORD,
   SCHEMA_VALUE,
+  SCHEMA_METADATA,
 ];
 
 export async function registerAllSchemas(lix: Lix): Promise<void> {


### PR DESCRIPTION
## Summary
- add durable local .acrm identity via acrm_metadata and ensureWorkspaceIdentity
- bind .agent-crm-cloud.json to localWorkspaceId with stale legacy rotation/backfill
- make communication batch imports dedupe by sourceKey and replace pending single values

## Tests
- npm run test

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix cloud workspace identity binding and deduplicate communication imports by source key
> - Introduces a durable local workspace identity stored in `acrm_metadata`, created on workspace open/init via `ensureWorkspaceIdentity` in [identity.ts](https://github.com/cluster-software/agent-crm/pull/145/files#diff-36263c5ab3534966a1f57f444ff92a3a0d1e798079d85f77a4f133f17b48dc0c).
> - Adds `ensureCloudWorkspaceMetadataForWorkspace` in [cloud-workspace.ts](https://github.com/cluster-software/agent-crm/pull/145/files#diff-dc6510de9617586a0aa8a79f5c9728fc7df1f39cd1bf1e4d708624e7fb8ccd20) to bind cloud sidecar metadata to the local workspace identity, archiving stale or mismatched sidecars as `.stale-<timestamp>` files.
> - CLI commands (`connect`, `import-gmail`, `import-linkedin`) now use the new workspace-file-aware metadata helper instead of the directory-based `ensureCloudWorkspaceMetadata`.
> - Deduplicates records in `importCommunicationBatch` by `sourceKey` before planning, and coalesces single-value attribute writes within a batch using the new `enqueueSingleValue` method to prevent duplicate creations.
> - Behavioral Change: cloud sidecar files tied to a different or missing local workspace identity are renamed to `.stale-<timestamp>` and regenerated on next use.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e30775d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->