### PR TITLE
Update Lix SDK to preview 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -786,9 +786,12 @@
       "license": "MIT"
     },
     "node_modules/@lix-js/sdk": {
-      "version": "0.6.0-preview.3",
-      "resolved": "https://registry.npmjs.org/@lix-js/sdk/-/sdk-0.6.0-preview.3.tgz",
-      "integrity": "sha512-jE4QCyXhnzCJ6BDmSWxe0Ql+TCTXMY4AMpOtue2wsCnxH9scoSLto8Rg/TjAXkHR5GsU8y5r4quB4Q4cs/9s4g==",
+      "version": "0.6.0-preview.5",
+      "resolved": "https://registry.npmjs.org/@lix-js/sdk/-/sdk-0.6.0-preview.5.tgz",
+      "integrity": "sha512-NDUEObELThs0LCwTFVRkfvk1nL37vDKhjFxv49Y8+nkCiwCzt792ShwEIOZ7DE8hOv5mQcvsQfLz+cjcjVJI7Q==",
+      "engines": {
+        "node": ">=22"
+      },
       "peerDependencies": {
         "better-sqlite3": "^12.9.0"
       },
@@ -3547,11 +3550,11 @@
     },
     "packages/cli": {
       "name": "@agent-crm/cli",
-      "version": "0.17.0",
+      "version": "0.19.11",
       "hasInstallScript": true,
       "dependencies": {
-        "@agent-crm/sdk": "0.5.1",
-        "@lix-js/sdk": "0.6.0-preview.3",
+        "@agent-crm/sdk": "0.7.7",
+        "@lix-js/sdk": "0.6.0-preview.5",
         "better-sqlite3": "^12.9.0",
         "commander": "^12.1.0"
       },
@@ -3564,9 +3567,9 @@
     },
     "packages/sdk": {
       "name": "@agent-crm/sdk",
-      "version": "0.5.1",
+      "version": "0.7.7",
       "dependencies": {
-        "@lix-js/sdk": "0.6.0-preview.3",
+        "@lix-js/sdk": "0.6.0-preview.5",
         "better-sqlite3": "^12.9.0",
         "libphonenumber-js": "^1.13.2"
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@agent-crm/sdk": "0.7.7",
-    "@lix-js/sdk": "0.6.0-preview.3",
+    "@lix-js/sdk": "0.6.0-preview.5",
     "better-sqlite3": "^12.9.0",
     "commander": "^12.1.0"
   },

--- a/packages/cli/src/workspace/schemas/index.test.ts
+++ b/packages/cli/src/workspace/schemas/index.test.ts
@@ -9,7 +9,7 @@ describe("registerAllSchemas", () => {
 
     const result = await exec(
       lix,
-      "SELECT value FROM lix_registered_schema ORDER BY lixcol_entity_id",
+      "SELECT value FROM lix_registered_schema ORDER BY lixcol_entity_pk",
     );
     const registeredKeys = result.rows
       .map((row) => {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -25,7 +25,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@lix-js/sdk": "0.6.0-preview.3",
+    "@lix-js/sdk": "0.6.0-preview.5",
     "better-sqlite3": "^12.9.0",
     "libphonenumber-js": "^1.13.2"
   },


### PR DESCRIPTION
Related https://github.com/opral/lix/issues/474

## Summary

- update `@lix-js/sdk` from `0.6.0-preview.3` to `0.6.0-preview.5` in the SDK and CLI packages
- refresh `package-lock.json` for the new package version
- update the schema registration test to order by `lixcol_entity_pk`, which replaces the old `lixcol_entity_id` column exposed by newer Lix

## Validation

- `npm run test --workspace @agent-crm/cli -- src/workspace/schemas/index.test.ts`
- `npm test`

Full suite passed locally after the `lixcol_entity_pk` update:

- CLI: 21 test files, 191 tests passed
- SDK: 3 test files, 18 tests passed


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update @lix-js/sdk dependency to 0.6.0-preview.5
> - Bumps `@lix-js/sdk` from `0.6.0-preview.3` to `0.6.0-preview.5` in both [packages/cli/package.json](https://github.com/cluster-software/agent-crm/pull/154/files#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758) and [packages/sdk/package.json](https://github.com/cluster-software/agent-crm/pull/154/files#diff-77164cc5c071d1488e1cf72c0f91fdd99dd8976edb5004c83198bbd517039572).
> - Updates a test query in [index.test.ts](https://github.com/cluster-software/agent-crm/pull/154/files#diff-c1503cd66a2502c8b118842745c42ad7ddb4fe02f21b13a357b42b5a87a6451d) to order `lix_registered_schema` rows by `lixcol_entity_pk` instead of `lixcol_entity_id`, matching the schema change in the new preview.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0b3e17.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->