### PR TITLE
Import LinkedIn profile photos locally

### DIFF
--- a/packages/cli/src/commands/import-linkedin-relations.test.ts
+++ b/packages/cli/src/commands/import-linkedin-relations.test.ts
@@ -25,6 +25,7 @@ describe("importLinkedinRelations", () => {
           headline: "Founder at Analytical Engines",
           public_identifier: "ada-lovelace",
           public_profile_url: "https://www.linkedin.com/in/ada-lovelace/",
+          profile_picture_url: "https://media.example.com/ada.jpg",
         }),
       ],
     });
@@ -32,6 +33,7 @@ describe("importLinkedinRelations", () => {
     expect(result.stats.people_created).toBe(1);
     await expect(valueFor(ws, "people", "linkedin_url")).resolves.toBe("linkedin.com/in/ada-lovelace");
     await expect(valueFor(ws, "people", "name")).resolves.toBe("Ada Lovelace");
+    await expect(valueFor(ws, "people", "profile_picture_url")).resolves.toBe("https://media.example.com/ada.jpg");
     await expect(valueFor(ws, "people", "job_title")).resolves.toBe("Founder at Analytical Engines");
     await expect(valueFor(ws, "people", "linkedin_connected_at")).resolves.toBe("2025-03-15T15:16:09.000Z");
     await expect(countValues(ws, "source_keys")).resolves.toBe(1);

--- a/packages/cli/src/commands/import-linkedin.test.ts
+++ b/packages/cli/src/commands/import-linkedin.test.ts
@@ -33,6 +33,7 @@ describe("import linkedin command", () => {
       headline: "Founder at Analytical Engines",
       public_identifier: "ada-lovelace",
       public_profile_url: "https://www.linkedin.com/in/ada-lovelace/",
+      profile_picture_url: "https://media.example.com/ada.jpg",
     };
     const fetchMock = vi.fn(async (url: string) => {
       const parsed = new URL(url);
@@ -84,6 +85,7 @@ describe("import linkedin command", () => {
       const reopened = await Workspace.open(workspacePath);
       try {
         await expect(singleValue(reopened, "linkedin_url")).resolves.toBe("linkedin.com/in/ada-lovelace");
+        await expect(singleValue(reopened, "profile_picture_url")).resolves.toBe("https://media.example.com/ada.jpg");
         await expect(singleValue(reopened, "linkedin_connected_at")).resolves.toBe("2025-03-15T15:16:09.000Z");
         await expect(singleValue(reopened, "linkedin_url", "companies")).resolves.toBe("linkedin.com/company/analytical-engines");
       } finally {

--- a/packages/sdk/src/integrations/linkedin-mapping.ts
+++ b/packages/sdk/src/integrations/linkedin-mapping.ts
@@ -3,6 +3,7 @@ import type { LinkedInProfile } from "./apify-linkedin.js";
 export type MappedPerson = {
   name: string | null;
   linkedin_url: string | null;
+  profile_picture_url: string | null;
   job_title: string | null;
 };
 
@@ -48,6 +49,15 @@ export function mapProfile(profile: LinkedInProfile): MappedProfile {
     (pickString(profile.publicIdentifier)
       ? `https://www.linkedin.com/in/${pickString(profile.publicIdentifier)}`
       : null);
+  const profilePictureUrl =
+    pickString(profile.profilePictureUrl) ??
+    pickString(profile.profile_picture_url) ??
+    pickString(profile.profileImageUrl) ??
+    pickString(profile.profile_image_url) ??
+    pickString(profile.pictureUrl) ??
+    pickString(profile.picture_url) ??
+    pickString(profile.imageUrl) ??
+    pickString(profile.image_url);
 
   const current = firstPosition(profile);
   const experience = Array.isArray(profile.experience)
@@ -70,6 +80,7 @@ export function mapProfile(profile: LinkedInProfile): MappedProfile {
     person: {
       name: fullName || null,
       linkedin_url: linkedinUrl,
+      profile_picture_url: profilePictureUrl,
       job_title: jobTitle,
     },
     company: {

--- a/packages/sdk/src/operations/import-communication.test.ts
+++ b/packages/sdk/src/operations/import-communication.test.ts
@@ -47,11 +47,13 @@ describe("importCommunicationBatch", () => {
             sourceKey: "gmail:me@example.com:email:alice@example.com",
             email: "alice@example.com",
             displayName: "Alice A",
+            profilePictureUrl: "https://media.example.com/alice-a.jpg",
           },
           {
             sourceKey: "gmail:other@example.com:email:alice@example.com",
             email: "alice@example.com",
             displayName: "Alice B",
+            profilePictureUrl: "https://media.example.com/alice-b.jpg",
           },
         ],
         communicationThreads: [],
@@ -60,8 +62,10 @@ describe("importCommunicationBatch", () => {
 
       await expect(recordCount(workspace, "people")).resolves.toBe(1);
       await expect(activeValueCount(workspace, "people", "name")).resolves.toBe(1);
+      await expect(activeValueCount(workspace, "people", "profile_picture_url")).resolves.toBe(1);
       await expect(activeValueCount(workspace, "people", "source_keys")).resolves.toBe(2);
       await expect(singleDisplayValue(workspace, "people", "name")).resolves.toBe("Alice B");
+      await expect(singleDisplayValue(workspace, "people", "profile_picture_url")).resolves.toBe("https://media.example.com/alice-b.jpg");
     });
   });
 });

--- a/packages/sdk/src/operations/import-communication.ts
+++ b/packages/sdk/src/operations/import-communication.ts
@@ -22,6 +22,7 @@ export type CommunicationImportPerson = {
   email?: string;
   displayName?: string;
   linkedinUrl?: string;
+  profilePictureUrl?: string;
   companySourceKey?: string;
 };
 
@@ -236,6 +237,9 @@ export async function importCommunicationBatch(
     }
     if (person.displayName) {
       enqueueSingle(writer, existingValues, plan, "name", "personal-name", person.displayName);
+    }
+    if (person.profilePictureUrl) {
+      enqueueSingle(writer, existingValues, plan, "profile_picture_url", "url", person.profilePictureUrl);
     }
     if (person.companySourceKey) {
       const companyId = resolveRecordId("companies", person.companySourceKey, companyPlans, plannedSourceIndex);

--- a/packages/sdk/src/operations/import-linkedin-relations.ts
+++ b/packages/sdk/src/operations/import-linkedin-relations.ts
@@ -57,6 +57,7 @@ type NormalizedRelation = {
   relation: LinkedinRelation;
   sourceKey: string;
   linkedinUrl: string | null;
+  profilePictureUrl: string | null;
   fullName: string | null;
   headline: string | null;
   connectedAt: string | null;
@@ -215,6 +216,9 @@ export async function importLinkedinRelations(
     if (relation.fullName) {
       changed = enqueueSingleIfMissing(writer, existingValues, plan, "name", "personal-name", relation.fullName, provenance) || changed;
     }
+    if (relation.profilePictureUrl) {
+      changed = enqueueSingleIfMissing(writer, existingValues, plan, "profile_picture_url", "url", relation.profilePictureUrl, provenance) || changed;
+    }
     if (relation.headline) {
       changed = enqueueSingleIfMissing(writer, existingValues, plan, "job_title", "text", relation.headline, provenance) || changed;
     }
@@ -278,6 +282,7 @@ function normalizeRelation(relation: LinkedinRelation): NormalizedRelation | nul
     relation,
     sourceKey,
     linkedinUrl: relationLinkedinUrl(relation),
+    profilePictureUrl: relationProfilePictureUrl(relation),
     fullName: relationFullName(relation),
     headline: cleanString(relation.headline),
     connectedAt: relationConnectedAt(relation.created_at),
@@ -310,6 +315,19 @@ function relationFullName(relation: LinkedinRelation): string | null {
     .join(" ")
     .trim();
   return full || null;
+}
+
+function relationProfilePictureUrl(relation: LinkedinRelation): string | null {
+  return stringField(relation, [
+    "profile_picture_url",
+    "profilePictureUrl",
+    "profile_image_url",
+    "profileImageUrl",
+    "picture_url",
+    "pictureUrl",
+    "avatar_url",
+    "avatarUrl",
+  ]);
 }
 
 function relationConnectedAt(value: LinkedinRelation["created_at"]): string | null {

--- a/packages/sdk/src/operations/import-linkedin.ts
+++ b/packages/sdk/src/operations/import-linkedin.ts
@@ -147,6 +147,18 @@ export async function importLinkedinProfile(
     });
   }
 
+  if (mapped.person.profile_picture_url) {
+    await setSingleValue(lix, {
+      object_slug: "people",
+      record_id: personId,
+      attribute_slug: "profile_picture_url",
+      attribute_type: "url",
+      value: mapped.person.profile_picture_url,
+      source: SOURCE,
+      provenance,
+    });
+  }
+
   if (mapped.person.job_title) {
     await setSingleValue(lix, {
       object_slug: "people",

--- a/packages/sdk/src/workspace/seeds.ts
+++ b/packages/sdk/src/workspace/seeds.ts
@@ -43,6 +43,7 @@ const ATTRIBUTES: AttributeSeed[] = [
   { object_slug: "people", attribute_slug: "phone_numbers", title: "Phone numbers", attribute_type: "phone-number", is_multivalued: true, is_unique: true },
   { object_slug: "people", attribute_slug: "job_title", title: "Job title", attribute_type: "text", is_multivalued: false, is_unique: false },
   { object_slug: "people", attribute_slug: "linkedin_url", title: "LinkedIn", attribute_type: "url", is_multivalued: false, is_unique: false },
+  { object_slug: "people", attribute_slug: "profile_picture_url", title: "Profile picture", attribute_type: "url", is_multivalued: false, is_unique: false },
   { object_slug: "people", attribute_slug: "linkedin_connected_at", title: "LinkedIn connected at", attribute_type: "timestamp", is_multivalued: false, is_unique: false },
   { object_slug: "people", attribute_slug: "twitter_url", title: "Twitter / X", attribute_type: "url", is_multivalued: false, is_unique: false },
   { object_slug: "people", attribute_slug: "source_keys", title: "Source keys", attribute_type: "text", is_multivalued: true, is_unique: true },


### PR DESCRIPTION
## Summary
- seed profile_picture_url as a people attribute
- import profile photo URLs from LinkedIn profile, relation, and communication payloads
- add coverage for LinkedIn and communication imports

## Tests
- npm test

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Import LinkedIn profile photos and store them as `people.profile_picture_url`
> - Adds a `profile_picture_url` seed attribute (type `url`, single-valued) to the people schema in [seeds.ts](https://github.com/cluster-software/agent-crm/pull/168/files#diff-e4ce857ac7ed9f022d6d03e8ee46e137426655be361db110ec330791dfe8ab77).
> - Extracts profile picture URLs from LinkedIn profiles and relations by checking multiple common field name variants, then writes the value via `setSingleValue` or `enqueueSingleIfMissing`.
> - Extends communication import payloads to accept `profilePictureUrl` and write it to `people.profile_picture_url` during batch import.
> - Behavioral Change: existing workspaces will gain the new `profile_picture_url` attribute on their next schema ensure run.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db735e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->