### PR TITLE
Report existing LinkedIn connection from connect command

### DIFF
--- a/.changeset/linkedin-connect-status-guidance.md
+++ b/.changeset/linkedin-connect-status-guidance.md
@@ -1,0 +1,6 @@
+---
+"@agent-crm/cli": patch
+"@agent-crm/sdk": patch
+---
+
+Have `acrm connect linkedin` report when the workspace is already connected instead of returning a hosted connect URL.

--- a/packages/cli/skills/connect-linkedin-to-acrm.md
+++ b/packages/cli/skills/connect-linkedin-to-acrm.md
@@ -35,11 +35,15 @@ Run commands from the directory containing the active `.acrm` file and omit `-w`
 
 Do not set or re-export a `WORKSPACE` shell variable. Tool calls usually run in fresh shells, so repeated exports add noise without preserving useful state.
 
-Start the connect flow:
+Start the connect flow. If the workspace is already connected, this command
+returns `data.connected: true` instead of an `auth_url`.
 
 ```sh
 CONNECT_JSON=$(acrm --json connect linkedin)
 echo "$CONNECT_JSON"
+if echo "$CONNECT_JSON" | jq -e '.data.connected == true' >/dev/null; then
+  exit 0
+fi
 open "$(echo "$CONNECT_JSON" | jq -r '.data.auth_url')"
 ```
 

--- a/packages/cli/src/commands/connect.test.ts
+++ b/packages/cli/src/commands/connect.test.ts
@@ -39,6 +39,91 @@ describe("connect linkedin command", () => {
     );
   });
 
+  it("returns a hosted sync-engine LinkedIn connect URL when the workspace is not connected", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "acrm-linkedin-connect-"));
+    const workspacePath = join(dir, "workspace.acrm");
+    const ws = await Workspace.create(workspacePath);
+    await ws.close();
+    process.env.ACRM_SYNC_ENGINE_URL = "https://sync.example.com";
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith("/register")) return Response.json({ ok: true });
+      return Response.json({
+        ok: true,
+        integrations: {
+          gmail: { connected: false },
+          linkedin: { connected: false },
+        },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const result = await connectCommandTest.runConnectLinkedin({
+        workspace: workspacePath,
+        orgId: "org-1",
+      });
+
+      expect(result.connected).toBe(false);
+      if (!result.connected) {
+        expect(result.auth_url).toContain("/integrations/linkedin/connect");
+        expect(result.auth_url).toContain("cluster_org_id=org-1");
+      }
+      expect(result.linkedin.connected).toBe(false);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(new URL(String(fetchMock.mock.calls[0]?.[0])).pathname).toContain("/register");
+      expect(new URL(String(fetchMock.mock.calls[1]?.[0])).pathname).toContain("/integrations/status");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports an already connected workspace instead of returning a connect URL", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "acrm-linkedin-connected-"));
+    const workspacePath = join(dir, "workspace.acrm");
+    const ws = await Workspace.create(workspacePath);
+    await ws.close();
+    process.env.ACRM_SYNC_ENGINE_URL = "https://sync.example.com";
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith("/register")) return Response.json({ ok: true });
+      return Response.json({
+        ok: true,
+        integrations: {
+          gmail: { connected: false },
+          linkedin: {
+            connected: true,
+            displayName: "Luis on LinkedIn",
+            providerAccountId: "unipile-account-1",
+            accounts: [
+              {
+                id: "acct-1",
+                providerAccountId: "unipile-account-1",
+                displayName: "Luis on LinkedIn",
+                status: "active",
+              },
+            ],
+          },
+        },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const result = await connectCommandTest.runConnectLinkedin({
+        workspace: workspacePath,
+      });
+
+      expect(result.connected).toBe(true);
+      expect("auth_url" in result).toBe(false);
+      expect(result.message).toBe("This workspace is already connected with LinkedIn: Luis on LinkedIn");
+      expect(result.linkedin.connected).toBe(true);
+      expect(result.linkedin.display_name).toBe("Luis on LinkedIn");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("requires an active LinkedIn account before reporting connected status", async () => {
     const dir = await mkdtemp(join(tmpdir(), "acrm-linkedin-status-"));
     const workspacePath = join(dir, "workspace.acrm");

--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -44,15 +44,19 @@ export function registerConnect(program: Command): void {
           orgId: opts.orgId,
         });
         if (!isJson()) {
-          process.stdout.write(
-            [
-              "Open this URL to connect LinkedIn:",
-              result.auth_url,
-              "",
-              "After login, LinkedIn sync runs in the background through Agent CRM's hosted sync engine.",
-              "",
-            ].join("\n")
-          );
+          if (result.connected) {
+            process.stdout.write(`${result.message}\n`);
+          } else {
+            process.stdout.write(
+              [
+                "Open this URL to connect LinkedIn:",
+                result.auth_url,
+                "",
+                "After login, LinkedIn sync runs in the background through Agent CRM's hosted sync engine.",
+                "",
+              ].join("\n")
+            );
+          }
           return;
         }
         ok(result);
@@ -72,12 +76,23 @@ function getOrCreateConnectCommand(program: Command): Command {
     .description("connect external accounts to this .acrm workspace");
 }
 
-async function runConnectLinkedin(opts: { workspace?: string; orgId?: string }): Promise<{
+type LinkedinConnectResult = {
+  connected: false;
   auth_url: string;
   workspace_id: string;
   cluster_org_id: string | null;
   sync_engine_url: string;
-}> {
+  linkedin: CliProviderStatus;
+} | {
+  connected: true;
+  message: string;
+  workspace_id: string;
+  cluster_org_id: string | null;
+  sync_engine_url: string;
+  linkedin: CliProviderStatus;
+};
+
+async function runConnectLinkedin(opts: { workspace?: string; orgId?: string }): Promise<LinkedinConnectResult> {
   const workspaceFile = resolveWorkspacePath(opts.workspace);
   const workspaceDir = path.dirname(workspaceFile);
   loadDotenv(workspaceDir);
@@ -95,7 +110,26 @@ async function runConnectLinkedin(opts: { workspace?: string; orgId?: string }):
     clientToken: metadata.clientToken,
     workspaceName: path.basename(workspaceDir),
   });
+  const status = await fetchCloudIntegrationStatus({
+    syncEngineUrl,
+    workspaceId: metadata.workspaceId,
+    clientToken: metadata.clientToken,
+  });
+  const linkedin = toCliProviderStatus(status.linkedin, {
+    requireActiveAccount: true,
+  });
+  if (linkedin.connected) {
+    return {
+      connected: true,
+      message: linkedinAlreadyConnectedMessage(linkedin),
+      workspace_id: metadata.workspaceId,
+      cluster_org_id: metadata.clusterOrgId ?? null,
+      sync_engine_url: syncEngineUrl,
+      linkedin,
+    };
+  }
   return {
+    connected: false,
     auth_url: linkedinConnectUrl({
       syncEngineUrl,
       workspaceId: metadata.workspaceId,
@@ -105,6 +139,7 @@ async function runConnectLinkedin(opts: { workspace?: string; orgId?: string }):
     workspace_id: metadata.workspaceId,
     cluster_org_id: metadata.clusterOrgId ?? null,
     sync_engine_url: syncEngineUrl,
+    linkedin,
   };
 }
 
@@ -196,6 +231,13 @@ function linkedinStatusMessage(status: CliProviderStatus): string {
   if (!status.connected) return "LinkedIn is not connected yet.\n";
   const label = status.display_name ?? status.account_email ?? status.provider_account_id;
   return label ? `LinkedIn is connected: ${label}\n` : "LinkedIn is connected.\n";
+}
+
+function linkedinAlreadyConnectedMessage(status: CliProviderStatus): string {
+  const label = status.display_name ?? status.account_email ?? status.provider_account_id;
+  return label
+    ? `This workspace is already connected with LinkedIn: ${label}`
+    : "This workspace is already connected with LinkedIn.";
 }
 
 export const __test = {

--- a/packages/sdk/src/agent-instructions.ts
+++ b/packages/sdk/src/agent-instructions.ts
@@ -52,7 +52,7 @@ export const AGENT_INSTRUCTIONS_BLOCK = [
   "- Prefer first-class CLI commands for common writes. Use `acrm execute` for inspection, reporting, or custom SQL when the CLI does not expose the exact operation.",
   "",
   "Common commands:",
-  "- `acrm connect linkedin` connects LinkedIn through Agent CRM's hosted sync engine; `acrm connect linkedin --status` checks whether the workspace is connected.",
+  "- `acrm connect linkedin` connects LinkedIn through Agent CRM's hosted sync engine, or reports when the workspace is already connected. `acrm connect linkedin --status` checks status without starting a connect flow.",
   "- `acrm import csv ./leads.csv` imports people and companies from a CSV. It creates deals only when deal columns such as `deal_name` or `deal` are present.",
   "- `acrm import gmail` connects Gmail through Agent CRM's hosted sync engine and syncs people, email threads, and email messages.",
   "- `acrm import linkedin` imports existing contacts from the connected LinkedIn account, then starts hosted LinkedIn message-history backfill in the background. `acrm import linkedin --sync` imports already-stored LinkedIn messages from the hosted sync engine into the local workspace.",


### PR DESCRIPTION
## Summary
- make `acrm connect linkedin` register/fetch workspace integration status before returning a hosted connect URL
- when an active LinkedIn account is already enabled for the workspace, return `connected: true` and a clear already-connected message instead of `auth_url`
- update LinkedIn agent guidance to branch on `data.connected` from the connect command

## Tests
- npm run test --workspace @agent-crm/cli -- src/commands/connect.test.ts
- npm run build --workspace @agent-crm/cli
- npm run check:agent-instructions --workspace @agent-crm/cli
- git diff --check

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Report existing LinkedIn connection status from `acrm connect linkedin` command
> - `runConnectLinkedin` in [connect.ts](https://github.com/cluster-software/agent-crm/pull/152/files#diff-e3f1e3ab4a99c7f0f1db00244fa6131196fba90403a20122f9d2933eae850843) now fetches the current LinkedIn integration status after registering the cloud workspace, returning `connected: true` with a human-readable message when an active account is already linked, or `connected: false` with the `auth_url` when not.
> - The non-JSON output branch now prints the already-connected message instead of the connect URL when `connected` is true.
> - The new `linkedinAlreadyConnectedMessage` helper resolves the best available label (`display_name`, `account_email`, or `provider_account_id`) for the message.
> - Skill guidance in [connect-linkedin-to-acrm.md](https://github.com/cluster-software/agent-crm/pull/152/files#diff-b969a2be9eded716d7c83777adc64e3813af3bfc9f1bb352f2a6e1438ab5e35f) and agent instructions in [agent-instructions.ts](https://github.com/cluster-software/agent-crm/pull/152/files#diff-08c10eeda4a8c219afebb9e6374c59115c64e7b2bd0024782078714a602f496a) are updated to reflect the new behavior.
> - Behavioral Change: `acrm connect linkedin` no longer always returns an `auth_url`; callers must check `connected` before attempting to open the URL.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e03cd22.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->