### PR TITLE
Start LinkedIn message backfill after contact import

### DIFF
--- a/.changeset/linkedin-message-backfill.md
+++ b/.changeset/linkedin-message-backfill.md
@@ -1,0 +1,6 @@
+---
+"@agent-crm/cli": patch
+"@agent-crm/sdk": patch
+---
+
+Start hosted LinkedIn message-history backfill after importing existing contacts, and update the LinkedIn agent guidance for the background message and company enrichment flow.

--- a/packages/cli/skills/connect-linkedin-to-acrm.md
+++ b/packages/cli/skills/connect-linkedin-to-acrm.md
@@ -15,7 +15,7 @@ This is the hosted LinkedIn sync flow:
 2. The user opens Agent CRM's hosted LinkedIn connect page.
 3. Future LinkedIn messages and contacts sync automatically after connection.
 4. The user chooses whether to import existing 1st-degree LinkedIn relations.
-5. Existing relations import `people` first, then enrich structured company records from LinkedIn profile URLs.
+5. Existing relations import `people` first, start hosted message-history backfill, then enrich structured company records from LinkedIn profile URLs.
 
 ## Run
 
@@ -68,6 +68,8 @@ After the polling loop verifies completion, use `AskUserQuestion` with this exac
   2. `All existing contacts` — import every current 1st-degree connection
   3. `Recent connections` — import only after a cutoff date
 
+These options affect existing contacts only; future contacts and messages sync either way.
+
 If they choose `No existing contacts`, stop after confirming LinkedIn is connected.
 
 If they choose `All existing contacts`, run:
@@ -82,10 +84,11 @@ If they choose `Recent connections`, ask for a cutoff date. Default to 30 days a
 acrm --json import linkedin --cutoff-date <YYYY-MM-DD>
 ```
 
-Existing people are written before the company enrichment pass. For a few
-hundred contacts, the final JSON can take another 1-2 minutes while company
-LinkedIn URLs fill in; run this as a background/long-timeout command and do not
-cancel it just because the people already appeared.
+Existing people are written first. Message-history backfill then starts in the
+hosted engine without blocking local people import. For a few hundred contacts,
+the final JSON can still take another 1-2 minutes while company LinkedIn URLs
+fill in; run this as a background/long-timeout command and do not cancel it just
+because the people already appeared.
 
 If `acrm import linkedin` says LinkedIn is not connected, send the user back to the connect flow above.
 
@@ -93,9 +96,9 @@ If `acrm import linkedin` says LinkedIn is not connected, send the user back to 
 
 Do not run `acrm --json import linkedin --sync` in the normal connect/import
 flow. Future LinkedIn messages and contacts sync automatically. Use `--sync`
-only for debugging or backfilling already-stored hosted message events, and
-check `communication_messages_seen` / `communication_messages_created` before
-claiming messages were imported.
+only for debugging or importing already-stored hosted message history into the
+local `.acrm` file. Check `communication_messages_seen` /
+`communication_messages_created` before claiming messages were imported.
 
 ## Hard rules
 

--- a/packages/cli/skills/connect-linkedin-to-acrm.md
+++ b/packages/cli/skills/connect-linkedin-to-acrm.md
@@ -97,7 +97,10 @@ If `acrm import linkedin` says LinkedIn is not connected, send the user back to 
 Do not run `acrm --json import linkedin --sync` in the normal connect/import
 flow. Future LinkedIn messages and contacts sync automatically. Use `--sync`
 only for debugging or importing already-stored hosted message history into the
-local `.acrm` file. Check `communication_messages_seen` /
+local `.acrm` file. When the user asks to pull messages locally, run `--sync`
+for the resolved workspace by default; it imports stored messages for every
+active LinkedIn account enabled for that workspace, not just the most recently
+connected profile. Check `communication_messages_seen` /
 `communication_messages_created` before claiming messages were imported.
 
 ## Hard rules

--- a/packages/cli/skills/connect-linkedin-to-acrm.md
+++ b/packages/cli/skills/connect-linkedin-to-acrm.md
@@ -97,10 +97,11 @@ If `acrm import linkedin` says LinkedIn is not connected, send the user back to 
 Do not run `acrm --json import linkedin --sync` in the normal connect/import
 flow. Future LinkedIn messages and contacts sync automatically. Use `--sync`
 only for debugging or importing already-stored hosted message history into the
-local `.acrm` file. When the user asks to pull messages locally, run `--sync`
-for the resolved workspace by default; it imports stored messages for every
-active LinkedIn account enabled for that workspace, not just the most recently
-connected profile. Check `communication_messages_seen` /
+local `.acrm` file. Run it only when the user explicitly asks to pull messages
+locally or the current task needs local `.acrm` queries over stored messages. In
+that case, run `--sync` for the resolved workspace by default; it imports stored
+messages for every active LinkedIn account enabled for that workspace, not just
+the most recently connected profile. Check `communication_messages_seen` /
 `communication_messages_created` before claiming messages were imported.
 
 ## Hard rules

--- a/packages/cli/src/commands/import-linkedin.test.ts
+++ b/packages/cli/src/commands/import-linkedin.test.ts
@@ -35,7 +35,15 @@ describe("import linkedin command", () => {
       public_profile_url: "https://www.linkedin.com/in/ada-lovelace/",
     };
     const fetchMock = vi.fn(async (url: string) => {
-      const enrichCompanies = new URL(url).searchParams.get("enrich_companies") === "1";
+      const parsed = new URL(url);
+      if (parsed.pathname.endsWith("/integrations/linkedin/messages/backfill")) {
+        return Response.json({
+          ok: true,
+          started: 1,
+          integration_account_ids: ["acct-1"],
+        });
+      }
+      const enrichCompanies = parsed.searchParams.get("enrich_companies") === "1";
       return Response.json({
         ok: true,
         data: {
@@ -61,11 +69,17 @@ describe("import linkedin command", () => {
 
       expect(result.stats.people_created).toBe(1);
       expect(result.stats.companies_created).toBe(1);
-      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(result.message_backfill).toEqual({
+        started: 1,
+        integration_account_ids: ["acct-1"],
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(3);
       const [url] = fetchMock.mock.calls[0] as [string];
-      const [enrichedUrl] = fetchMock.mock.calls[1] as [string];
+      const [backfillUrl] = fetchMock.mock.calls[1] as [string];
+      const [enrichedUrl] = fetchMock.mock.calls[2] as [string];
       expect(url).toContain("/integrations/linkedin/relations/export");
       expect(url).not.toContain("enrich_companies=1");
+      expect(backfillUrl).toContain("/integrations/linkedin/messages/backfill");
       expect(enrichedUrl).toContain("enrich_companies=1");
       const reopened = await Workspace.open(workspacePath);
       try {

--- a/packages/cli/src/commands/import-linkedin.ts
+++ b/packages/cli/src/commands/import-linkedin.ts
@@ -19,6 +19,7 @@ import {
   ensureCloudWorkspaceMetadataForWorkspace,
   fetchCloudCommunicationExport,
   fetchCloudLinkedinRelationsExport,
+  startCloudLinkedinMessageBackfill,
 } from "../lib/cloud-workspace.js";
 import { type BackgroundSignalRun, startMissingSignalsForRecords } from "../signals.js";
 
@@ -101,6 +102,11 @@ async function runImportLinkedinNetwork(opts: { workspace?: string; cutoffDate?:
   stats: ImportLinkedinRelationsResult["stats"];
   company_enrichment?: unknown;
   company_enrichment_warning?: string;
+  message_backfill?: {
+    started: number;
+    integration_account_ids: string[];
+  };
+  message_backfill_warning?: string;
 }> {
   const workspaceFile = resolveWorkspacePath(opts.workspace);
   const workspaceDir = path.dirname(workspaceFile);
@@ -125,7 +131,18 @@ async function runImportLinkedinNetwork(opts: { workspace?: string; cutoffDate?:
     let stats = result.stats;
     let companyEnrichment: unknown;
     let companyEnrichmentWarning: string | undefined;
+    let messageBackfill: { started: number; integration_account_ids: string[] } | undefined;
+    let messageBackfillWarning: string | undefined;
     if (relations.length > 0) {
+      try {
+        messageBackfill = await startCloudLinkedinMessageBackfill({
+          syncEngineUrl,
+          workspaceId: metadata.workspaceId,
+          clientToken: metadata.clientToken,
+        });
+      } catch (error) {
+        messageBackfillWarning = error instanceof Error ? error.message : String(error);
+      }
       try {
         const enriched = await fetchCloudLinkedinRelationsExport({
           syncEngineUrl,
@@ -147,6 +164,8 @@ async function runImportLinkedinNetwork(opts: { workspace?: string; cutoffDate?:
       stats,
       ...(companyEnrichment ? { company_enrichment: companyEnrichment } : {}),
       ...(companyEnrichmentWarning ? { company_enrichment_warning: companyEnrichmentWarning } : {}),
+      ...(messageBackfill ? { message_backfill: messageBackfill } : {}),
+      ...(messageBackfillWarning ? { message_backfill_warning: messageBackfillWarning } : {}),
     };
   } finally {
     await ws.close();

--- a/packages/cli/src/lib/cloud-workspace.test.ts
+++ b/packages/cli/src/lib/cloud-workspace.test.ts
@@ -9,7 +9,8 @@ import {
   fetchCloudLinkedinRelationsExport,
   LINKEDIN_NOT_CONNECTED_HINT,
   LINKEDIN_NOT_CONNECTED_MESSAGE,
-  registerCloudWorkspace
+  registerCloudWorkspace,
+  startCloudLinkedinMessageBackfill
 } from "./cloud-workspace.js";
 import { ERR } from "@agent-crm/sdk";
 
@@ -275,6 +276,34 @@ describe("cloud workspace metadata", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       "https://sync.example.com/workspaces/workspace-1/integrations/linkedin/relations/export?cutoff_date=2026-04-25&enrich_companies=1",
       {
+        headers: {
+          authorization: "Bearer client-token-1",
+        },
+      },
+    );
+  });
+
+  it("starts LinkedIn message backfill", async () => {
+    const fetchMock = vi.fn(async () => Response.json({
+      ok: true,
+      started: 1,
+      integration_account_ids: ["acct-1"],
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(startCloudLinkedinMessageBackfill({
+      syncEngineUrl: "https://sync.example.com",
+      workspaceId: "workspace-1",
+      clientToken: "client-token-1",
+    })).resolves.toEqual({
+      started: 1,
+      integration_account_ids: ["acct-1"],
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://sync.example.com/workspaces/workspace-1/integrations/linkedin/messages/backfill",
+      {
+        method: "POST",
         headers: {
           authorization: "Bearer client-token-1",
         },

--- a/packages/cli/src/lib/cloud-workspace.ts
+++ b/packages/cli/src/lib/cloud-workspace.ts
@@ -306,6 +306,46 @@ export async function fetchCloudLinkedinRelationsExport(input: {
   };
 }
 
+export async function startCloudLinkedinMessageBackfill(input: {
+  syncEngineUrl: string;
+  workspaceId: string;
+  clientToken: string;
+}): Promise<{ started: number; integration_account_ids: string[] }> {
+  const url = new URL(
+    `/workspaces/${encodeURIComponent(input.workspaceId)}/integrations/linkedin/messages/backfill`,
+    input.syncEngineUrl,
+  );
+  const response = await fetch(url.toString(), {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${input.clientToken}`,
+    },
+  });
+  const payload = await response.json().catch(() => undefined) as
+    | { ok?: unknown; started?: unknown; integration_account_ids?: unknown; error?: unknown; code?: unknown }
+    | undefined;
+  if (isLinkedinNotConnected(payload)) {
+    throw new AcrmError(
+      LINKEDIN_NOT_CONNECTED_MESSAGE,
+      ERR.INVALID_INPUT,
+      LINKEDIN_NOT_CONNECTED_HINT,
+    );
+  }
+  if (!response.ok || payload?.ok !== true) {
+    throw new AcrmError(
+      "failed to start LinkedIn message backfill",
+      ERR.IMPORT,
+      payloadError(payload) ?? `sync engine returned HTTP ${response.status}`,
+    );
+  }
+  return {
+    started: typeof payload.started === "number" ? payload.started : 0,
+    integration_account_ids: Array.isArray(payload.integration_account_ids)
+      ? payload.integration_account_ids.filter((id): id is string => typeof id === "string")
+      : [],
+  };
+}
+
 function parseProviderStatus(value: unknown): CloudIntegrationProviderStatus {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return { connected: false };

--- a/packages/sdk/src/agent-instructions.ts
+++ b/packages/sdk/src/agent-instructions.ts
@@ -55,7 +55,7 @@ export const AGENT_INSTRUCTIONS_BLOCK = [
   "- `acrm connect linkedin` connects LinkedIn through Agent CRM's hosted sync engine; `acrm connect linkedin --status` checks whether the workspace is connected.",
   "- `acrm import csv ./leads.csv` imports people and companies from a CSV. It creates deals only when deal columns such as `deal_name` or `deal` are present.",
   "- `acrm import gmail` connects Gmail through Agent CRM's hosted sync engine and syncs people, email threads, and email messages.",
-  "- `acrm import linkedin` imports existing contacts from the connected LinkedIn account; `acrm import linkedin --sync` imports LinkedIn messages from the hosted sync engine.",
+  "- `acrm import linkedin` imports existing contacts from the connected LinkedIn account, then starts hosted LinkedIn message-history backfill in the background. `acrm import linkedin --sync` imports already-stored LinkedIn messages from the hosted sync engine into the local workspace.",
   "- `acrm import linkedin <profile-url-or-slug>` imports one LinkedIn profile, upserts the person, and links their current employer as a company. Requires `APIFY_API_TOKEN` in `.env`.",
   "- `acrm import x <handle-or-url>` imports one X/Twitter profile. Requires `APIFY_API_TOKEN` in `.env`; if the result says `needs_enrichment`, run the `enrich-x-bio` skill.",
   "- `acrm import post <linkedin-or-x-post-url>` imports a LinkedIn or X post, upserts the author as a person, stores the post, and links them.",


### PR DESCRIPTION
## Summary
- start hosted LinkedIn message-history backfill after importing existing contacts
- keep people import non-blocking and leave company enrichment as the longer tail
- update LinkedIn agent guidance and generated workspace instructions

## Tests
- npm run check:agent-instructions --workspace @agent-crm/cli
- npm run test --workspace @agent-crm/cli -- src/commands/import-linkedin.test.ts src/lib/cloud-workspace.test.ts
- npm test
- npm run build

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Start LinkedIn message-history backfill after contact import
> - Adds `startCloudLinkedinMessageBackfill` in [cloud-workspace.ts](https://github.com/cluster-software/agent-crm/pull/148/files#diff-dc6510de9617586a0aa8a79f5c9728fc7df1f39cd1bf1e4d708624e7fb8ccd20) that POSTs to `/workspaces/{workspaceId}/integrations/linkedin/messages/backfill`, maps a `linkedin_not_connected` response to a typed error, and returns `started` count and `integration_account_ids`.
> - `runImportLinkedinNetwork` in [import-linkedin.ts](https://github.com/cluster-software/agent-crm/pull/148/files#diff-d12da4064a84a7426efb0bae2fc9fd45042f3d2b1906667389d5b683d1dcfe6f) calls this function after importing relations (when at least one relation exists), and includes `message_backfill` or `message_backfill_warning` in its JSON output.
> - Updates LinkedIn agent guidance in [connect-linkedin-to-acrm.md](https://github.com/cluster-software/agent-crm/pull/148/files#diff-b969a2be9eded716d7c83777adc64e3813af3bfc9f1bb352f2a6e1438ab5e35f) to reflect that backfill starts before company enrichment and clarifies `--sync` flag usage.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c704cf9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->