### PR TITLE
Route Gmail import through browser Cluster auth

### DIFF
--- a/.changeset/gmail-browser-cluster-gate.md
+++ b/.changeset/gmail-browser-cluster-gate.md
@@ -1,0 +1,5 @@
+---
+"@agent-crm/cli": patch
+---
+
+Route `acrm import gmail` through the hosted browser Cluster-auth bridge, matching LinkedIn org inference and selection, and update the onboarding skill instructions for the gated flow.

--- a/packages/cli/skills/acrm-onboarding.md
+++ b/packages/cli/skills/acrm-onboarding.md
@@ -53,6 +53,13 @@ Use `AskUserQuestion` with this exact question and options (single-select, multi
 Powered by Agent CRM's hosted sync engine. Do **not** run a local Gmail
 contacts import.
 
+Gmail uses the same browser-side Cluster auth gate as LinkedIn. Do not
+ask the user for a Cluster org id before starting. The hosted connect page
+will infer the org from the user's Cluster browser session, or ask them to
+choose one if the session belongs to multiple orgs. Only pass
+`--org-id <org-id>` when the user explicitly provides an org id or the
+workspace already has one configured.
+
 Run:
 
 ```sh
@@ -77,9 +84,10 @@ people, threads, and messages into your local `.acrm` workspace.
 What `acrm import gmail` does now:
 
 1. Reads or creates `.agent-crm-cloud.json` next to the local workspace.
-2. Starts a hosted sync-engine OAuth attempt.
-3. Opens the Google OAuth URL in the user's browser and returns it as
-   `data.auth_url` for fallback/debugging.
+2. Registers the cloud workspace with the hosted sync engine.
+3. Opens the hosted Gmail connect page in the user's browser. That page
+   checks Cluster auth, chooses the org, then starts Google OAuth.
+4. Returns the hosted connect URL as `data.auth_url` for fallback/debugging.
 
 After OAuth, the sync engine redirects to a "Gmail sync started" page and
 imports Gmail in the background. Gmail data is written to the cloud

--- a/packages/cli/src/commands/import-gmail.test.ts
+++ b/packages/cli/src/commands/import-gmail.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { openTestWorkspace } from "../test/open-test-lix.js";
 import {
   exec,
@@ -28,7 +31,25 @@ async function rowsFor(
 }
 
 describe("importGoogleContacts", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
   it("builds a hosted sync-engine Gmail OAuth URL", () => {
+    const url = gmailCommandTest.gmailConnectUrl({
+      syncEngineUrl: "https://sync.example.com",
+      workspaceId: "workspace-1",
+      clusterOrgId: "org-1",
+      workspaceName: "pipeline",
+    });
+
+    expect(url).toBe(
+      "https://sync.example.com/integrations/gmail/connect?workspace_id=workspace-1&cluster_org_id=org-1&workspace_name=pipeline",
+    );
+  });
+
+  it("omits Cluster org id when browser auth should infer it", () => {
     const url = gmailCommandTest.gmailConnectUrl({
       syncEngineUrl: "https://sync.example.com",
       workspaceId: "workspace-1",
@@ -53,6 +74,47 @@ describe("importGoogleContacts", () => {
       command: "xdg-open",
       args: ["https://example.com"],
     });
+  });
+
+  it("registers the cloud workspace and returns a hosted Gmail browser URL", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "acrm-gmail-import-"));
+    const workspacePath = join(dir, "pipeline.acrm");
+    const ws = await Workspace.create(workspacePath);
+    await ws.close();
+    vi.stubEnv("ACRM_SYNC_ENGINE_URL", "https://sync.example.com");
+    vi.stubEnv("ACRM_CLOUD_WORKSPACE_ID", "workspace-1");
+    vi.stubEnv("ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN", "client-token-1");
+    const fetchMock = vi.fn(async () => Response.json({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const result = await gmailCommandTest.runImportGmail({
+        workspace: workspacePath,
+        orgId: "org-1",
+      });
+      const authUrl = new URL(result.auth_url);
+
+      expect(result.workspace_id).toBe("workspace-1");
+      expect(result.cluster_org_id).toBe("org-1");
+      expect(result.sync_engine_url).toBe("https://sync.example.com");
+      expect(authUrl.origin + authUrl.pathname).toBe("https://sync.example.com/integrations/gmail/connect");
+      expect(authUrl.searchParams.get("workspace_id")).toBe("workspace-1");
+      expect(authUrl.searchParams.get("cluster_org_id")).toBe("org-1");
+      expect(authUrl.searchParams.get("workspace_name")).toBe(basename(dir));
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [registerUrl, registerInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const parsedRegisterUrl = new URL(registerUrl);
+      expect(parsedRegisterUrl.origin + parsedRegisterUrl.pathname).toBe("https://sync.example.com/workspaces/workspace-1/register");
+      expect(parsedRegisterUrl.searchParams.get("workspace_name")).toBe(basename(dir));
+      expect(registerInit).toEqual({
+        method: "POST",
+        headers: {
+          authorization: "Bearer client-token-1",
+        },
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   it("creates person + company from a connection with email + organization", async () => {

--- a/packages/cli/src/commands/import-gmail.ts
+++ b/packages/cli/src/commands/import-gmail.ts
@@ -4,10 +4,16 @@ import { basename, dirname } from "node:path";
 import { AcrmError, ERR } from "@agent-crm/sdk";
 import { resolveWorkspacePath } from "../workspace-resolve.js";
 import { fail, isJson, ok, setJsonMode } from "../output/json.js";
-import { DEFAULT_SYNC_ENGINE_URL, ensureCloudWorkspaceMetadataForWorkspace } from "../lib/cloud-workspace.js";
+import { loadDotenv } from "../lib/dotenv.js";
+import {
+  DEFAULT_SYNC_ENGINE_URL,
+  ensureCloudWorkspaceMetadataForWorkspace,
+  registerCloudWorkspace,
+} from "../lib/cloud-workspace.js";
 
 type Opts = {
   open?: boolean;
+  orgId?: string;
 };
 
 export function attachGmailSubcommand(parent: Command): void {
@@ -17,6 +23,7 @@ export function attachGmailSubcommand(parent: Command): void {
       "Connect Gmail through Agent CRM's hosted sync engine. Opens hosted Google OAuth and syncs people, email threads, and email messages into the cloud workspace.",
     )
     .option("--no-open", "print the OAuth URL without opening it in a browser")
+    .option("--org-id <org-id>", "Cluster organization id for hosted Gmail sync")
     .action(async (opts: Opts) => {
       const root = parent.parent?.opts() as
         | { workspace?: string; json?: boolean }
@@ -24,21 +31,12 @@ export function attachGmailSubcommand(parent: Command): void {
       setJsonMode(root?.json);
 
       try {
-        const workspaceFile = resolveWorkspacePath(root?.workspace);
-        const workspaceDir = dirname(workspaceFile);
-        const metadata = await ensureCloudWorkspaceMetadataForWorkspace(workspaceFile, {
-          workspaceId: process.env.ACRM_CLOUD_WORKSPACE_ID,
-          clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,
-        });
-        const syncEngineUrl = process.env.ACRM_SYNC_ENGINE_URL ?? DEFAULT_SYNC_ENGINE_URL;
-        const authUrl = await createGmailConnectUrl({
-          syncEngineUrl,
-          workspaceId: metadata.workspaceId,
-          clientToken: metadata.clientToken,
-          workspaceName: basename(workspaceDir),
+        const result = await runImportGmail({
+          workspace: root?.workspace,
+          orgId: opts.orgId,
         });
 
-        if (opts.open !== false) openInBrowser(authUrl);
+        if (opts.open !== false) openInBrowser(result.auth_url);
 
         if (!isJson()) {
           process.stdout.write(
@@ -46,7 +44,7 @@ export function attachGmailSubcommand(parent: Command): void {
               opts.open === false
                 ? "Open this URL to connect Gmail:"
                 : "Opening browser to connect Gmail. If it doesn't open, paste this URL:",
-              authUrl,
+              result.auth_url,
               "",
               "After OAuth, Gmail sync runs in the background through Agent CRM's hosted sync engine.",
               "",
@@ -55,11 +53,7 @@ export function attachGmailSubcommand(parent: Command): void {
           return;
         }
 
-        ok({
-          auth_url: authUrl,
-          workspace_id: metadata.workspaceId,
-          sync_engine_url: syncEngineUrl,
-        });
+        ok(result);
       } catch (error) {
         if (error instanceof AcrmError) fail(error.message, error.code, error.hint);
         else fail(error instanceof Error ? error.message : String(error), ERR.IMPORT);
@@ -68,43 +62,51 @@ export function attachGmailSubcommand(parent: Command): void {
     });
 }
 
-async function createGmailConnectUrl(input: {
-  syncEngineUrl: string;
-  workspaceId: string;
-  clientToken: string;
-  workspaceName: string;
-}): Promise<string> {
-  const url = gmailConnectUrl({
-    syncEngineUrl: input.syncEngineUrl,
-    workspaceId: input.workspaceId,
-    workspaceName: input.workspaceName,
+async function runImportGmail(opts: { workspace?: string; orgId?: string }): Promise<{
+  auth_url: string;
+  workspace_id: string;
+  cluster_org_id: string | null;
+  sync_engine_url: string;
+}> {
+  const workspaceFile = resolveWorkspacePath(opts.workspace);
+  const workspaceDir = dirname(workspaceFile);
+  loadDotenv(workspaceDir);
+  loadDotenv(process.cwd());
+
+  const metadata = await ensureCloudWorkspaceMetadataForWorkspace(workspaceFile, {
+    workspaceId: process.env.ACRM_CLOUD_WORKSPACE_ID,
+    clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,
+    clusterOrgId: opts.orgId ?? process.env.ACRM_CLOUD_CLUSTER_ORG_ID,
   });
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      authorization: `Bearer ${input.clientToken}`,
-    },
+  const syncEngineUrl = process.env.ACRM_SYNC_ENGINE_URL ?? DEFAULT_SYNC_ENGINE_URL;
+  await registerCloudWorkspace({
+    syncEngineUrl,
+    workspaceId: metadata.workspaceId,
+    clientToken: metadata.clientToken,
+    workspaceName: basename(workspaceDir),
   });
-  const payload = await response.json().catch(() => undefined) as
-    | { authUrl?: unknown; error?: unknown }
-    | undefined;
-  if (!response.ok || typeof payload?.authUrl !== "string") {
-    throw new AcrmError(
-      "failed to start hosted Gmail OAuth",
-      ERR.IMPORT,
-      typeof payload?.error === "string" ? payload.error : `sync engine returned HTTP ${response.status}`,
-    );
-  }
-  return payload.authUrl;
+  return {
+    auth_url: gmailConnectUrl({
+      syncEngineUrl,
+      workspaceId: metadata.workspaceId,
+      clusterOrgId: metadata.clusterOrgId,
+      workspaceName: basename(workspaceDir),
+    }),
+    workspace_id: metadata.workspaceId,
+    cluster_org_id: metadata.clusterOrgId ?? null,
+    sync_engine_url: syncEngineUrl,
+  };
 }
 
 function gmailConnectUrl(input: {
   syncEngineUrl: string;
   workspaceId: string;
+  clusterOrgId?: string;
   workspaceName: string;
 }): string {
   const url = new URL("/integrations/gmail/connect", input.syncEngineUrl);
   url.searchParams.set("workspace_id", input.workspaceId);
+  if (input.clusterOrgId) url.searchParams.set("cluster_org_id", input.clusterOrgId);
   url.searchParams.set("workspace_name", input.workspaceName || "Agent CRM workspace");
   return url.toString();
 }
@@ -132,7 +134,7 @@ function openInBrowser(url: string): void {
 }
 
 export const __test = {
-  createGmailConnectUrl,
+  runImportGmail,
   browserOpenCommand,
   gmailConnectUrl,
 };


### PR DESCRIPTION
## Summary\n- route `acrm import gmail` through the hosted Gmail connect page instead of POSTing directly with the workspace token\n- mirror LinkedIn org handling by allowing browser-side Cluster auth to infer/select the org\n- update the acrm-onboarding skill and add a CLI changeset\n\n## Tests\n- `npm run build --workspace @agent-crm/sdk`\n- `npm run build --workspace @agent-crm/cli`\n- `npm test --workspace @agent-crm/cli`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route `acrm import gmail` through browser Cluster auth
> - Replaces the previous flow (POSTing to `/integrations/gmail/connect` for an auth URL) with direct client-side URL construction after registering the cloud workspace via `registerCloudWorkspace`.
> - Adds `--org-id` CLI option; when provided, `cluster_org_id` is appended to the generated connect URL so org selection is pre-filled on the hosted page.
> - `runImportGmail` loads `.env` files from the workspace and current directory, registers the workspace, then returns `auth_url`, `workspace_id`, `cluster_org_id`, and `sync_engine_url`.
> - Updates [acrm-onboarding.md](https://github.com/cluster-software/agent-crm/pull/146/files#diff-62c6a245c0067c368907b06da492d53a7808aedf9a47d02a16704ed93f5688c8) to reflect that Gmail now uses the same browser-side Cluster auth gate as LinkedIn.
> - Behavioral Change: JSON output from `acrm import gmail` now includes `cluster_org_id` and `sync_engine_url`; the command no longer calls the sync engine's connect endpoint to obtain an auth URL.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39cce72.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->