### PR TITLE
Enforce ACRM version preflight in onboarding skill

### DIFF
--- a/.changeset/onboarding-version-preflight.md
+++ b/.changeset/onboarding-version-preflight.md
@@ -1,0 +1,5 @@
+---
+"@agent-crm/cli": patch
+---
+
+Require the bundled `acrm-onboarding` skill to run `acrm --version` before any other `acrm` command, matching generated workspace instructions.

--- a/packages/cli/skills/acrm-onboarding.md
+++ b/packages/cli/skills/acrm-onboarding.md
@@ -15,13 +15,12 @@ Say:
 
 > Welcome to Agent CRM — the headless CRM for Claude. Let's get you set up.
 
-Then check whether a workspace already exists in this directory:
+Before any other `acrm` command, verify the CLI version:
 
 ```sh
-acrm execute "SELECT 1" --json
+acrm --version
 ```
 
-- If that succeeds, you're already inside a workspace — skip to step 2.
 - If `acrm` is not found (`command not found`, `not found`, or exit code 127), stop. Do not search the filesystem, check brew, inspect npm globals, or ask follow-up questions. Tell the user to install the CLI with:
 
   ```sh
@@ -29,6 +28,21 @@ acrm execute "SELECT 1" --json
   ```
 
   Then ask them to rerun `/acrm-onboarding`.
+- If the command reports that a newer `@agent-crm/cli` is available, run:
+
+  ```sh
+  npm install -g @agent-crm/cli@latest
+  ```
+
+  Then run `acrm --version` again before continuing. Only ask the user to update manually if npm requires credentials or permissions you cannot satisfy.
+
+Then check whether a workspace already exists in this directory:
+
+```sh
+acrm execute "SELECT 1" --json
+```
+
+- If that succeeds, you're already inside a workspace — skip to step 2.
 - If it fails with `ACRM_ERROR_NO_WORKSPACE`, ask the user what to name their workspace (default: `pipeline.acrm`) and run:
 
   ```sh
@@ -150,6 +164,7 @@ Keep the close short — one or two suggestions, not a feature dump.
 ## Hard rules
 
 - **Never** fabricate a workspace path or skip the `acrm init` step. If no workspace exists, the user must explicitly name one.
+- **Always** run `acrm --version` before any other `acrm` command, including `acrm execute`.
 - **If `acrm` is not installed, only show `npm i -g @agent-crm/cli` and stop.** Do not troubleshoot local install paths.
 - **Never** silently run a destructive command.
 - **Do not use `gws` for Gmail.** Gmail now goes through the hosted sync engine.

--- a/packages/cli/src/skills.test.ts
+++ b/packages/cli/src/skills.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("bundled skills", () => {
+  it("keeps acrm-onboarding aligned with the workspace version preflight", () => {
+    const skill = readFileSync(
+      new URL("../skills/acrm-onboarding.md", import.meta.url),
+      "utf8",
+    );
+    const versionCheck = skill.indexOf("acrm --version");
+    const workspaceCheck = skill.indexOf('acrm execute "SELECT 1" --json');
+
+    expect(versionCheck).toBeGreaterThanOrEqual(0);
+    expect(workspaceCheck).toBeGreaterThanOrEqual(0);
+    expect(versionCheck).toBeLessThan(workspaceCheck);
+    expect(skill).toContain("Always** run `acrm --version` before any other `acrm` command");
+  });
+});


### PR DESCRIPTION
## Summary\n- require the bundled `acrm-onboarding` skill to run `acrm --version` before any other `acrm` command\n- keep install/update handling aligned with generated `CLAUDE.md` workspace instructions\n- add a regression test that asserts the version preflight appears before the workspace probe\n\n## Tests\n- `npm run build --workspace @agent-crm/sdk`\n- `npm run build --workspace @agent-crm/cli`\n- `npm test --workspace @agent-crm/cli -- src/skills.test.ts`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce `acrm --version` preflight check in `acrm-onboarding` skill
> - Updates [acrm-onboarding.md](https://github.com/cluster-software/agent-crm/pull/149/files#diff-62c6a245c0067c368907b06da492d53a7808aedf9a47d02a16704ed93f5688c8) to require `acrm --version` as the first step, before the workspace existence check, and adds a hard rule reinforcing this order.
> - Adds an explicit update step instructing users to run `npm install -g @agent-crm/cli@latest` and rerun `acrm --version` when a newer CLI version is detected.
> - Adds a Vitest test in [skills.test.ts](https://github.com/cluster-software/agent-crm/pull/149/files#diff-3cb7388daa94e87db63f696e6dda6796ebdf67994a2c50402cd4081b062ebb3f) that asserts the version check is present, precedes the workspace check, and includes the hard rule text.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 24de881.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->