### PR TITLE
fix(cli): remove Granola version preflight

### DIFF
--- a/.changeset/remove-granola-version-preflight.md
+++ b/.changeset/remove-granola-version-preflight.md
@@ -1,0 +1,5 @@
+---
+"@agent-crm/cli": patch
+---
+
+Remove the stale `acrm --version` preflight from the Granola connection skill.

--- a/packages/cli/skills/connect-granola-to-acrm.md
+++ b/packages/cli/skills/connect-granola-to-acrm.md
@@ -13,7 +13,6 @@ troubleshoot Granola with Agent CRM.
 1. Confirm the workspace is ready:
 
    ```sh
-   acrm --version
    acrm connect granola --status --json
    ```
 

--- a/packages/cli/src/skills.test.ts
+++ b/packages/cli/src/skills.test.ts
@@ -1,7 +1,16 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("bundled skills", () => {
+  it("does not ask bundled skills to run version preflight checks", () => {
+    const skillsDir = new URL("../skills/", import.meta.url);
+    for (const filename of readdirSync(skillsDir)) {
+      if (!filename.endsWith(".md")) continue;
+      const skill = readFileSync(new URL(filename, skillsDir), "utf8");
+      expect(skill, filename).not.toContain("acrm --version");
+    }
+  });
+
   it("does not ask acrm-onboarding to run preflight checks", () => {
     const skill = readFileSync(
       new URL("../skills/acrm-onboarding.md", import.meta.url),


### PR DESCRIPTION
## Summary
- remove the stale acrm --version command from the Granola connection skill
- add coverage that no bundled CLI skill asks agents to run acrm --version
- add a patch changeset for @agent-crm/cli

## Tests
- npx vitest run packages/cli/src/skills.test.ts
- npm run build --workspace @agent-crm/sdk
- npm run check:agent-instructions --workspace @agent-crm/cli

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `acrm --version` preflight from the Granola connection skill
> - Removes the `acrm --version` command from Step 1 of [connect-granola-to-acrm.md](https://github.com/cluster-software/agent-crm/pull/180/files#diff-0a144735bae7904a6aa5811a742bfc62cfaf3335e87d54081efe97688ea797da); the step now only runs `acrm connect granola --status --json`.
> - Adds a test in [skills.test.ts](https://github.com/cluster-software/agent-crm/pull/180/files#diff-3cb7388daa94e87db63f696e6dda6796ebdf67994a2c50402cd4081b062ebb3f) that scans all `.md` files in the skills directory and fails if any contain `acrm --version`, preventing regressions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a92b59.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->