### PR TITLE
chore: add profile photo changeset

### DIFF
--- a/.changeset/pretty-profile-photos.md
+++ b/.changeset/pretty-profile-photos.md
@@ -1,0 +1,6 @@
+---
+"@agent-crm/cli": patch
+"@agent-crm/sdk": patch
+---
+
+Import LinkedIn profile photo URLs into `people.profile_picture_url` during LinkedIn and communication imports.


### PR DESCRIPTION
## Summary
- add a changeset for the merged LinkedIn profile photo import work
- mark both @agent-crm/sdk and @agent-crm/cli for patch releases

## Validation
- npx changeset status --since=origin/main

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add changeset for LinkedIn profile photo URL import to `profile_picture_url`
> Adds a changeset file documenting patch releases for `@agent-crm/cli` and `@agent-crm/sdk`. The changeset notes that LinkedIn profile photo URLs will be imported into `people.profile_picture_url` during LinkedIn and communication imports.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a4542c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->