### PR TITLE
Use Agent CRM auth opener for hosted auth flows

### DIFF
--- a/.changeset/green-auth-windows.md
+++ b/.changeset/green-auth-windows.md
@@ -1,0 +1,5 @@
+---
+"@agent-crm/cli": minor
+---
+
+Use Agent CRM's in-app auth opener for hosted Gmail and LinkedIn auth flows when available.

--- a/packages/cli/skills/acrm-onboarding.md
+++ b/packages/cli/skills/acrm-onboarding.md
@@ -84,10 +84,9 @@ Use `AskUserQuestion` with this exact question and options (single-select, multi
 Powered by Agent CRM's hosted sync engine. Do **not** run a local Gmail
 contacts import.
 
-Gmail uses the same browser-side Cluster auth gate as LinkedIn. Do not
+Gmail uses the same hosted Cluster auth gate as LinkedIn. Do not
 ask the user for a Cluster org id before starting. The hosted connect page
-will infer the org from the user's Cluster browser session, or ask them to
-choose one if the session belongs to multiple orgs. Only pass
+will infer or create the org from the user's signed-in email domain. Only pass
 `--org-id <org-id>` when the user explicitly provides an org id or the
 workspace already has one configured.
 
@@ -127,13 +126,14 @@ acrm --json import gmail --backfill-since <YYYY-MM-DD> --exclude-newsletters
 Use `--include-newsletters` instead of `--exclude-newsletters` when the user
 chooses to include newsletters and marketing emails.
 
-This opens the Google OAuth URL in the user's browser automatically. Do
-not print `data.auth_url` unless the command fails to open the browser and
-the user needs the fallback URL. If you do need to show the fallback URL,
+When running inside the Agent CRM Electron app, this opens the hosted auth
+flow in the app. Outside the app, it falls back to the system browser. Do
+not print `data.auth_url` unless the command fails to open the auth window
+and the user needs the fallback URL. If you do need to show the fallback URL,
 print it as a bare URL on its own line, not as a Markdown link.
 
 ```md
-Your browser should now be open to connect Gmail.
+The Agent CRM auth window should now be open to connect Gmail.
 
 Pick your Google account and click Allow.
 
@@ -146,8 +146,9 @@ What `acrm import gmail` does now:
 
 1. Reads or creates `.agent-crm-cloud.json` next to the local workspace.
 2. Registers the cloud workspace with the hosted sync engine.
-3. Opens the hosted Gmail connect page in the user's browser. That page
-   checks Cluster auth, chooses the org, then starts Google OAuth.
+3. Opens the hosted Gmail connect page in Agent CRM when available, falling
+   back to the system browser. That page checks Cluster auth, resolves the
+   org from the signed-in email domain, then starts Google OAuth.
 4. Passes the selected Gmail backfill and newsletter filtering preferences
    to the hosted sync engine.
 5. Returns the hosted connect URL as `data.auth_url` for fallback/debugging.
@@ -192,7 +193,7 @@ Both require `APIFY_API_TOKEN` in `.env` next to the workspace. If missing, the 
 ### 4. Confirm + next step
 
 For Gmail, do not add a separate confirmation or next-step message after
-the OAuth browser-open copy above. Do not suggest `/prep-call`,
+the OAuth auth-window copy above. Do not suggest `/prep-call`,
 `/setup-transcripts`, or any other next step. The user still needs to
 finish OAuth first.
 

--- a/packages/cli/skills/connect-linkedin-to-acrm.md
+++ b/packages/cli/skills/connect-linkedin-to-acrm.md
@@ -44,12 +44,21 @@ echo "$CONNECT_JSON"
 if echo "$CONNECT_JSON" | jq -e '.data.connected == true' >/dev/null; then
   exit 0
 fi
-open "$(echo "$CONNECT_JSON" | jq -r '.data.auth_url')"
+AUTH_URL=$(echo "$CONNECT_JSON" | jq -r '.data.auth_url')
+if command -v agent-crm-open-url >/dev/null 2>&1; then
+  agent-crm-open-url "$AUTH_URL"
+elif command -v open >/dev/null 2>&1; then
+  open "$AUTH_URL"
+elif command -v xdg-open >/dev/null 2>&1; then
+  xdg-open "$AUTH_URL"
+else
+  echo "$AUTH_URL"
+fi
 ```
 
-Have the user finish Cluster auth and LinkedIn verification in the browser. If they belong to multiple Cluster organizations, the hosted page will ask which one to use. LinkedIn may ask for an email, SMS, authenticator-app code, or in-app sign-in approval.
+Have the user finish Cluster auth and LinkedIn verification in the Agent CRM auth window. Outside the Electron app this falls back to the system browser. The hosted page resolves the Cluster org from the signed-in email domain. LinkedIn may ask for an email, SMS, authenticator-app code, or in-app sign-in approval.
 
-After opening the browser, keep the agent turn active and poll for completion every 2 seconds. Do not surface import options until the status command verifies LinkedIn is connected:
+After opening the auth window, keep the agent turn active and poll for completion every 2 seconds. Do not surface import options until the status command verifies LinkedIn is connected:
 
 ```sh
 while true; do

--- a/packages/cli/src/commands/import-gmail.test.ts
+++ b/packages/cli/src/commands/import-gmail.test.ts
@@ -121,6 +121,12 @@ describe("importGoogleContacts", () => {
       command: "xdg-open",
       args: ["https://example.com"],
     });
+    expect(gmailCommandTest.browserOpenCommand("darwin", "https://example.com", {
+      ACRM_OPEN_URL_COMMAND: "/tmp/agent-crm-open-url",
+    })).toEqual({
+      command: "/tmp/agent-crm-open-url",
+      args: ["https://example.com"],
+    });
   });
 
   it("registers the cloud workspace and returns a hosted Gmail browser URL", async () => {

--- a/packages/cli/src/commands/import-gmail.ts
+++ b/packages/cli/src/commands/import-gmail.ts
@@ -32,7 +32,7 @@ export function attachGmailSubcommand(parent: Command): void {
     .description(
       "Connect Gmail through Agent CRM's hosted sync engine. Opens hosted Google OAuth and syncs people, email threads, and email messages into the cloud workspace.",
     )
-    .option("--no-open", "print the OAuth URL without opening it in a browser")
+    .option("--no-open", "print the OAuth URL without opening the auth window")
     .option("--org-id <org-id>", "Cluster organization id for hosted Gmail sync")
     .option("--backfill-days <days>", "Gmail backfill window in days. Supported values: 30, 90")
     .option("--backfill-since <YYYY-MM-DD>", "Gmail backfill start date")
@@ -59,7 +59,9 @@ export function attachGmailSubcommand(parent: Command): void {
             [
               opts.open === false
                 ? "Open this URL to connect Gmail:"
-                : "Opening browser to connect Gmail. If it doesn't open, paste this URL:",
+                : process.env.ACRM_OPEN_URL_COMMAND
+                  ? "Opening Agent CRM to connect Gmail. If it doesn't open, paste this URL:"
+                  : "Opening browser to connect Gmail. If it doesn't open, paste this URL:",
               result.auth_url,
               "",
               "After OAuth, Gmail sync runs in the background through Agent CRM's hosted sync engine.",
@@ -217,7 +219,10 @@ function hasGmailSyncPreferences(opts: GmailSyncPreferences): boolean {
 function browserOpenCommand(
   platform: NodeJS.Platform,
   url: string,
+  env: NodeJS.ProcessEnv = process.env,
 ): { command: string; args: string[] } {
+  const appUrlOpener = env.ACRM_OPEN_URL_COMMAND?.trim();
+  if (appUrlOpener) return { command: appUrlOpener, args: [url] };
   if (platform === "darwin") return { command: "open", args: [url] };
   if (platform === "win32") {
     return { command: "cmd", args: ["/c", "start", "", url] };


### PR DESCRIPTION
## Summary
- make Gmail import prefer `ACRM_OPEN_URL_COMMAND` when Agent CRM provides an in-app auth opener
- update Gmail and LinkedIn onboarding skill docs for in-app hosted auth flows
- add coverage for the app-provided auth opener command selection

## Tests
- `npm run build --workspace @agent-crm/sdk`
- `npm run build --workspace @agent-crm/cli`
- `npm run test --workspace @agent-crm/cli -- import-gmail`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use Agent CRM in-app opener for hosted Gmail and LinkedIn auth flows
> - `browserOpenCommand` in [import-gmail.ts](https://github.com/cluster-software/agent-crm/pull/159/files#diff-36789d97aa605afd689fd8e3680527a4ed53b7308da55e0aef8403eb0bb206bc) now checks for an `ACRM_OPEN_URL_COMMAND` environment variable; if set, it invokes that command with the auth URL instead of the platform-specific browser opener.
> - Console messages and `--no-open` help text updated to reference "Agent CRM auth window" when `ACRM_OPEN_URL_COMMAND` is present.
> - The LinkedIn connect skill script in [connect-linkedin-to-acrm.md](https://github.com/cluster-software/agent-crm/pull/159/files#diff-b969a2be9eded716d7c83777adc64e3813af3bfc9f1bb352f2a6e1438ab5e35f) is updated to try `agent-crm-open-url` before falling back to `open`/`xdg-open`.
> - Behavioral Change: when `ACRM_OPEN_URL_COMMAND` is set, URL opening bypasses all platform-specific logic and delegates entirely to that command.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf9f0a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->