### PR TITLE
Remove onboarding workspace preflight

### DIFF
--- a/.changeset/remove-onboarding-workspace-preflight.md
+++ b/.changeset/remove-onboarding-workspace-preflight.md
@@ -1,0 +1,5 @@
+---
+"@agent-crm/cli": patch
+---
+
+Remove the `acrm-onboarding` workspace preflight so onboarding assumes it is run inside an existing workspace.

--- a/packages/cli/skills/acrm-onboarding.md
+++ b/packages/cli/skills/acrm-onboarding.md
@@ -1,32 +1,19 @@
 ---
 name: acrm-onboarding
-description: Onboard a new Agent CRM user — initialize a `.acrm` workspace (if needed), then walk them through picking a first data source (Gmail / LinkedIn sync / CSV / LinkedIn or X profile) and importing it. Trigger phrasings — "onboard me", "set up agent crm", "get started with acrm", "I'm new to acrm", or a bare `/acrm-onboarding`.
+description: Onboard a new Agent CRM user in an existing `.acrm` workspace — walk them through picking a first data source (Gmail / LinkedIn sync / CSV / LinkedIn or X profile) and importing it. Trigger phrasings — "onboard me", "set up agent crm", "get started with acrm", "I'm new to acrm", or a bare `/acrm-onboarding`.
 ---
 
 # acrm-onboarding
 
-The first-run flow for Agent CRM. Goal: in one conversation, take a user from "nothing" to "populated `.acrm` with their real contacts" so the rest of the skills have something to chew on.
+The first-run flow for Agent CRM. Goal: in one conversation, help a user populate their existing `.acrm` workspace with real contacts so the rest of the skills have something to chew on.
 
 ## Run
 
-### 1. Greet + workspace check
+### 1. Greet
 
 Say:
 
 > Welcome to Agent CRM — the headless CRM for Claude. Let's get you set up.
-
-Check whether a workspace already exists in this directory:
-
-```sh
-acrm execute "SELECT 1" --json
-```
-
-- If that succeeds, you're already inside a workspace — skip to step 2.
-- If it fails with `ACRM_ERROR_NO_WORKSPACE`, ask the user what to name their workspace (default: `pipeline.acrm`) and run:
-
-  ```sh
-  acrm init <name>.acrm
-  ```
 
 ### 2. Pick a data source
 
@@ -172,7 +159,6 @@ Keep the close short - pick the most relevant one or two suggestions, not a feat
 
 ## Hard rules
 
-- **Never** fabricate a workspace path or skip the `acrm init` step. If no workspace exists, the user must explicitly name one.
 - **Never** silently run a destructive command.
 - **Do not use `gws` for Gmail.** Gmail now goes through the hosted sync engine.
 - **Don't** fabricate OAuth credentials or paper over auth errors. The user owns the Google consent flow.

--- a/packages/cli/src/skills.test.ts
+++ b/packages/cli/src/skills.test.ts
@@ -2,13 +2,15 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("bundled skills", () => {
-  it("does not ask acrm-onboarding to manually preflight CLI versions", () => {
+  it("does not ask acrm-onboarding to run preflight checks", () => {
     const skill = readFileSync(
       new URL("../skills/acrm-onboarding.md", import.meta.url),
       "utf8",
     );
 
-    expect(skill).toContain('acrm execute "SELECT 1" --json');
+    expect(skill).not.toContain('acrm execute "SELECT 1" --json');
+    expect(skill).not.toContain("ACRM_ERROR_NO_WORKSPACE");
+    expect(skill).not.toContain("acrm init");
     expect(skill).not.toContain("acrm --version");
     expect(skill).not.toContain("npm view @agent-crm/cli version");
     expect(skill).not.toContain("npm install -g @agent-crm/cli@latest");


### PR DESCRIPTION
## Summary
- remove the `acrm execute "SELECT 1" --json` workspace preflight from the bundled onboarding skill
- update onboarding copy to assume an existing `.acrm` workspace
- add regression assertions and a CLI patch changeset

## Tests
- `npm run test --workspace @agent-crm/cli -- src/skills.test.ts`
- `npm run check:agent-instructions --workspace @agent-crm/cli`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove workspace preflight from `acrm-onboarding` skill
> The `acrm-onboarding` skill now assumes it runs inside an existing `.acrm` workspace, removing the preflight checks that previously ran `acrm execute "SELECT 1" --json`, handled `ACRM_ERROR_NO_WORKSPACE`, and called `acrm init`. The skill spec and its bundled test in [`skills.test.ts`](https://github.com/cluster-software/agent-crm/pull/176/files#diff-3cb7388daa94e87db63f696e6dda6796ebdf67994a2c50402cd4081b062ebb3f) are updated to assert these commands are absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 26dfdcb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->