### PR TITLE
Add Gmail onboarding backfill and filtering flags

### DIFF
--- a/.changeset/gmail-import-preferences.md
+++ b/.changeset/gmail-import-preferences.md
@@ -1,5 +1,6 @@
 ---
 "@agent-crm/cli": patch
+"@agent-crm/sdk": patch
 ---
 
-Add Gmail import backfill and newsletter filtering preferences to onboarding and CLI import flags.
+Add Gmail import backfill and newsletter filtering preferences to onboarding, CLI import flags, and workspace agent instructions.

--- a/.changeset/gmail-import-preferences.md
+++ b/.changeset/gmail-import-preferences.md
@@ -1,0 +1,5 @@
+---
+"@agent-crm/cli": patch
+---
+
+Add Gmail import backfill and newsletter filtering preferences to onboarding and CLI import flags.

--- a/packages/cli/skills/acrm-onboarding.md
+++ b/packages/cli/skills/acrm-onboarding.md
@@ -74,11 +74,41 @@ choose one if the session belongs to multiple orgs. Only pass
 `--org-id <org-id>` when the user explicitly provides an org id or the
 workspace already has one configured.
 
-Run:
+Before starting OAuth, ask how much Gmail history to import. Use
+`AskUserQuestion` with this exact question and options (single-select,
+multipleChoice off):
+
+- **Question**: `How much Gmail history should Agent CRM import?`
+- **Options**:
+  1. `Last 30 days` — quickest backfill for recent conversations
+  2. `Last 90 days` — broader backfill for recent pipeline context
+  3. `Custom date` — import messages since a specific date
+
+If they choose `Custom date`, ask for a cutoff date in `YYYY-MM-DD` format.
+Do not continue until the user provides a valid-looking date.
+
+Then ask whether to filter newsletters and marketing emails. Use
+`AskUserQuestion` with this exact question and options (single-select,
+multipleChoice off):
+
+- **Question**: `Filter newsletters and marketing emails out of Gmail sync?`
+- **Options**:
+  1. `Yes, filter them` — recommended for CRM-quality contacts and conversations
+  2. `No, include them` — import all matching Gmail history
+
+These choices affect the initial Gmail backfill and future Gmail syncs for
+this account.
+
+Run the command with explicit flags:
 
 ```sh
-acrm import gmail --json
+acrm --json import gmail --backfill-days 30 --exclude-newsletters
+acrm --json import gmail --backfill-days 90 --exclude-newsletters
+acrm --json import gmail --backfill-since <YYYY-MM-DD> --exclude-newsletters
 ```
+
+Use `--include-newsletters` instead of `--exclude-newsletters` when the user
+chooses to include newsletters and marketing emails.
 
 This opens the Google OAuth URL in the user's browser automatically. Do
 not print `data.auth_url` unless the command fails to open the browser and
@@ -101,7 +131,9 @@ What `acrm import gmail` does now:
 2. Registers the cloud workspace with the hosted sync engine.
 3. Opens the hosted Gmail connect page in the user's browser. That page
    checks Cluster auth, chooses the org, then starts Google OAuth.
-4. Returns the hosted connect URL as `data.auth_url` for fallback/debugging.
+4. Passes the selected Gmail backfill and newsletter filtering preferences
+   to the hosted sync engine.
+5. Returns the hosted connect URL as `data.auth_url` for fallback/debugging.
 
 After OAuth, the sync engine redirects to a "Gmail sync started" page and
 imports Gmail in the background. Gmail data is written to the cloud

--- a/packages/cli/src/commands/import-gmail.test.ts
+++ b/packages/cli/src/commands/import-gmail.test.ts
@@ -61,6 +61,53 @@ describe("importGoogleContacts", () => {
     );
   });
 
+  it("adds Gmail sync preferences to the hosted OAuth URL", () => {
+    const url = gmailCommandTest.gmailConnectUrl({
+      syncEngineUrl: "https://sync.example.com",
+      workspaceId: "workspace-1",
+      clusterOrgId: "org-1",
+      workspaceName: "pipeline",
+      backfillDays: 30,
+      excludeNewsletters: true,
+    });
+
+    expect(url).toBe(
+      "https://sync.example.com/integrations/gmail/connect?workspace_id=workspace-1&cluster_org_id=org-1&workspace_name=pipeline&backfill_days=30&exclude_newsletters=true",
+    );
+  });
+
+  it("validates Gmail sync preference flags", () => {
+    expect(gmailCommandTest.parseGmailSyncPreferences({
+      backfillDays: "90",
+      includeNewsletters: true,
+    })).toEqual({
+      backfillDays: 90,
+      excludeNewsletters: false,
+    });
+    expect(gmailCommandTest.parseGmailSyncPreferences({
+      backfillSince: "2026-01-01",
+      excludeNewsletters: true,
+    })).toEqual({
+      backfillSince: "2026-01-01",
+      excludeNewsletters: true,
+    });
+
+    expect(() => gmailCommandTest.parseGmailSyncPreferences({
+      backfillDays: "30",
+      backfillSince: "2026-01-01",
+    })).toThrow(/cannot be used together/);
+    expect(() => gmailCommandTest.parseGmailSyncPreferences({
+      backfillDays: "60",
+    })).toThrow(/must be 30 or 90/);
+    expect(() => gmailCommandTest.parseGmailSyncPreferences({
+      backfillSince: "2026-02-31",
+    })).toThrow(/valid calendar date/);
+    expect(() => gmailCommandTest.parseGmailSyncPreferences({
+      excludeNewsletters: true,
+      includeNewsletters: true,
+    })).toThrow(/cannot be used together/);
+  });
+
   it("selects the platform browser opener command", () => {
     expect(gmailCommandTest.browserOpenCommand("darwin", "https://example.com")).toEqual({
       command: "open",

--- a/packages/cli/src/commands/import-gmail.ts
+++ b/packages/cli/src/commands/import-gmail.ts
@@ -14,6 +14,16 @@ import {
 type Opts = {
   open?: boolean;
   orgId?: string;
+  backfillDays?: string;
+  backfillSince?: string;
+  excludeNewsletters?: boolean;
+  includeNewsletters?: boolean;
+};
+
+type GmailSyncPreferences = {
+  backfillDays?: 30 | 90;
+  backfillSince?: string;
+  excludeNewsletters?: boolean;
 };
 
 export function attachGmailSubcommand(parent: Command): void {
@@ -24,6 +34,10 @@ export function attachGmailSubcommand(parent: Command): void {
     )
     .option("--no-open", "print the OAuth URL without opening it in a browser")
     .option("--org-id <org-id>", "Cluster organization id for hosted Gmail sync")
+    .option("--backfill-days <days>", "Gmail backfill window in days. Supported values: 30, 90")
+    .option("--backfill-since <YYYY-MM-DD>", "Gmail backfill start date")
+    .option("--exclude-newsletters", "filter newsletters and marketing emails out of the Gmail sync")
+    .option("--include-newsletters", "include newsletters and marketing emails in the Gmail sync")
     .action(async (opts: Opts) => {
       const root = parent.parent?.opts() as
         | { workspace?: string; json?: boolean }
@@ -31,9 +45,11 @@ export function attachGmailSubcommand(parent: Command): void {
       setJsonMode(root?.json);
 
       try {
+        const preferences = parseGmailSyncPreferences(opts);
         const result = await runImportGmail({
           workspace: root?.workspace,
           orgId: opts.orgId,
+          ...preferences,
         });
 
         if (opts.open !== false) openInBrowser(result.auth_url);
@@ -62,11 +78,12 @@ export function attachGmailSubcommand(parent: Command): void {
     });
 }
 
-async function runImportGmail(opts: { workspace?: string; orgId?: string }): Promise<{
+async function runImportGmail(opts: { workspace?: string; orgId?: string } & GmailSyncPreferences): Promise<{
   auth_url: string;
   workspace_id: string;
   cluster_org_id: string | null;
   sync_engine_url: string;
+  gmail_sync_preferences?: GmailSyncPreferences;
 }> {
   const workspaceFile = resolveWorkspacePath(opts.workspace);
   const workspaceDir = dirname(workspaceFile);
@@ -91,10 +108,22 @@ async function runImportGmail(opts: { workspace?: string; orgId?: string }): Pro
       workspaceId: metadata.workspaceId,
       clusterOrgId: metadata.clusterOrgId,
       workspaceName: basename(workspaceDir),
+      backfillDays: opts.backfillDays,
+      backfillSince: opts.backfillSince,
+      excludeNewsletters: opts.excludeNewsletters,
     }),
     workspace_id: metadata.workspaceId,
     cluster_org_id: metadata.clusterOrgId ?? null,
     sync_engine_url: syncEngineUrl,
+    ...(hasGmailSyncPreferences(opts)
+      ? {
+          gmail_sync_preferences: {
+            ...(opts.backfillDays ? { backfillDays: opts.backfillDays } : {}),
+            ...(opts.backfillSince ? { backfillSince: opts.backfillSince } : {}),
+            ...(opts.excludeNewsletters != null ? { excludeNewsletters: opts.excludeNewsletters } : {}),
+          },
+        }
+      : {}),
   };
 }
 
@@ -103,12 +132,86 @@ function gmailConnectUrl(input: {
   workspaceId: string;
   clusterOrgId?: string;
   workspaceName: string;
+  backfillDays?: 30 | 90;
+  backfillSince?: string;
+  excludeNewsletters?: boolean;
 }): string {
   const url = new URL("/integrations/gmail/connect", input.syncEngineUrl);
   url.searchParams.set("workspace_id", input.workspaceId);
   if (input.clusterOrgId) url.searchParams.set("cluster_org_id", input.clusterOrgId);
   url.searchParams.set("workspace_name", input.workspaceName || "Agent CRM workspace");
+  if (input.backfillDays) url.searchParams.set("backfill_days", String(input.backfillDays));
+  if (input.backfillSince) url.searchParams.set("backfill_since", input.backfillSince);
+  if (input.excludeNewsletters != null) {
+    url.searchParams.set("exclude_newsletters", String(input.excludeNewsletters));
+  }
   return url.toString();
+}
+
+function parseGmailSyncPreferences(opts: Opts): GmailSyncPreferences {
+  if (opts.backfillDays && opts.backfillSince) {
+    throw new AcrmError(
+      "--backfill-days and --backfill-since cannot be used together",
+      ERR.INVALID_INPUT,
+    );
+  }
+  if (opts.excludeNewsletters && opts.includeNewsletters) {
+    throw new AcrmError(
+      "--exclude-newsletters and --include-newsletters cannot be used together",
+      ERR.INVALID_INPUT,
+    );
+  }
+
+  return {
+    ...(opts.backfillDays ? { backfillDays: parseBackfillDays(opts.backfillDays) } : {}),
+    ...(opts.backfillSince ? { backfillSince: parseBackfillSince(opts.backfillSince) } : {}),
+    ...(opts.excludeNewsletters
+      ? { excludeNewsletters: true }
+      : opts.includeNewsletters
+        ? { excludeNewsletters: false }
+        : {}),
+  };
+}
+
+function parseBackfillDays(value: string): 30 | 90 {
+  const days = Number(value);
+  if (days === 30 || days === 90) return days;
+  throw new AcrmError(
+    "--backfill-days must be 30 or 90",
+    ERR.INVALID_INPUT,
+  );
+}
+
+function parseBackfillSince(value: string): string {
+  const trimmed = value.trim();
+  const match = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) {
+    throw new AcrmError(
+      "--backfill-since must use YYYY-MM-DD format",
+      ERR.INVALID_INPUT,
+    );
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    throw new AcrmError(
+      "--backfill-since must be a valid calendar date",
+      ERR.INVALID_INPUT,
+    );
+  }
+
+  return trimmed;
+}
+
+function hasGmailSyncPreferences(opts: GmailSyncPreferences): boolean {
+  return Boolean(opts.backfillDays || opts.backfillSince || opts.excludeNewsletters != null);
 }
 
 function browserOpenCommand(
@@ -137,4 +240,5 @@ export const __test = {
   runImportGmail,
   browserOpenCommand,
   gmailConnectUrl,
+  parseGmailSyncPreferences,
 };

--- a/packages/sdk/src/agent-instructions.ts
+++ b/packages/sdk/src/agent-instructions.ts
@@ -55,6 +55,7 @@ export const AGENT_INSTRUCTIONS_BLOCK = [
   "- `acrm connect linkedin` connects LinkedIn through Agent CRM's hosted sync engine, or reports when the workspace is already connected. `acrm connect linkedin --status` checks status without starting a connect flow.",
   "- `acrm import csv ./leads.csv` imports people and companies from a CSV. It creates deals only when deal columns such as `deal_name` or `deal` are present.",
   "- `acrm import gmail` connects Gmail through Agent CRM's hosted sync engine and syncs people, email threads, and email messages.",
+  "- For Gmail CRM imports, ask for a backfill window and newsletter filtering before OAuth. Use `acrm import gmail --backfill-days 30 --exclude-newsletters`, `--backfill-days 90`, or `--backfill-since YYYY-MM-DD`; use `--include-newsletters` only when the user wants marketing/newsletter mail in the CRM.",
   "- `acrm import linkedin` imports existing contacts from the connected LinkedIn account, then starts hosted LinkedIn message-history backfill in the background. `acrm import linkedin --sync` imports already-stored LinkedIn messages from the hosted sync engine into the local workspace.",
   "- `acrm import linkedin <profile-url-or-slug>` imports one LinkedIn profile, upserts the person, and links their current employer as a company. Requires `APIFY_API_TOKEN` in `.env`.",
   "- `acrm import x <handle-or-url>` imports one X/Twitter profile. Requires `APIFY_API_TOKEN` in `.env`; if the result says `needs_enrichment`, run the `enrich-x-bio` skill.",


### PR DESCRIPTION
## Summary
- add Gmail import flags for 30/90 day backfill, custom since-date backfill, and newsletter inclusion/exclusion
- validate conflicting and invalid flag combinations before opening hosted OAuth
- update onboarding skill prompts to collect Gmail backfill and filtering preferences before OAuth

## Tests
- npm run build --workspace @agent-crm/cli
- npm run test --workspace @agent-crm/cli -- src/commands/import-gmail.test.ts

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add backfill and newsletter filtering flags to `acrm import gmail`
> - Adds `--backfill-days` (30 or 90), `--backfill-since` (YYYY-MM-DD), `--exclude-newsletters`, and `--include-newsletters` flags to the `acrm import gmail` subcommand in [import-gmail.ts](https://github.com/cluster-software/agent-crm/pull/155/files#diff-36789d97aa605afd689fd8e3680527a4ed53b7308da55e0aef8403eb0bb206bc).
> - Validates flags via `parseGmailSyncPreferences`, enforcing mutual exclusivity between `--backfill-days`/`--backfill-since` and `--exclude-newsletters`/`--include-newsletters`, throwing an `AcrmError` on conflicts or invalid values.
> - Forwards validated preferences as query params (`backfill_days`, `backfill_since`, `exclude_newsletters`) on the Gmail OAuth URL and includes a `gmail_sync_preferences` object in JSON output.
> - Updates onboarding instructions in [acrm-onboarding.md](https://github.com/cluster-software/agent-crm/pull/155/files#diff-62c6a245c0067c368907b06da492d53a7808aedf9a47d02a16704ed93f5688c8) to prompt users for backfill history and newsletter filtering preferences during setup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fcdbdfb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->