### PR TITLE
Open hosted auth in the system browser

### DIFF
--- a/.changeset/default-browser-auth.md
+++ b/.changeset/default-browser-auth.md
@@ -1,0 +1,5 @@
+---
+"@agent-crm/cli": patch
+---
+
+Open hosted Gmail and LinkedIn auth flows in the system browser instead of the Electron app.

--- a/packages/cli/skills/acrm-onboarding.md
+++ b/packages/cli/skills/acrm-onboarding.md
@@ -126,14 +126,13 @@ acrm --json import gmail --backfill-since <YYYY-MM-DD> --exclude-newsletters
 Use `--include-newsletters` instead of `--exclude-newsletters` when the user
 chooses to include newsletters and marketing emails.
 
-When running inside the Agent CRM Electron app, this opens the hosted auth
-flow in the app. Outside the app, it falls back to the system browser. Do
-not print `data.auth_url` unless the command fails to open the auth window
-and the user needs the fallback URL. If you do need to show the fallback URL,
-print it as a bare URL on its own line, not as a Markdown link.
+This opens the hosted auth flow in the user's default browser. Do not print
+`data.auth_url` unless the command fails to open the browser and the user
+needs the fallback URL. If you do need to show the fallback URL, print it as a
+bare URL on its own line, not as a Markdown link.
 
 ```md
-The Agent CRM auth window should now be open to connect Gmail.
+Your browser should now be open to connect Gmail.
 
 Pick your Google account and click Allow.
 
@@ -146,9 +145,9 @@ What `acrm import gmail` does now:
 
 1. Reads or creates `.agent-crm-cloud.json` next to the local workspace.
 2. Registers the cloud workspace with the hosted sync engine.
-3. Opens the hosted Gmail connect page in Agent CRM when available, falling
-   back to the system browser. That page checks Cluster auth, resolves the
-   org from the signed-in email domain, then starts Google OAuth.
+3. Opens the hosted Gmail connect page in the user's default browser. That
+   page checks Cluster auth, resolves the org from the signed-in email domain,
+   then starts Google OAuth.
 4. Passes the selected Gmail backfill and newsletter filtering preferences
    to the hosted sync engine.
 5. Returns the hosted connect URL as `data.auth_url` for fallback/debugging.

--- a/packages/cli/skills/connect-linkedin-to-acrm.md
+++ b/packages/cli/skills/connect-linkedin-to-acrm.md
@@ -45,9 +45,7 @@ if echo "$CONNECT_JSON" | jq -e '.data.connected == true' >/dev/null; then
   exit 0
 fi
 AUTH_URL=$(echo "$CONNECT_JSON" | jq -r '.data.auth_url')
-if command -v agent-crm-open-url >/dev/null 2>&1; then
-  agent-crm-open-url "$AUTH_URL"
-elif command -v open >/dev/null 2>&1; then
+if command -v open >/dev/null 2>&1; then
   open "$AUTH_URL"
 elif command -v xdg-open >/dev/null 2>&1; then
   xdg-open "$AUTH_URL"
@@ -56,9 +54,9 @@ else
 fi
 ```
 
-Have the user finish Cluster auth and LinkedIn verification in the Agent CRM auth window. Outside the Electron app this falls back to the system browser. The hosted page resolves the Cluster org from the signed-in email domain. LinkedIn may ask for an email, SMS, authenticator-app code, or in-app sign-in approval.
+Have the user finish Cluster auth and LinkedIn verification in the default browser. The hosted page resolves the Cluster org from the signed-in email domain. LinkedIn may ask for an email, SMS, authenticator-app code, or in-app sign-in approval.
 
-After opening the auth window, keep the agent turn active and poll for completion every 2 seconds. Do not surface import options until the status command verifies LinkedIn is connected:
+After opening the browser, keep the agent turn active and poll for completion every 2 seconds. Do not surface import options until the status command verifies LinkedIn is connected:
 
 ```sh
 while true; do

--- a/packages/cli/src/commands/import-gmail.test.ts
+++ b/packages/cli/src/commands/import-gmail.test.ts
@@ -121,12 +121,6 @@ describe("importGoogleContacts", () => {
       command: "xdg-open",
       args: ["https://example.com"],
     });
-    expect(gmailCommandTest.browserOpenCommand("darwin", "https://example.com", {
-      ACRM_OPEN_URL_COMMAND: "/tmp/agent-crm-open-url",
-    })).toEqual({
-      command: "/tmp/agent-crm-open-url",
-      args: ["https://example.com"],
-    });
   });
 
   it("registers the cloud workspace and returns a hosted Gmail browser URL", async () => {

--- a/packages/cli/src/commands/import-gmail.ts
+++ b/packages/cli/src/commands/import-gmail.ts
@@ -32,7 +32,7 @@ export function attachGmailSubcommand(parent: Command): void {
     .description(
       "Connect Gmail through Agent CRM's hosted sync engine. Opens hosted Google OAuth and syncs people, email threads, and email messages into the cloud workspace.",
     )
-    .option("--no-open", "print the OAuth URL without opening the auth window")
+    .option("--no-open", "print the OAuth URL without opening the browser")
     .option("--org-id <org-id>", "Cluster organization id for hosted Gmail sync")
     .option("--backfill-days <days>", "Gmail backfill window in days. Supported values: 30, 90")
     .option("--backfill-since <YYYY-MM-DD>", "Gmail backfill start date")
@@ -59,9 +59,7 @@ export function attachGmailSubcommand(parent: Command): void {
             [
               opts.open === false
                 ? "Open this URL to connect Gmail:"
-                : process.env.ACRM_OPEN_URL_COMMAND
-                  ? "Opening Agent CRM to connect Gmail. If it doesn't open, paste this URL:"
-                  : "Opening browser to connect Gmail. If it doesn't open, paste this URL:",
+                : "Opening browser to connect Gmail. If it doesn't open, paste this URL:",
               result.auth_url,
               "",
               "After OAuth, Gmail sync runs in the background through Agent CRM's hosted sync engine.",
@@ -218,11 +216,8 @@ function hasGmailSyncPreferences(opts: GmailSyncPreferences): boolean {
 
 function browserOpenCommand(
   platform: NodeJS.Platform,
-  url: string,
-  env: NodeJS.ProcessEnv = process.env,
+  url: string
 ): { command: string; args: string[] } {
-  const appUrlOpener = env.ACRM_OPEN_URL_COMMAND?.trim();
-  if (appUrlOpener) return { command: appUrlOpener, args: [url] };
   if (platform === "darwin") return { command: "open", args: [url] };
   if (platform === "win32") {
     return { command: "cmd", args: ["/c", "start", "", url] };


### PR DESCRIPTION
## Summary
- update Gmail auth launch behavior to use the system browser directly
- remove the Electron app URL-opener override from the Gmail command and tests
- update onboarding and LinkedIn sync skill docs to guide users through browser-based auth
- add a patch changeset for @agent-crm/cli

## Verification
- npm run build
- npm run test --workspace @agent-crm/cli -- import-gmail.test.ts
- git diff --check

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open hosted Gmail and LinkedIn auth flows in the system browser
> - Replaces the `ACRM_OPEN_URL_COMMAND` override (used to open auth in the Electron app) with platform-native commands: `open` on macOS, `cmd /c start` on Windows, and `xdg-open` on Linux.
> - Updates CLI messaging to always say 'Opening browser...' rather than conditionally referencing an app opener.
> - Updates skill documentation for Gmail and LinkedIn onboarding to reflect that auth completes in the default browser.
> - Behavioral Change: `ACRM_OPEN_URL_COMMAND` is no longer honored; any environment using that override will now open the system browser instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de23f2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->