### PR TITLE
fix: make SDK Postgres writes transactional

### DIFF
--- a/.changeset/fix-gmail-communication-import.md
+++ b/.changeset/fix-gmail-communication-import.md
@@ -1,0 +1,5 @@
+---
+"@agent-crm/sdk": patch
+---
+
+Fix Gmail communication imports against Postgres by avoiding oversized normalized-key index entries for long text values and making the import write transactionally.

--- a/.changeset/fix-gmail-communication-import.md
+++ b/.changeset/fix-gmail-communication-import.md
@@ -1,5 +1,8 @@
 ---
 "@agent-crm/sdk": patch
+"@agent-crm/cli": patch
 ---
 
 Fix Postgres imports by avoiding oversized normalized-key index entries for long text values and making SDK write operations transactional so failed value inserts do not leave partial record shells.
+
+Honor direct SDK Postgres connection strings with `channel_binding=require`, and update the records dedupe help text to match its transactional behavior.

--- a/.changeset/fix-gmail-communication-import.md
+++ b/.changeset/fix-gmail-communication-import.md
@@ -2,4 +2,4 @@
 "@agent-crm/sdk": patch
 ---
 
-Fix Gmail communication imports against Postgres by avoiding oversized normalized-key index entries for long text values and making the import write transactionally.
+Fix Postgres imports by avoiding oversized normalized-key index entries for long text values and making Gmail and LinkedIn import writes transactional.

--- a/.changeset/fix-gmail-communication-import.md
+++ b/.changeset/fix-gmail-communication-import.md
@@ -2,4 +2,4 @@
 "@agent-crm/sdk": patch
 ---
 
-Fix Postgres imports by avoiding oversized normalized-key index entries for long text values and making Gmail and LinkedIn import writes transactional.
+Fix Postgres imports by avoiding oversized normalized-key index entries for long text values and making SDK write operations transactional so failed value inserts do not leave partial record shells.

--- a/packages/cli/src/commands/records.ts
+++ b/packages/cli/src/commands/records.ts
@@ -249,10 +249,8 @@ What it does:
      record already had an active ref to the keeper.
   3. Deletes the discarded record from \`acrm_record\`.
 
-Note: this command currently applies the validated plan as a series of writes
-rather than one workspace transaction. Use \`--dry-run\` to inspect the plan.
-If a step fails midway, re-run the command — the operation is idempotent once
-the duplicate row has been redirected.
+Note: the final merge writes run in one workspace transaction. Use \`--dry-run\`
+to inspect the validated plan before applying it.
 `,
     )
     .action(async (object: string, opts: DedupeOpts) => {

--- a/packages/sdk/src/db/postgres.test.ts
+++ b/packages/sdk/src/db/postgres.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { PostgresDatabase, type Queryable } from "./postgres.js";
+import type { AcrmDatabase, SqlValue } from "./types.js";
+
+describe("PostgresDatabase", () => {
+  it("rolls back failed pool-backed transactions", async () => {
+    const pool = new TransactionalPool();
+    const db = PostgresDatabase.fromQueryable(pool);
+
+    await expectRollback(db);
+
+    expect(pool.releaseCount).toBe(1);
+    expect(pool.queries).toEqual([
+      "CREATE TABLE tx_probe (value text)",
+      "BEGIN",
+      "INSERT INTO tx_probe (value) VALUES ($1)",
+      "ROLLBACK",
+      "SELECT value FROM tx_probe",
+    ]);
+  });
+
+  it("rolls back failed client-backed transactions", async () => {
+    const client = new TransactionalQueryable();
+    const db = PostgresDatabase.fromQueryable(client);
+
+    await expectRollback(db);
+
+    expect(client.queries).toEqual([
+      "CREATE TABLE tx_probe (value text)",
+      "BEGIN",
+      "INSERT INTO tx_probe (value) VALUES ($1)",
+      "ROLLBACK",
+      "SELECT value FROM tx_probe",
+    ]);
+  });
+});
+
+async function expectRollback(db: AcrmDatabase): Promise<void> {
+  await db.execute("CREATE TABLE tx_probe (value text)");
+
+  await expect(db.transaction(async (tx) => {
+    await tx.execute("INSERT INTO tx_probe (value) VALUES ($1)", ["rolled back"]);
+    throw new Error("forced rollback");
+  })).rejects.toThrow("forced rollback");
+
+  const result = await db.execute("SELECT value FROM tx_probe");
+  expect(result.rows).toEqual([]);
+}
+
+class TransactionalQueryable implements Queryable {
+  readonly queries: string[] = [];
+  private rows: string[] = [];
+  private transactionRows: string[] | null = null;
+
+  async query(
+    sql: string,
+    params: ReadonlyArray<SqlValue> = [],
+  ): Promise<{ rows: Record<string, unknown>[]; rowCount: number | null }> {
+    this.queries.push(sql);
+
+    if (sql === "BEGIN") {
+      this.transactionRows = [...this.rows];
+      return { rows: [], rowCount: null };
+    }
+    if (sql === "COMMIT") {
+      if (this.transactionRows) this.rows = this.transactionRows;
+      this.transactionRows = null;
+      return { rows: [], rowCount: null };
+    }
+    if (sql === "ROLLBACK") {
+      this.transactionRows = null;
+      return { rows: [], rowCount: null };
+    }
+    if (/^CREATE TABLE tx_probe\b/i.test(sql)) {
+      return { rows: [], rowCount: null };
+    }
+    if (/^INSERT INTO tx_probe\b/i.test(sql)) {
+      this.activeRows().push(String(params[0]));
+      return { rows: [], rowCount: 1 };
+    }
+    if (/^SELECT value FROM tx_probe\b/i.test(sql)) {
+      return {
+        rows: this.rows.map((value) => ({ value })),
+        rowCount: this.rows.length,
+      };
+    }
+
+    throw new Error(`unexpected SQL: ${sql}`);
+  }
+
+  private activeRows(): string[] {
+    return this.transactionRows ?? this.rows;
+  }
+}
+
+class TransactionalPool extends TransactionalQueryable {
+  releaseCount = 0;
+
+  async connect(): Promise<Queryable & { release(): void }> {
+    return {
+      query: (sql, params) => this.query(sql, params),
+      release: () => {
+        this.releaseCount++;
+      },
+    };
+  }
+}

--- a/packages/sdk/src/db/postgres.test.ts
+++ b/packages/sdk/src/db/postgres.test.ts
@@ -3,6 +3,29 @@ import { PostgresDatabase, type Queryable } from "./postgres.js";
 import type { AcrmDatabase, SqlValue } from "./types.js";
 
 describe("PostgresDatabase", () => {
+  it("maps direct connection string channel binding params into node-postgres options", async () => {
+    const required = PostgresDatabase.connect(
+      "postgresql://user:pass@example.com/db?channel_binding=require",
+    );
+    const preferred = PostgresDatabase.connect(
+      "postgresql://user:pass@example.com/db?channel_binding=prefer",
+    );
+    const disabled = PostgresDatabase.connect(
+      "postgresql://user:pass@example.com/db?channel_binding=disable",
+    );
+    try {
+      expect(poolOptions(required).enableChannelBinding).toBe(true);
+      expect(poolOptions(preferred).enableChannelBinding).toBe(true);
+      expect(poolOptions(disabled).enableChannelBinding).toBeUndefined();
+    } finally {
+      await Promise.all([
+        required.close(),
+        preferred.close(),
+        disabled.close(),
+      ]);
+    }
+  });
+
   it("rolls back failed pool-backed transactions", async () => {
     const pool = new TransactionalPool();
     const db = PostgresDatabase.fromQueryable(pool);
@@ -104,6 +127,12 @@ async function expectRollback(db: AcrmDatabase): Promise<void> {
 
   const result = await db.execute("SELECT value FROM tx_probe");
   expect(result.rows).toEqual([]);
+}
+
+function poolOptions(db: PostgresDatabase): { enableChannelBinding?: boolean } {
+  return (db as unknown as {
+    queryable: { options: { enableChannelBinding?: boolean } };
+  }).queryable.options;
 }
 
 class TransactionalQueryable implements Queryable {

--- a/packages/sdk/src/db/postgres.test.ts
+++ b/packages/sdk/src/db/postgres.test.ts
@@ -19,7 +19,7 @@ describe("PostgresDatabase", () => {
     ]);
   });
 
-  it("rolls back failed client-backed transactions", async () => {
+  it("rolls back failed queryable-backed transactions", async () => {
     const client = new TransactionalQueryable();
     const db = PostgresDatabase.fromQueryable(client);
 
@@ -30,6 +30,65 @@ describe("PostgresDatabase", () => {
       "BEGIN",
       "INSERT INTO tx_probe (value) VALUES ($1)",
       "ROLLBACK",
+      "SELECT value FROM tx_probe",
+    ]);
+  });
+
+  it("does not commit an outer pool-backed transaction from a nested transaction", async () => {
+    const pool = new TransactionalPool();
+    const db = PostgresDatabase.fromQueryable(pool);
+
+    await db.execute("CREATE TABLE tx_probe (value text)");
+
+    await expect(db.transaction(async (tx) => {
+      await tx.execute("INSERT INTO tx_probe (value) VALUES ($1)", ["outer"]);
+      await tx.transaction(async (nested) => {
+        await nested.execute("INSERT INTO tx_probe (value) VALUES ($1)", ["nested"]);
+      });
+      throw new Error("outer rollback");
+    })).rejects.toThrow("outer rollback");
+
+    const result = await db.execute("SELECT value FROM tx_probe");
+    expect(result.rows).toEqual([]);
+    expect(pool.queries).toEqual([
+      "CREATE TABLE tx_probe (value text)",
+      "BEGIN",
+      "INSERT INTO tx_probe (value) VALUES ($1)",
+      expect.stringMatching(/^SAVEPOINT acrm_sp_\d+$/),
+      "INSERT INTO tx_probe (value) VALUES ($1)",
+      expect.stringMatching(/^RELEASE SAVEPOINT acrm_sp_\d+$/),
+      "ROLLBACK",
+      "SELECT value FROM tx_probe",
+    ]);
+  });
+
+  it("rolls back failed nested transactions to a savepoint", async () => {
+    const pool = new TransactionalPool();
+    const db = PostgresDatabase.fromQueryable(pool);
+
+    await db.execute("CREATE TABLE tx_probe (value text)");
+
+    await db.transaction(async (tx) => {
+      await tx.execute("INSERT INTO tx_probe (value) VALUES ($1)", ["outer"]);
+      await expect(tx.transaction(async (nested) => {
+        await nested.execute("INSERT INTO tx_probe (value) VALUES ($1)", ["nested"]);
+        throw new Error("nested rollback");
+      })).rejects.toThrow("nested rollback");
+      await tx.execute("INSERT INTO tx_probe (value) VALUES ($1)", ["after"]);
+    });
+
+    const result = await db.execute("SELECT value FROM tx_probe");
+    expect(result.rows).toEqual([{ value: "outer" }, { value: "after" }]);
+    expect(pool.queries).toEqual([
+      "CREATE TABLE tx_probe (value text)",
+      "BEGIN",
+      "INSERT INTO tx_probe (value) VALUES ($1)",
+      expect.stringMatching(/^SAVEPOINT acrm_sp_\d+$/),
+      "INSERT INTO tx_probe (value) VALUES ($1)",
+      expect.stringMatching(/^ROLLBACK TO SAVEPOINT acrm_sp_\d+$/),
+      expect.stringMatching(/^RELEASE SAVEPOINT acrm_sp_\d+$/),
+      "INSERT INTO tx_probe (value) VALUES ($1)",
+      "COMMIT",
       "SELECT value FROM tx_probe",
     ]);
   });
@@ -51,6 +110,7 @@ class TransactionalQueryable implements Queryable {
   readonly queries: string[] = [];
   private rows: string[] = [];
   private transactionRows: string[] | null = null;
+  private readonly savepoints = new Map<string, string[]>();
 
   async query(
     sql: string,
@@ -65,10 +125,27 @@ class TransactionalQueryable implements Queryable {
     if (sql === "COMMIT") {
       if (this.transactionRows) this.rows = this.transactionRows;
       this.transactionRows = null;
+      this.savepoints.clear();
       return { rows: [], rowCount: null };
     }
     if (sql === "ROLLBACK") {
       this.transactionRows = null;
+      this.savepoints.clear();
+      return { rows: [], rowCount: null };
+    }
+    const savepoint = sql.match(/^SAVEPOINT ([a-zA-Z0-9_]+)$/);
+    if (savepoint) {
+      this.savepoints.set(savepoint[1]!, [...this.activeRows()]);
+      return { rows: [], rowCount: null };
+    }
+    const rollbackToSavepoint = sql.match(/^ROLLBACK TO SAVEPOINT ([a-zA-Z0-9_]+)$/);
+    if (rollbackToSavepoint) {
+      this.transactionRows = [...(this.savepoints.get(rollbackToSavepoint[1]!) ?? [])];
+      return { rows: [], rowCount: null };
+    }
+    const releaseSavepoint = sql.match(/^RELEASE SAVEPOINT ([a-zA-Z0-9_]+)$/);
+    if (releaseSavepoint) {
+      this.savepoints.delete(releaseSavepoint[1]!);
       return { rows: [], rowCount: null };
     }
     if (/^CREATE TABLE tx_probe\b/i.test(sql)) {
@@ -79,9 +156,10 @@ class TransactionalQueryable implements Queryable {
       return { rows: [], rowCount: 1 };
     }
     if (/^SELECT value FROM tx_probe\b/i.test(sql)) {
+      const rows = this.activeRows();
       return {
-        rows: this.rows.map((value) => ({ value })),
-        rowCount: this.rows.length,
+        rows: rows.map((value) => ({ value })),
+        rowCount: rows.length,
       };
     }
 

--- a/packages/sdk/src/db/postgres.test.ts
+++ b/packages/sdk/src/db/postgres.test.ts
@@ -26,6 +26,22 @@ describe("PostgresDatabase", () => {
     }
   });
 
+  it("maps object-form connection string channel binding params without overriding explicit options", async () => {
+    const required = PostgresDatabase.connect({
+      connectionString: "postgresql://user:pass@example.com/db?channel_binding=require",
+    });
+    const explicit = PostgresDatabase.connect({
+      connectionString: "postgresql://user:pass@example.com/db?channel_binding=require",
+      enableChannelBinding: false,
+    });
+    try {
+      expect(poolOptions(required).enableChannelBinding).toBe(true);
+      expect(poolOptions(explicit).enableChannelBinding).toBe(false);
+    } finally {
+      await Promise.all([required.close(), explicit.close()]);
+    }
+  });
+
   it("rolls back failed pool-backed transactions", async () => {
     const pool = new TransactionalPool();
     const db = PostgresDatabase.fromQueryable(pool);

--- a/packages/sdk/src/db/postgres.ts
+++ b/packages/sdk/src/db/postgres.ts
@@ -37,7 +37,9 @@ export class PostgresDatabase implements AcrmDatabase {
 
   static connect(options: string | PostgresConnectionOptions): PostgresDatabase {
     const pool = new Pool(
-      typeof options === "string" ? connectionOptionsFromString(options) : options,
+      typeof options === "string"
+        ? connectionOptionsFromString(options)
+        : normalizeConnectionOptions(options),
     );
     return new PostgresDatabase(pool, () => pool.end());
   }
@@ -125,10 +127,16 @@ export class PostgresDatabase implements AcrmDatabase {
 function connectionOptionsFromString(
   connectionString: string,
 ): PostgresConnectionOptions {
-  const options: PostgresConnectionOptions = { connectionString };
-  const channelBinding = channelBindingMode(connectionString);
+  return normalizeConnectionOptions({ connectionString });
+}
+
+function normalizeConnectionOptions(
+  options: PostgresConnectionOptions,
+): PostgresConnectionOptions {
+  if (options.enableChannelBinding !== undefined) return options;
+  const channelBinding = channelBindingMode(options.connectionString);
   if (channelBinding === "require" || channelBinding === "prefer") {
-    options.enableChannelBinding = true;
+    return { ...options, enableChannelBinding: true };
   }
   return options;
 }

--- a/packages/sdk/src/db/postgres.ts
+++ b/packages/sdk/src/db/postgres.ts
@@ -37,7 +37,7 @@ export class PostgresDatabase implements AcrmDatabase {
 
   static connect(options: string | PostgresConnectionOptions): PostgresDatabase {
     const pool = new Pool(
-      typeof options === "string" ? { connectionString: options } : options,
+      typeof options === "string" ? connectionOptionsFromString(options) : options,
     );
     return new PostgresDatabase(pool, () => pool.end());
   }
@@ -119,5 +119,27 @@ export class PostgresDatabase implements AcrmDatabase {
       await this.queryable.query(`RELEASE SAVEPOINT ${name}`).catch(() => undefined);
       throw error;
     }
+  }
+}
+
+function connectionOptionsFromString(
+  connectionString: string,
+): PostgresConnectionOptions {
+  const options: PostgresConnectionOptions = { connectionString };
+  const channelBinding = channelBindingMode(connectionString);
+  if (channelBinding === "require" || channelBinding === "prefer") {
+    options.enableChannelBinding = true;
+  }
+  return options;
+}
+
+function channelBindingMode(connectionString: string): string | null {
+  try {
+    return (
+      new URL(connectionString).searchParams.get("channel_binding")?.toLowerCase() ??
+      null
+    );
+  } catch {
+    return null;
   }
 }

--- a/packages/sdk/src/db/postgres.ts
+++ b/packages/sdk/src/db/postgres.ts
@@ -19,6 +19,9 @@ export type Queryable = {
 
 export type PostgresConnectionOptions = PoolConfig & {
   connectionString: string;
+  // Supported by node-postgres at runtime; older @types/pg releases do not
+  // expose it yet.
+  enableChannelBinding?: boolean;
 };
 
 type TransactionState = "root" | "active" | "passthrough";

--- a/packages/sdk/src/db/postgres.ts
+++ b/packages/sdk/src/db/postgres.ts
@@ -21,10 +21,15 @@ export type PostgresConnectionOptions = PoolConfig & {
   connectionString: string;
 };
 
+type TransactionState = "root" | "active" | "passthrough";
+
 export class PostgresDatabase implements AcrmDatabase {
+  private static nextSavepointId = 1;
+
   private constructor(
     private readonly queryable: Queryable,
     private readonly closeFn: (() => Promise<void>) | null,
+    private readonly transactionState: TransactionState = "root",
   ) {}
 
   static connect(options: string | PostgresConnectionOptions): PostgresDatabase {
@@ -35,7 +40,7 @@ export class PostgresDatabase implements AcrmDatabase {
   }
 
   static fromClient(client: PoolClient): PostgresDatabase {
-    return new PostgresDatabase(client, null);
+    return new PostgresDatabase(client, null, "passthrough");
   }
 
   static fromQueryable(
@@ -57,10 +62,19 @@ export class PostgresDatabase implements AcrmDatabase {
   }
 
   async transaction<T>(fn: (db: AcrmDatabase) => Promise<T>): Promise<T> {
+    if (this.transactionState === "passthrough") {
+      return await fn(this);
+    }
+
+    if (this.transactionState === "active") {
+      return await this.savepoint(fn);
+    }
+
     if (!("connect" in this.queryable)) {
       await this.queryable.query("BEGIN");
+      const tx = new PostgresDatabase(this.queryable, null, "active");
       try {
-        const result = await fn(this);
+        const result = await fn(tx);
         await this.queryable.query("COMMIT");
         return result;
       } catch (error) {
@@ -71,7 +85,7 @@ export class PostgresDatabase implements AcrmDatabase {
 
     const pool = this.queryable as PgPool;
     const client = await pool.connect();
-    const tx = PostgresDatabase.fromClient(client);
+    const tx = new PostgresDatabase(client, null, "active");
     try {
       await client.query("BEGIN");
       const result = await fn(tx);
@@ -87,5 +101,20 @@ export class PostgresDatabase implements AcrmDatabase {
 
   async close(): Promise<void> {
     await this.closeFn?.();
+  }
+
+  private async savepoint<T>(fn: (db: AcrmDatabase) => Promise<T>): Promise<T> {
+    const name = `acrm_sp_${PostgresDatabase.nextSavepointId++}`;
+    await this.queryable.query(`SAVEPOINT ${name}`);
+    const tx = new PostgresDatabase(this.queryable, null, "active");
+    try {
+      const result = await fn(tx);
+      await this.queryable.query(`RELEASE SAVEPOINT ${name}`);
+      return result;
+    } catch (error) {
+      await this.queryable.query(`ROLLBACK TO SAVEPOINT ${name}`).catch(() => undefined);
+      await this.queryable.query(`RELEASE SAVEPOINT ${name}`).catch(() => undefined);
+      throw error;
+    }
   }
 }

--- a/packages/sdk/src/db/postgres.ts
+++ b/packages/sdk/src/db/postgres.ts
@@ -58,7 +58,15 @@ export class PostgresDatabase implements AcrmDatabase {
 
   async transaction<T>(fn: (db: AcrmDatabase) => Promise<T>): Promise<T> {
     if (!("connect" in this.queryable)) {
-      return await fn(this);
+      await this.queryable.query("BEGIN");
+      try {
+        const result = await fn(this);
+        await this.queryable.query("COMMIT");
+        return result;
+      } catch (error) {
+        await this.queryable.query("ROLLBACK").catch(() => undefined);
+        throw error;
+      }
     }
 
     const pool = this.queryable as PgPool;

--- a/packages/sdk/src/db/providers/common.ts
+++ b/packages/sdk/src/db/providers/common.ts
@@ -46,6 +46,13 @@ export function createPostgresCompatibleProvider(
       ) {
         connectionOptions.ssl = { rejectUnauthorized: false };
       }
+      const channelBinding = parsed.searchParams.get("channel_binding")?.toLowerCase();
+      if (
+        (channelBinding === "require" || channelBinding === "prefer") &&
+        pool?.enableChannelBinding === undefined
+      ) {
+        connectionOptions.enableChannelBinding = true;
+      }
       return connectionOptions;
     },
     connect: (config) => PostgresDatabase.connect(config.connectionOptions),

--- a/packages/sdk/src/db/providers/contract.test.ts
+++ b/packages/sdk/src/db/providers/contract.test.ts
@@ -36,6 +36,22 @@ async function expectAcrmDatabaseContract(db: AcrmDatabase): Promise<void> {
   });
   expect(committed.rows).toEqual([{ value: "ok" }]);
 
+  const rollbackTable = `acrm_provider_contract_rollback_${Date.now()}_${Math.trunc(
+    Math.random() * 1_000_000,
+  )}`;
+  await db.execute(`CREATE TABLE ${rollbackTable} (value text)`);
+  try {
+    await expect(db.transaction(async (tx) => {
+      await tx.execute(`INSERT INTO ${rollbackTable} (value) VALUES ($1)`, ["rolled back"]);
+      throw new Error("rollback");
+    })).rejects.toThrow("rollback");
+
+    const rolledBack = await db.execute(`SELECT value FROM ${rollbackTable}`);
+    expect(rolledBack.rows).toEqual([]);
+  } finally {
+    await db.execute(`DROP TABLE IF EXISTS ${rollbackTable}`);
+  }
+
   await expect(db.transaction(async (tx) => {
     await tx.execute("CREATE TEMP TABLE acrm_provider_contract_rollback (value text)");
     throw new Error("rollback");

--- a/packages/sdk/src/db/providers/registry.test.ts
+++ b/packages/sdk/src/db/providers/registry.test.ts
@@ -110,6 +110,27 @@ describe("database provider registry", () => {
     expect(poolSsl.connectionOptions.ssl).toBe(true);
   });
 
+  it("maps channel binding URL params into node-postgres options", () => {
+    const required = resolveDatabaseProviderConfig({
+      databaseUrl: "postgres://user:pass@ep-blue-1.us-east-1.aws.neon.tech/db?sslmode=require&channel_binding=require",
+    });
+    const preferred = resolveDatabaseProviderConfig({
+      databaseUrl: "postgres://user:pass@ep-blue-1.us-east-1.aws.neon.tech/db?channel_binding=prefer",
+    });
+    const disabled = resolveDatabaseProviderConfig({
+      databaseUrl: "postgres://user:pass@ep-blue-1.us-east-1.aws.neon.tech/db?channel_binding=disable",
+    });
+    const poolOverride = resolveDatabaseProviderConfig({
+      databaseUrl: "postgres://user:pass@ep-blue-1.us-east-1.aws.neon.tech/db?channel_binding=require",
+      pool: { enableChannelBinding: false },
+    });
+
+    expect(required.connectionOptions.enableChannelBinding).toBe(true);
+    expect(preferred.connectionOptions.enableChannelBinding).toBe(true);
+    expect(disabled.connectionOptions.enableChannelBinding).toBeUndefined();
+    expect(poolOverride.connectionOptions.enableChannelBinding).toBe(false);
+  });
+
   it("rejects unsupported providers and non-Postgres URLs", () => {
     expect(() => getDatabaseProvider("mysql")).toThrow("unsupported database provider");
     expect(() => resolveDatabaseProviderConfig({

--- a/packages/sdk/src/db/providers/types.ts
+++ b/packages/sdk/src/db/providers/types.ts
@@ -1,4 +1,3 @@
-import type { PoolConfig } from "pg";
 import type { AcrmDatabase } from "../types.js";
 import type { PostgresConnectionOptions } from "../postgres.js";
 
@@ -6,7 +5,7 @@ export type DatabaseProviderName = "postgres" | "neon" | "supabase";
 
 export type DatabaseProviderEnv = Record<string, string | undefined>;
 
-export type DatabasePoolOptions = Omit<PoolConfig, "connectionString">;
+export type DatabasePoolOptions = Omit<PostgresConnectionOptions, "connectionString">;
 
 export type DatabaseProviderResolveInput = {
   databaseUrl?: string;

--- a/packages/sdk/src/db/upsert.ts
+++ b/packages/sdk/src/db/upsert.ts
@@ -5,6 +5,7 @@ import { generateUuid } from "../lib/ids.js";
 import { nowIso } from "../lib/time.js";
 import {
   encode,
+  normalizeLookupKey,
   normalizeUniqueKey,
   type AttributeType,
   type ValueJson,
@@ -21,13 +22,15 @@ export async function findRecordByUnique(
   attribute_slug: string,
   normalized_key: string,
 ): Promise<string | null> {
+  const lookupKey = normalizeLookupKey(normalized_key);
+  if (!lookupKey) return null;
   const r = await exec(
     db,
     `SELECT record_id FROM acrm_value
      WHERE object_slug = $1 AND attribute_slug = $2
        AND normalized_key = $3 AND active_until IS NULL
      LIMIT 1`,
-    [object_slug, attribute_slug, normalized_key],
+    [object_slug, attribute_slug, lookupKey],
   );
   return (r.rows[0]?.record_id as string | undefined) ?? null;
 }

--- a/packages/sdk/src/domain/values.test.ts
+++ b/packages/sdk/src/domain/values.test.ts
@@ -1,0 +1,27 @@
+import { Buffer } from "node:buffer";
+import { describe, expect, it } from "vitest";
+import { normalizeLookupKey, normalizeUniqueKey } from "./values.js";
+
+describe("normalized keys", () => {
+  it("keeps short text and URL keys readable", () => {
+    expect(normalizeUniqueKey("text", { value: "Example" })).toBe("Example");
+    expect(normalizeUniqueKey("url", { value: "HTTPS://EXAMPLE.COM/A" })).toBe(
+      "https://example.com/a",
+    );
+  });
+
+  it("hashes oversized text and URL keys with the same representation used for lookups", () => {
+    const longText = "x".repeat(6_000);
+    const longUrl = `https://example.com/${"path".repeat(2_000)}`;
+
+    const textKey = normalizeUniqueKey("text", { value: longText });
+    const urlKey = normalizeUniqueKey("url", { value: longUrl });
+
+    expect(textKey).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(urlKey).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(Buffer.byteLength(textKey!, "utf8")).toBeLessThan(1024);
+    expect(Buffer.byteLength(urlKey!, "utf8")).toBeLessThan(1024);
+    expect(normalizeLookupKey(longText)).toBe(textKey);
+    expect(normalizeLookupKey(longUrl.toLowerCase())).toBe(urlKey);
+  });
+});

--- a/packages/sdk/src/domain/values.ts
+++ b/packages/sdk/src/domain/values.ts
@@ -3,6 +3,7 @@ import {
   type CountryCode,
 } from "libphonenumber-js/min";
 import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
 import { AcrmError, ERR } from "../lib/errors.js";
 
 export type AttributeType =
@@ -39,6 +40,7 @@ export type AttributeConfig = {
 };
 
 const MAX_NORMALIZED_KEY_BYTES = 1024;
+const NORMALIZED_KEY_HASH_PREFIX = "sha256:";
 
 export function resolveStatusOption(
   raw: string,
@@ -165,9 +167,14 @@ export function normalizeUniqueKey(
   }
 }
 
+export function normalizeLookupKey(value: string | null | undefined): string | null {
+  return boundedNormalizedKey(value ?? undefined);
+}
+
 function boundedNormalizedKey(value: string | undefined): string | null {
   if (!value) return null;
-  return Buffer.byteLength(value, "utf8") <= MAX_NORMALIZED_KEY_BYTES ? value : null;
+  if (Buffer.byteLength(value, "utf8") <= MAX_NORMALIZED_KEY_BYTES) return value;
+  return `${NORMALIZED_KEY_HASH_PREFIX}${createHash("sha256").update(value).digest("hex")}`;
 }
 
 export function recordReferenceTarget(

--- a/packages/sdk/src/domain/values.ts
+++ b/packages/sdk/src/domain/values.ts
@@ -2,6 +2,7 @@ import {
   parsePhoneNumberFromString,
   type CountryCode,
 } from "libphonenumber-js/min";
+import { Buffer } from "node:buffer";
 import { AcrmError, ERR } from "../lib/errors.js";
 
 export type AttributeType =
@@ -36,6 +37,8 @@ export type AttributeConfig = {
   // intentionally not typed here — they're consumed elsewhere.
   [key: string]: unknown;
 };
+
+const MAX_NORMALIZED_KEY_BYTES = 1024;
 
 export function resolveStatusOption(
   raw: string,
@@ -154,12 +157,17 @@ export function normalizeUniqueKey(
     case "domain":
       return (value.domain as string | undefined)?.toLowerCase() ?? null;
     case "url":
-      return (value.value as string | undefined)?.toLowerCase() ?? null;
+      return boundedNormalizedKey((value.value as string | undefined)?.toLowerCase());
     case "text":
-      return (value.value as string | undefined) ?? null;
+      return boundedNormalizedKey(value.value as string | undefined);
     default:
       return null;
   }
+}
+
+function boundedNormalizedKey(value: string | undefined): string | null {
+  if (!value) return null;
+  return Buffer.byteLength(value, "utf8") <= MAX_NORMALIZED_KEY_BYTES ? value : null;
 }
 
 export function recordReferenceTarget(

--- a/packages/sdk/src/operations/import-communication.test.ts
+++ b/packages/sdk/src/operations/import-communication.test.ts
@@ -78,7 +78,7 @@ describe("importCommunicationBatch", () => {
     });
   });
 
-  it("does not index long text values as normalized keys", async () => {
+  it("hashes long text values into bounded normalized keys", async () => {
     await withWorkspace(async (workspace) => {
       const batch = duplicateCommunicationBatch();
       batch.communicationMessages = [{
@@ -93,7 +93,7 @@ describe("importCommunicationBatch", () => {
       ).resolves.toBe(1);
       await expect(
         normalizedKeyFor(workspace, "communication_messages", "body_text"),
-      ).resolves.toBeNull();
+      ).resolves.toMatch(/^sha256:[0-9a-f]{64}$/);
     });
   });
 

--- a/packages/sdk/src/operations/import-communication.test.ts
+++ b/packages/sdk/src/operations/import-communication.test.ts
@@ -2,6 +2,7 @@ import { newDb } from "pg-mem";
 import { describe, expect, it } from "vitest";
 import { exec } from "../db/execute.js";
 import { PostgresDatabase } from "../db/postgres.js";
+import type { AcrmDatabase, ExecuteResult, SqlValue } from "../db/types.js";
 import { uuidv7 } from "../lib/uuidv7.js";
 import { Workspace } from "../workspace.js";
 import { importCommunicationBatch, type CommunicationImportBatch } from "./import-communication.js";
@@ -76,9 +77,47 @@ describe("importCommunicationBatch", () => {
       await expect(singleDisplayValue(workspace, "people", "profile_picture_url")).resolves.toBe("https://media.example.com/alice-b.jpg");
     });
   });
+
+  it("does not index long text values as normalized keys", async () => {
+    await withWorkspace(async (workspace) => {
+      const batch = duplicateCommunicationBatch();
+      batch.communicationMessages = [{
+        ...batch.communicationMessages[0]!,
+        bodyText: "x".repeat(6_000),
+      }];
+
+      await importCommunicationBatch(workspace, batch);
+
+      await expect(
+        activeValueCount(workspace, "communication_messages", "body_text"),
+      ).resolves.toBe(1);
+      await expect(
+        normalizedKeyFor(workspace, "communication_messages", "body_text"),
+      ).resolves.toBeNull();
+    });
+  });
+
+  it("rolls back record shells if value insertion fails", async () => {
+    await withWorkspace(
+      async (workspace) => {
+        await expect(importCommunicationBatch(workspace, duplicateCommunicationBatch()))
+          .rejects
+          .toThrow("forced value insert failure");
+
+        await expect(recordCount(workspace, "people")).resolves.toBe(0);
+        await expect(recordCount(workspace, "companies")).resolves.toBe(0);
+        await expect(recordCount(workspace, "communication_threads")).resolves.toBe(0);
+        await expect(recordCount(workspace, "communication_messages")).resolves.toBe(0);
+      },
+      { wrapDb: (db) => new FailingValueInsertDatabase(db) },
+    );
+  });
 });
 
-async function withWorkspace(run: (workspace: Workspace) => Promise<void>): Promise<void> {
+async function withWorkspace(
+  run: (workspace: Workspace) => Promise<void>,
+  options: { wrapDb?: (db: AcrmDatabase) => AcrmDatabase } = {},
+): Promise<void> {
   const mem = newDb({ noAstCoverageCheck: true });
   mem.public.registerFunction({
     name: "gen_random_uuid",
@@ -87,13 +126,67 @@ async function withWorkspace(run: (workspace: Workspace) => Promise<void>): Prom
   });
   const pg = mem.adapters.createPg();
   const pool = new pg.Pool();
-  const db = PostgresDatabase.fromQueryable(pool, () => pool.end());
+  const baseDb = PostgresDatabase.fromQueryable(pool, () => pool.end());
+  const db = options.wrapDb?.(baseDb) ?? baseDb;
   const workspace = await Workspace.create({ db });
   try {
     await run(workspace);
   } finally {
     await workspace.close();
     await db.close();
+  }
+}
+
+class FailingValueInsertDatabase implements AcrmDatabase {
+  private readonly createdRecords: Array<{ object_slug: string; record_id: string }>;
+
+  constructor(
+    private readonly inner: AcrmDatabase,
+    private readonly trackRecordInserts = false,
+    createdRecords: Array<{ object_slug: string; record_id: string }> = [],
+  ) {
+    this.createdRecords = createdRecords;
+  }
+
+  async execute(
+    sql: string,
+    params?: ReadonlyArray<SqlValue>,
+  ): Promise<ExecuteResult> {
+    if (this.trackRecordInserts && /\bINSERT\s+INTO\s+acrm_record\b/i.test(sql)) {
+      for (let index = 0; index < (params?.length ?? 0); index += 2) {
+        this.createdRecords.push({
+          object_slug: String(params?.[index]),
+          record_id: String(params?.[index + 1]),
+        });
+      }
+    }
+    if (/\bINSERT\s+INTO\s+acrm_value\b/i.test(sql)) {
+      throw new Error("forced value insert failure");
+    }
+    return await this.inner.execute(sql, params);
+  }
+
+  async transaction<T>(fn: (db: AcrmDatabase) => Promise<T>): Promise<T> {
+    const createdRecords: Array<{ object_slug: string; record_id: string }> = [];
+    try {
+      return await this.inner.transaction((db) =>
+        fn(new FailingValueInsertDatabase(db, true, createdRecords))
+      );
+    } catch (error) {
+      // pg-mem does not model rollback for these writes; postgres.test covers
+      // adapter rollback, and this keeps the operation-level assertion stable.
+      for (const record of createdRecords.reverse()) {
+        await this.inner.execute(
+          "DELETE FROM acrm_record WHERE object_slug = $1 AND record_id = $2",
+          [record.object_slug, record.record_id],
+        ).catch(() => undefined);
+      }
+      throw error;
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.inner.close();
   }
 }
 
@@ -169,6 +262,24 @@ async function activeValueCount(
     [objectSlug, attributeSlug],
   );
   return Number(result.rows[0]?.count ?? 0);
+}
+
+async function normalizedKeyFor(
+  workspace: Workspace,
+  objectSlug: string,
+  attributeSlug: string,
+): Promise<string | null> {
+  const result = await exec(
+    workspace.db,
+    `SELECT normalized_key
+     FROM acrm_value
+     WHERE active_until IS NULL
+       AND object_slug = $1
+       AND attribute_slug = $2
+     LIMIT 1`,
+    [objectSlug, attributeSlug],
+  );
+  return (result.rows[0]?.normalized_key as string | null | undefined) ?? null;
 }
 
 async function singleDisplayValue(

--- a/packages/sdk/src/operations/import-communication.ts
+++ b/packages/sdk/src/operations/import-communication.ts
@@ -136,7 +136,15 @@ export async function importCommunicationBatch(
   await ensureCommunicationSchema(workspace);
 
   const normalizedBatch = normalizeCommunicationBatch(batch);
-  const db = workspace.db;
+  return await workspace.db.transaction(async (db) =>
+    importNormalizedCommunicationBatch(db, normalizedBatch)
+  );
+}
+
+async function importNormalizedCommunicationBatch(
+  db: Workspace["db"],
+  normalizedBatch: CommunicationImportBatch,
+): Promise<CommunicationImportResult> {
   const stats: CommunicationImportResult["stats"] = {
     people_seen: normalizedBatch.people.length,
     people_created: 0,

--- a/packages/sdk/src/operations/import-communication.ts
+++ b/packages/sdk/src/operations/import-communication.ts
@@ -6,6 +6,7 @@ import {
 } from "../db/value-row.js";
 import {
   encode,
+  normalizeLookupKey,
   normalizeLinkedinUrl,
   normalizeDomain as normalizeDomainValue,
   type AttributeConfig,
@@ -190,11 +191,11 @@ async function importNormalizedCommunicationBatch(
     const linkedinUrl = normalizeLinkedinUrlValue(person.linkedinUrl);
     const existingRecordId = plannedSourceIndex.get(sourceIndexKey("people", person.sourceKey)) ??
       (email ? plannedEmailIndex.get(email) : undefined) ??
-      (linkedinUrl ? plannedLinkedinIndex.get(linkedinUrl) : undefined);
+      (linkedinUrl ? plannedLinkedinIndex.get(lookupIndexKey(linkedinUrl)) : undefined);
     const plan = planRecord("people", person.sourceKey, existingRecordId, recordsToCreate, plannedSourceIndex);
     personPlans.set(person.sourceKey, plan);
     if (email) plannedEmailIndex.set(email, plan.recordId);
-    if (linkedinUrl) plannedLinkedinIndex.set(linkedinUrl, plan.recordId);
+    if (linkedinUrl) plannedLinkedinIndex.set(lookupIndexKey(linkedinUrl), plan.recordId);
     if (plan.created) stats.people_created++;
   }
 
@@ -443,7 +444,7 @@ async function loadSourceKeyIndex(
   sourceKeys: string[],
 ): Promise<Map<string, string>> {
   const index = new Map<string, string>();
-  for (const chunk of chunks(unique(sourceKeys), SELECT_CHUNK_SIZE)) {
+  for (const chunk of chunks(unique(sourceKeys.map(lookupIndexKey)), SELECT_CHUNK_SIZE)) {
     const placeholders = chunk.map((_, index) => `$${index + 1}`).join(", ");
     const result = await exec(
       db,
@@ -495,7 +496,12 @@ async function loadPeopleByLinkedinUrl(
   db: Workspace["db"],
   people: CommunicationImportPerson[],
 ): Promise<Map<string, string>> {
-  const urls = unique(people.map((person) => normalizeLinkedinUrlValue(person.linkedinUrl)).filter((url): url is string => Boolean(url)));
+  const urls = unique(
+    people
+      .map((person) => normalizeLinkedinUrlValue(person.linkedinUrl))
+      .filter((url): url is string => Boolean(url))
+      .map(lookupIndexKey),
+  );
   const index = new Map<string, string>();
   for (const chunk of chunks(urls, SELECT_CHUNK_SIZE)) {
     const placeholders = chunk.map((_, index) => `$${index + 1}`).join(", ");
@@ -928,7 +934,11 @@ function preparedValueKey(value: PreparedValueInsert): string | null {
 }
 
 function sourceIndexKey(objectSlug: string, sourceKey: string): string {
-  return `${objectSlug}\0${sourceKey}`;
+  return `${objectSlug}\0${lookupIndexKey(sourceKey)}`;
+}
+
+function lookupIndexKey(value: string): string {
+  return normalizeLookupKey(value) ?? value;
 }
 
 function singleValueKey(objectSlug: string, recordId: string, attributeSlug: string): string {

--- a/packages/sdk/src/operations/import-csv.test.ts
+++ b/packages/sdk/src/operations/import-csv.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { runWithConcurrency } from "./run-with-concurrency.js";
+
+describe("import CSV concurrency", () => {
+  it("waits for already-running workers before surfacing the first failure", async () => {
+    const events: string[] = [];
+    let releaseSlow!: () => void;
+    let slowStarted!: () => void;
+    const slowCanFinish = new Promise<void>((resolve) => {
+      releaseSlow = resolve;
+    });
+    const slowHasStarted = new Promise<void>((resolve) => {
+      slowStarted = resolve;
+    });
+
+    const run = runWithConcurrency(2, 2, async (index) => {
+      if (index === 0) {
+        events.push("slow-start");
+        slowStarted();
+        await slowCanFinish;
+        events.push("slow-done");
+        return;
+      }
+      await slowHasStarted;
+      events.push("fail");
+      throw new Error("boom");
+    });
+
+    let settled = false;
+    run.catch(() => {
+      settled = true;
+    });
+    await slowHasStarted;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(events).toEqual(["slow-start", "fail"]);
+    expect(settled).toBe(false);
+
+    releaseSlow();
+    await expect(run).rejects.toThrow("boom");
+    expect(events).toEqual(["slow-start", "fail", "slow-done"]);
+  });
+});

--- a/packages/sdk/src/operations/import-csv.ts
+++ b/packages/sdk/src/operations/import-csv.ts
@@ -6,6 +6,7 @@ import {
 } from "../db/value-row.js";
 import {
   encode,
+  normalizeLookupKey,
   normalizeUniqueKey,
   normalizeDomain,
   normalizePhoneNumber,
@@ -21,6 +22,7 @@ import { generateUuid } from "../lib/ids.js";
 import { nowIso } from "../lib/time.js";
 import { loadAttribute } from "../workspace/catalog.js";
 import type { Workspace } from "../workspace.js";
+import { runWithConcurrency } from "./run-with-concurrency.js";
 
 type CsvRow = Record<string, string>;
 type LookupCache = Map<string, string | null>;
@@ -112,6 +114,26 @@ function cacheKey(object_slug: string, attribute_slug: string, normalized_key: s
   return `${object_slug}\x00${attribute_slug}\x00${normalized_key}`;
 }
 
+function lookupCacheKey(
+  object_slug: string,
+  attribute_slug: string,
+  normalized_key: string,
+): string | null {
+  const lookupKey = normalizeLookupKey(normalized_key);
+  return lookupKey ? cacheKey(object_slug, attribute_slug, lookupKey) : null;
+}
+
+function rememberLookup(
+  cache: LookupCache,
+  object_slug: string,
+  attribute_slug: string,
+  normalized_key: string,
+  record_id: string | null,
+): void {
+  const ck = lookupCacheKey(object_slug, attribute_slug, normalized_key);
+  if (ck) cache.set(ck, record_id);
+}
+
 type LookupKey = {
   object_slug: string;
   attribute_slug: string;
@@ -125,7 +147,9 @@ async function findRecordByUnique(
   attribute_slug: string,
   normalized_key: string,
 ): Promise<string | null> {
-  const ck = cacheKey(object_slug, attribute_slug, normalized_key);
+  const lookupKey = normalizeLookupKey(normalized_key);
+  if (!lookupKey) return null;
+  const ck = cacheKey(object_slug, attribute_slug, lookupKey);
   if (cache.has(ck)) return cache.get(ck) ?? null;
   const r = await exec(
     db,
@@ -133,7 +157,7 @@ async function findRecordByUnique(
      WHERE object_slug = $1 AND attribute_slug = $2
        AND normalized_key = $3 AND active_until IS NULL
      LIMIT 1`,
-    [object_slug, attribute_slug, normalized_key],
+    [object_slug, attribute_slug, lookupKey],
   );
   const id = (r.rows[0]?.record_id as string | undefined) ?? null;
   cache.set(ck, id);
@@ -146,8 +170,8 @@ async function findCompanyByName(
   name: string,
 ): Promise<string | null> {
   const key = name.trim().toLowerCase();
-  const ck = cacheKey("companies", "name__ci", key);
-  if (cache.has(ck)) return cache.get(ck) ?? null;
+  const ck = lookupCacheKey("companies", "name__ci", key);
+  if (ck && cache.has(ck)) return cache.get(ck) ?? null;
   const r = await exec(
     db,
     `SELECT record_id FROM acrm_value
@@ -158,7 +182,7 @@ async function findCompanyByName(
     [key],
   );
   const id = (r.rows[0]?.record_id as string | undefined) ?? null;
-  cache.set(ck, id);
+  if (ck) cache.set(ck, id);
   return id;
 }
 
@@ -471,8 +495,9 @@ function collectLookupKeysForRow(
     attribute_slug: string,
     normalized_key: string | null | undefined,
   ) => {
-    if (!normalized_key) return;
-    keys.push({ object_slug, attribute_slug, normalized_key });
+    const lookupKey = normalizeLookupKey(normalized_key);
+    if (!lookupKey) return;
+    keys.push({ object_slug, attribute_slug, normalized_key: lookupKey });
   };
 
   const emails = collectEmails(row);
@@ -713,7 +738,7 @@ async function importRow(
         provenance,
         isFresh: true,
       });
-      cache.set(cacheKey("companies", "domains", companyDomain), companyId);
+      rememberLookup(cache, "companies", "domains", companyDomain, companyId);
       if (companyName) {
         await setSingleValue(db, batcher, {
           object_slug: "companies",
@@ -745,7 +770,7 @@ async function importRow(
         provenance,
         isFresh: true,
       });
-      cache.set(cacheKey("companies", "name__ci", companyName.trim().toLowerCase()), companyId);
+      rememberLookup(cache, "companies", "name__ci", companyName.trim().toLowerCase(), companyId);
       stats.companies_created++;
     }
   }
@@ -786,7 +811,7 @@ async function importRow(
           provenance,
           isFresh: true,
         });
-        cache.set(cacheKey("people", "email_addresses", e.trim().toLowerCase()), personId);
+        rememberLookup(cache, "people", "email_addresses", e.trim().toLowerCase(), personId);
       }
       for (const p of phones) {
         const normalized = normalizePhoneNumber(p, defaultCountry);
@@ -802,7 +827,7 @@ async function importRow(
           provenance,
           isFresh: true,
         });
-        cache.set(cacheKey("people", "phone_numbers", normalized), personId);
+        rememberLookup(cache, "people", "phone_numbers", normalized, personId);
       }
       if (linkedinKey) {
         await setSingleValue(db, batcher, {
@@ -815,7 +840,7 @@ async function importRow(
           provenance,
           isFresh: true,
         });
-        cache.set(cacheKey("people", "linkedin_url", linkedinKey), personId);
+        rememberLookup(cache, "people", "linkedin_url", linkedinKey, personId);
       }
       if (twitterKey) {
         await setSingleValue(db, batcher, {
@@ -828,7 +853,7 @@ async function importRow(
           provenance,
           isFresh: true,
         });
-        cache.set(cacheKey("people", "twitter_url", twitterKey), personId);
+        rememberLookup(cache, "people", "twitter_url", twitterKey, personId);
       }
       if (fullName) {
         await setSingleValue(db, batcher, {
@@ -1032,24 +1057,6 @@ function normalizePositiveInt(value: unknown, fallback: number): number {
   const n = Number(value);
   if (!Number.isFinite(n) || n < 1) return fallback;
   return Math.floor(n);
-}
-
-async function runWithConcurrency(
-  total: number,
-  concurrency: number,
-  worker: (index: number) => Promise<void>,
-): Promise<void> {
-  let next = 0;
-  const workers = Array.from(
-    { length: Math.min(Math.max(1, concurrency), Math.max(1, total)) },
-    async () => {
-      while (next < total) {
-        const index = next++;
-        await worker(index);
-      }
-    },
-  );
-  await Promise.all(workers);
 }
 
 export type ImportCsvArgs = {

--- a/packages/sdk/src/operations/import-csv.ts
+++ b/packages/sdk/src/operations/import-csv.ts
@@ -1092,11 +1092,21 @@ export async function importCsv(
   workspace: Workspace,
   args: ImportCsvArgs,
 ): Promise<ImportCsvResult> {
-  const db = workspace.db;
   const rows = parseCsv(args.csvText);
   const detected = detectColumns(rows);
   args.onStart?.({ total: rows.length, detected });
 
+  return await workspace.db.transaction((db) =>
+    importCsvRowsInDatabase(db, rows, detected, args)
+  );
+}
+
+async function importCsvRowsInDatabase(
+  db: Workspace["db"],
+  rows: CsvRow[],
+  detected: DetectedColumns,
+  args: ImportCsvArgs,
+): Promise<ImportCsvResult> {
   const stats: ImportCsvStats = {
     rows: rows.length,
     companies_created: 0,

--- a/packages/sdk/src/operations/import-google.ts
+++ b/packages/sdk/src/operations/import-google.ts
@@ -96,7 +96,13 @@ export async function importGoogleContacts(
   workspace: Workspace,
   args: ImportGoogleContactsArgs,
 ): Promise<ImportGoogleContactsResult> {
-  const db = workspace.db;
+  return await workspace.db.transaction((db) => importGoogleContactsInDatabase(db, args));
+}
+
+async function importGoogleContactsInDatabase(
+  db: Workspace["db"],
+  args: ImportGoogleContactsArgs,
+): Promise<ImportGoogleContactsResult> {
   const stats: ImportGoogleContactsStats = {
     contacts_seen: 0,
     people_created: 0,

--- a/packages/sdk/src/operations/import-linkedin-relations.ts
+++ b/packages/sdk/src/operations/import-linkedin-relations.ts
@@ -6,6 +6,7 @@ import {
 } from "../db/value-row.js";
 import {
   encode,
+  normalizeLookupKey,
   normalizeDomain,
   normalizeLinkedinUrl,
   type AttributeType,
@@ -159,9 +160,9 @@ async function importNormalizedLinkedinRelations(
 
   for (const company of companies) {
     const existingRecordId =
-      (company.linkedinUrl ? plannedCompanyLinkedinIndex.get(company.linkedinUrl) : undefined) ??
+      (company.linkedinUrl ? plannedCompanyLinkedinIndex.get(lookupIndexKey(company.linkedinUrl)) : undefined) ??
       (company.domain ? plannedCompanyDomainIndex.get(company.domain) : undefined) ??
-      plannedCompanySourceIndex.get(company.sourceKey) ??
+      plannedCompanySourceIndex.get(lookupIndexKey(company.sourceKey)) ??
       plannedCompanyNameIndex.get(company.name.toLowerCase());
     const recordId = existingRecordId ?? uuidv7();
     const created = existingRecordId == null;
@@ -169,8 +170,8 @@ async function importNormalizedLinkedinRelations(
       recordsToCreate.push({ object_slug: "companies", record_id: recordId });
       createdCompanyIds.add(recordId);
     }
-    plannedCompanySourceIndex.set(company.sourceKey, recordId);
-    if (company.linkedinUrl) plannedCompanyLinkedinIndex.set(company.linkedinUrl, recordId);
+    plannedCompanySourceIndex.set(lookupIndexKey(company.sourceKey), recordId);
+    if (company.linkedinUrl) plannedCompanyLinkedinIndex.set(lookupIndexKey(company.linkedinUrl), recordId);
     if (company.domain) plannedCompanyDomainIndex.set(company.domain, recordId);
     plannedCompanyNameIndex.set(company.name.toLowerCase(), recordId);
     touchedCompanyIds.add(recordId);
@@ -182,16 +183,16 @@ async function importNormalizedLinkedinRelations(
 
   for (const relation of relations) {
     const existingRecordId =
-      (relation.linkedinUrl ? plannedLinkedinIndex.get(relation.linkedinUrl) : undefined) ??
-      plannedSourceIndex.get(relation.sourceKey);
+      (relation.linkedinUrl ? plannedLinkedinIndex.get(lookupIndexKey(relation.linkedinUrl)) : undefined) ??
+      plannedSourceIndex.get(lookupIndexKey(relation.sourceKey));
     const recordId = existingRecordId ?? uuidv7();
     const created = existingRecordId == null;
     if (created) {
       recordsToCreate.push({ object_slug: "people", record_id: recordId });
       createdRecordIds.add(recordId);
     }
-    plannedSourceIndex.set(relation.sourceKey, recordId);
-    if (relation.linkedinUrl) plannedLinkedinIndex.set(relation.linkedinUrl, recordId);
+    plannedSourceIndex.set(lookupIndexKey(relation.sourceKey), recordId);
+    if (relation.linkedinUrl) plannedLinkedinIndex.set(lookupIndexKey(relation.linkedinUrl), recordId);
     touchedRecordIds.add(recordId);
     plans.push({ relation, plan: { objectSlug: "people", recordId, created } });
   }
@@ -486,7 +487,7 @@ async function loadPeopleBySourceKeys(
   sourceKeys: string[],
 ): Promise<Map<string, string>> {
   const index = new Map<string, string>();
-  for (const chunk of chunks(unique(sourceKeys), SELECT_CHUNK_SIZE)) {
+  for (const chunk of chunks(unique(sourceKeys.map(lookupIndexKey)), SELECT_CHUNK_SIZE)) {
     const placeholders = chunk.map((_, index) => `$${index + 1}`).join(", ");
     const result = await exec(
       db,
@@ -512,7 +513,7 @@ async function loadPeopleByLinkedinUrl(
   linkedinUrls: string[],
 ): Promise<Map<string, string>> {
   const index = new Map<string, string>();
-  for (const chunk of chunks(unique(linkedinUrls), SELECT_CHUNK_SIZE)) {
+  for (const chunk of chunks(unique(linkedinUrls.map(lookupIndexKey)), SELECT_CHUNK_SIZE)) {
     const placeholders = chunk.map((_, index) => `$${index + 1}`).join(", ");
     const result = await exec(
       db,
@@ -538,7 +539,7 @@ async function loadCompaniesBySourceKeys(
   sourceKeys: string[],
 ): Promise<Map<string, string>> {
   const index = new Map<string, string>();
-  for (const chunk of chunks(unique(sourceKeys), SELECT_CHUNK_SIZE)) {
+  for (const chunk of chunks(unique(sourceKeys.map(lookupIndexKey)), SELECT_CHUNK_SIZE)) {
     const placeholders = chunk.map((_, index) => `$${index + 1}`).join(", ");
     const result = await exec(
       db,
@@ -564,7 +565,7 @@ async function loadCompaniesByLinkedinUrl(
   linkedinUrls: string[],
 ): Promise<Map<string, string>> {
   const index = new Map<string, string>();
-  for (const chunk of chunks(unique(linkedinUrls), SELECT_CHUNK_SIZE)) {
+  for (const chunk of chunks(unique(linkedinUrls.map(lookupIndexKey)), SELECT_CHUNK_SIZE)) {
     const placeholders = chunk.map((_, index) => `$${index + 1}`).join(", ");
     const result = await exec(
       db,
@@ -939,6 +940,10 @@ function uniqueCompanies(companies: NormalizedCompany[]): NormalizedCompany[] {
 
 function unique(values: string[]): string[] {
   return [...new Set(values)];
+}
+
+function lookupIndexKey(value: string): string {
+  return normalizeLookupKey(value) ?? value;
 }
 
 function chunks<T>(values: T[], size: number): T[][] {

--- a/packages/sdk/src/operations/import-linkedin-relations.ts
+++ b/packages/sdk/src/operations/import-linkedin-relations.ts
@@ -116,7 +116,16 @@ export async function importLinkedinRelations(
     relations.push(normalized);
   }
 
-  const db = workspace.db;
+  return await workspace.db.transaction((db) =>
+    importNormalizedLinkedinRelations(db, relations, stats)
+  );
+}
+
+async function importNormalizedLinkedinRelations(
+  db: Workspace["db"],
+  relations: NormalizedRelation[],
+  stats: ImportLinkedinRelationsResult["stats"],
+): Promise<ImportLinkedinRelationsResult> {
   const sourceIndex = await loadPeopleBySourceKeys(db, relations.map((relation) => relation.sourceKey));
   const plannedSourceIndex = new Map(sourceIndex);
   const linkedinIndex = await loadPeopleByLinkedinUrl(

--- a/packages/sdk/src/operations/import-linkedin.test.ts
+++ b/packages/sdk/src/operations/import-linkedin.test.ts
@@ -1,0 +1,160 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { newDb } from "pg-mem";
+import { describe, expect, it } from "vitest";
+import { exec } from "../db/execute.js";
+import { PostgresDatabase } from "../db/postgres.js";
+import type { AcrmDatabase, ExecuteResult, SqlValue } from "../db/types.js";
+import { uuidv7 } from "../lib/uuidv7.js";
+import { Workspace } from "../workspace.js";
+import { importLinkedinProfile } from "./import-linkedin.js";
+import { importLinkedinRelations } from "./import-linkedin-relations.js";
+
+describe("LinkedIn imports", () => {
+  it("rolls back profile record shells if value insertion fails", async () => {
+    const cacheDir = await mkdtemp(path.join(os.tmpdir(), "acrm-linkedin-profile-"));
+    try {
+      await writeFile(
+        path.join(cacheDir, "alice.json"),
+        JSON.stringify({
+          firstName: "Alice",
+          lastName: "Profile",
+          publicIdentifier: "alice",
+          linkedinUrl: "https://www.linkedin.com/in/alice/",
+        }),
+        "utf8",
+      );
+
+      await withWorkspace(
+        async (workspace) => {
+          await expect(importLinkedinProfile(workspace, {
+            urlOrSlug: "alice",
+            token: "unused",
+            cacheDir,
+          })).rejects.toThrow("forced value insert failure");
+
+          await expect(recordCount(workspace, "people")).resolves.toBe(0);
+          await expect(recordCount(workspace, "companies")).resolves.toBe(0);
+          await expect(valueCount(workspace)).resolves.toBe(0);
+        },
+        { wrapDb: (db) => new FailingValueInsertDatabase(db) },
+      );
+    } finally {
+      await rm(cacheDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rolls back relation record shells if value insertion fails", async () => {
+    await withWorkspace(
+      async (workspace) => {
+        await expect(importLinkedinRelations(workspace, {
+          relations: [{
+            member_id: "member-1",
+            first_name: "Alice",
+            last_name: "Relation",
+            public_identifier: "alice-relation",
+            company_name: "Example Co",
+          }],
+        })).rejects.toThrow("forced value insert failure");
+
+        await expect(recordCount(workspace, "people")).resolves.toBe(0);
+        await expect(recordCount(workspace, "companies")).resolves.toBe(0);
+        await expect(valueCount(workspace)).resolves.toBe(0);
+      },
+      { wrapDb: (db) => new FailingValueInsertDatabase(db) },
+    );
+  });
+});
+
+async function withWorkspace(
+  run: (workspace: Workspace) => Promise<void>,
+  options: { wrapDb?: (db: AcrmDatabase) => AcrmDatabase } = {},
+): Promise<void> {
+  const mem = newDb({ noAstCoverageCheck: true });
+  mem.public.registerFunction({
+    name: "gen_random_uuid",
+    returns: "text",
+    implementation: () => uuidv7(),
+  });
+  const pg = mem.adapters.createPg();
+  const pool = new pg.Pool();
+  const baseDb = PostgresDatabase.fromQueryable(pool, () => pool.end());
+  const db = options.wrapDb?.(baseDb) ?? baseDb;
+  const workspace = await Workspace.create({ db });
+  try {
+    await run(workspace);
+  } finally {
+    await workspace.close();
+    await db.close();
+  }
+}
+
+class FailingValueInsertDatabase implements AcrmDatabase {
+  private readonly createdRecords: Array<{ object_slug: string; record_id: string }>;
+
+  constructor(
+    private readonly inner: AcrmDatabase,
+    private readonly trackRecordInserts = false,
+    createdRecords: Array<{ object_slug: string; record_id: string }> = [],
+  ) {
+    this.createdRecords = createdRecords;
+  }
+
+  async execute(
+    sql: string,
+    params?: ReadonlyArray<SqlValue>,
+  ): Promise<ExecuteResult> {
+    if (this.trackRecordInserts && /\bINSERT\s+INTO\s+acrm_record\b/i.test(sql)) {
+      for (let index = 0; index < (params?.length ?? 0); index += 2) {
+        this.createdRecords.push({
+          object_slug: String(params?.[index]),
+          record_id: String(params?.[index + 1]),
+        });
+      }
+    }
+    if (/\bINSERT\s+INTO\s+acrm_value\b/i.test(sql)) {
+      throw new Error("forced value insert failure");
+    }
+    return await this.inner.execute(sql, params);
+  }
+
+  async transaction<T>(fn: (db: AcrmDatabase) => Promise<T>): Promise<T> {
+    const createdRecords: Array<{ object_slug: string; record_id: string }> = [];
+    try {
+      return await this.inner.transaction((db) =>
+        fn(new FailingValueInsertDatabase(db, true, createdRecords))
+      );
+    } catch (error) {
+      for (const record of createdRecords.reverse()) {
+        await this.inner.execute(
+          "DELETE FROM acrm_value WHERE object_slug = $1 AND record_id = $2",
+          [record.object_slug, record.record_id],
+        ).catch(() => undefined);
+        await this.inner.execute(
+          "DELETE FROM acrm_record WHERE object_slug = $1 AND record_id = $2",
+          [record.object_slug, record.record_id],
+        ).catch(() => undefined);
+      }
+      throw error;
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.inner.close();
+  }
+}
+
+async function recordCount(workspace: Workspace, objectSlug: string): Promise<number> {
+  const result = await exec(
+    workspace.db,
+    "SELECT COUNT(*) AS count FROM acrm_record WHERE object_slug = $1",
+    [objectSlug],
+  );
+  return Number(result.rows[0]?.count ?? 0);
+}
+
+async function valueCount(workspace: Workspace): Promise<number> {
+  const result = await exec(workspace.db, "SELECT COUNT(*) AS count FROM acrm_value");
+  return Number(result.rows[0]?.count ?? 0);
+}

--- a/packages/sdk/src/operations/import-linkedin.ts
+++ b/packages/sdk/src/operations/import-linkedin.ts
@@ -1,33 +1,16 @@
 import {
-  findCompanyByName,
-  findRecordByUnique,
-  insertRecord,
-  setSingleValue,
-} from "../db/upsert.js";
-import { normalizeLinkedinUrl } from "../domain/values.js";
-import {
   loadFromCacheOrFetch,
   normalizeLinkedinInput,
 } from "../integrations/apify-linkedin.js";
-import {
-  mapProfile,
-  type MappedProfile,
-} from "../integrations/linkedin-mapping.js";
-import { AcrmError, ERR } from "../lib/errors.js";
-import { generateUuid } from "../lib/ids.js";
+import { mapProfile } from "../integrations/linkedin-mapping.js";
 import { nowIso } from "../lib/time.js";
 import type { Workspace } from "../workspace.js";
+import {
+  upsertMappedLinkedinProfile,
+  type LinkedinProfileUpsertResult,
+} from "./profile-upserts.js";
 
-const SOURCE = "linkedin-import";
-
-export type LinkedinImportResult = {
-  person_record_id: string;
-  company_record_id: string | null;
-  created: { person: boolean; company: boolean };
-  cache_path: string | null;
-  cache_hit: boolean;
-  mapped: MappedProfile;
-};
+export type LinkedinImportResult = LinkedinProfileUpsertResult;
 
 export type ImportLinkedinProfileArgs = {
   urlOrSlug: string;
@@ -66,7 +49,7 @@ export async function importLinkedinProfile(
   };
 
   return await workspace.db.transaction((db) =>
-    importMappedLinkedinProfile(db, {
+    upsertMappedLinkedinProfile(db, {
       url,
       cachePath,
       cacheHit,
@@ -74,143 +57,4 @@ export async function importLinkedinProfile(
       provenance,
     })
   );
-}
-
-async function importMappedLinkedinProfile(
-  db: Workspace["db"],
-  args: {
-    url: string;
-    cachePath: string | null;
-    cacheHit: boolean;
-    mapped: MappedProfile;
-    provenance: Record<string, unknown>;
-  },
-): Promise<LinkedinImportResult> {
-  const { url, cachePath, cacheHit, mapped, provenance } = args;
-
-  // Company first so the person can reference it.
-  let companyId: string | null = null;
-  let companyCreated = false;
-  if (mapped.company.name) {
-    companyId = await findCompanyByName(db, mapped.company.name);
-    if (!companyId) {
-      companyId = await generateUuid(db);
-      await insertRecord(db, "companies", companyId);
-      await setSingleValue(db, {
-        object_slug: "companies",
-        record_id: companyId,
-        attribute_slug: "name",
-        attribute_type: "text",
-        value: mapped.company.name,
-        source: SOURCE,
-        provenance,
-      });
-      companyCreated = true;
-    }
-    if (mapped.company.linkedin_url) {
-      const cl = normalizeLinkedinUrl(mapped.company.linkedin_url);
-      if (cl) {
-        await setSingleValue(db, {
-          object_slug: "companies",
-          record_id: companyId,
-          attribute_slug: "linkedin_url",
-          attribute_type: "url",
-          value: cl,
-          source: SOURCE,
-          provenance,
-        });
-      }
-    }
-  }
-
-  // Person — dedupe by LinkedIn URL.
-  const linkedinKey = mapped.person.linkedin_url
-    ? normalizeLinkedinUrl(mapped.person.linkedin_url)
-    : normalizeLinkedinUrl(url);
-  if (!linkedinKey) {
-    throw new AcrmError(
-      "could not derive a normalized LinkedIn URL from the profile",
-      ERR.INVALID_INPUT,
-    );
-  }
-
-  let personId = await findRecordByUnique(
-    db,
-    "people",
-    "linkedin_url",
-    linkedinKey,
-  );
-  let personCreated = false;
-  if (!personId) {
-    personId = await generateUuid(db);
-    await insertRecord(db, "people", personId);
-    personCreated = true;
-  }
-
-  await setSingleValue(db, {
-    object_slug: "people",
-    record_id: personId,
-    attribute_slug: "linkedin_url",
-    attribute_type: "url",
-    value: linkedinKey,
-    source: SOURCE,
-    provenance,
-  });
-
-  if (mapped.person.name) {
-    await setSingleValue(db, {
-      object_slug: "people",
-      record_id: personId,
-      attribute_slug: "name",
-      attribute_type: "personal-name",
-      value: mapped.person.name,
-      source: SOURCE,
-      provenance,
-    });
-  }
-
-  if (mapped.person.profile_picture_url) {
-    await setSingleValue(db, {
-      object_slug: "people",
-      record_id: personId,
-      attribute_slug: "profile_picture_url",
-      attribute_type: "url",
-      value: mapped.person.profile_picture_url,
-      source: SOURCE,
-      provenance,
-    });
-  }
-
-  if (mapped.person.job_title) {
-    await setSingleValue(db, {
-      object_slug: "people",
-      record_id: personId,
-      attribute_slug: "job_title",
-      attribute_type: "text",
-      value: mapped.person.job_title,
-      source: SOURCE,
-      provenance,
-    });
-  }
-
-  if (companyId) {
-    await setSingleValue(db, {
-      object_slug: "people",
-      record_id: personId,
-      attribute_slug: "company",
-      attribute_type: "record-reference",
-      value: { target_object: "companies", target_record_id: companyId },
-      source: SOURCE,
-      provenance,
-    });
-  }
-
-  return {
-    person_record_id: personId,
-    company_record_id: companyId,
-    created: { person: personCreated, company: companyCreated },
-    cache_path: cachePath,
-    cache_hit: cacheHit,
-    mapped,
-  };
 }

--- a/packages/sdk/src/operations/import-linkedin.ts
+++ b/packages/sdk/src/operations/import-linkedin.ts
@@ -44,7 +44,6 @@ export async function importLinkedinProfile(
   workspace: Workspace,
   args: ImportLinkedinProfileArgs,
 ): Promise<LinkedinImportResult> {
-  const db = workspace.db;
   const { urlOrSlug, token, cacheDir, refresh, noCache } = args;
   const { url, publicId } = normalizeLinkedinInput(urlOrSlug);
 
@@ -65,6 +64,29 @@ export async function importLinkedinProfile(
     fetched_at: nowIso(),
     cache_hit: cacheHit,
   };
+
+  return await workspace.db.transaction((db) =>
+    importMappedLinkedinProfile(db, {
+      url,
+      cachePath,
+      cacheHit,
+      mapped,
+      provenance,
+    })
+  );
+}
+
+async function importMappedLinkedinProfile(
+  db: Workspace["db"],
+  args: {
+    url: string;
+    cachePath: string | null;
+    cacheHit: boolean;
+    mapped: MappedProfile;
+    provenance: Record<string, unknown>;
+  },
+): Promise<LinkedinImportResult> {
+  const { url, cachePath, cacheHit, mapped, provenance } = args;
 
   // Company first so the person can reference it.
   let companyId: string | null = null;

--- a/packages/sdk/src/operations/import-post.ts
+++ b/packages/sdk/src/operations/import-post.ts
@@ -8,22 +8,35 @@ import {
 } from "../db/upsert.js";
 import { normalizePostUrl, type PostPlatform } from "../domain/values.js";
 import {
+  loadFromCacheOrFetch as loadLinkedinProfile,
+  normalizeLinkedinInput,
+} from "../integrations/apify-linkedin.js";
+import {
   extractLinkedinPostId,
   extractXPostId,
   loadLinkedinPost,
   loadXPost,
 } from "../integrations/apify-post.js";
 import {
+  loadFromCacheOrFetch as loadXProfile,
+  normalizeXInput,
+} from "../integrations/apify-x.js";
+import { mapProfile as mapLinkedinProfile } from "../integrations/linkedin-mapping.js";
+import {
   mapLinkedinPost,
   mapXPost,
   type MappedPost,
 } from "../integrations/post-mapping.js";
+import { mapProfile as mapXProfile } from "../integrations/x-mapping.js";
 import { AcrmError, ERR } from "../lib/errors.js";
 import { generateUuid } from "../lib/ids.js";
 import { nowIso } from "../lib/time.js";
 import type { Workspace } from "../workspace.js";
-import { importLinkedinProfile } from "./import-linkedin.js";
-import { importXProfile } from "./import-x.js";
+import {
+  normalizedXProfileKey,
+  upsertMappedLinkedinProfile,
+  upsertMappedXProfile,
+} from "./profile-upserts.js";
 
 export type PostImportResult = {
   post_record_id: string;
@@ -46,6 +59,14 @@ export type ImportPostArgs = {
   noCache?: boolean;
 };
 
+type LoadedAuthorProfile =
+  | ({
+      platform: "linkedin";
+    } & Parameters<typeof upsertMappedLinkedinProfile>[1])
+  | ({
+      platform: "x";
+    } & Parameters<typeof upsertMappedXProfile>[1]);
+
 // Import a LinkedIn or X post by URL. Auto-detects platform, upserts the
 // post author as a person via the profile-import flow, upserts the post
 // record (deduped by normalized URL), and links them via `posts.author` +
@@ -63,7 +84,6 @@ export async function importPost(
     );
   }
   const { platform, url: normalizedUrl } = sniffed;
-  const db = workspace.db;
 
   // 1. Fetch the post (with cache).
   const postId =
@@ -102,80 +122,113 @@ export async function importPost(
     );
   }
 
-  // 3. Import the author via the existing profile flow.
-  let personId: string;
-  let companyId: string | null = null;
-  let personCreated = false;
-  let companyCreated = false;
-  let profileCachePath: string | null = null;
-  let profileCacheHit = false;
+  const authorProfile = await loadAuthorProfile(platform, mapped, args);
 
-  if (platform === "linkedin") {
-    const r = await importLinkedinProfile(workspace, {
-      urlOrSlug: mapped.author_profile_url,
-      token: args.token,
-      cacheDir: args.profileCacheDir,
-      refresh: args.refresh,
-      noCache: args.noCache,
+  const imported = await workspace.db.transaction(async (db) => {
+    const author =
+      authorProfile.platform === "linkedin"
+        ? await upsertMappedLinkedinProfile(db, authorProfile)
+        : await upsertMappedXProfile(db, authorProfile);
+    const personId = author.person_record_id;
+    const record = await upsertPost({
+      db,
+      platform,
+      normalizedUrl,
+      rawUrl: args.rawUrl,
+      mapped,
+      personId,
+      postCacheHit: postLoad.cacheHit,
+      apifyActor:
+        platform === "linkedin"
+          ? "apimaestro~linkedin-post-detail"
+          : "apidojo~twitter-scraper-lite",
     });
-    personId = r.person_record_id;
-    companyId = r.company_record_id;
-    personCreated = r.created.person;
-    companyCreated = r.created.company;
-    profileCachePath = r.cache_path;
-    profileCacheHit = r.cache_hit;
-  } else {
-    const r = await importXProfile(workspace, {
-      handleOrUrl: mapped.author_profile_url,
-      token: args.token,
-      cacheDir: args.profileCacheDir,
-      refresh: args.refresh,
-      noCache: args.noCache,
-    });
-    personId = r.person_record_id;
-    personCreated = r.created.person;
-    profileCachePath = r.cache_path;
-    profileCacheHit = r.cache_hit;
-  }
 
-  // 4. Upsert the post record (dedup by normalized URL).
-  const postRecord = await upsertPost({
-    db,
-    platform,
-    normalizedUrl,
-    rawUrl: args.rawUrl,
-    mapped,
-    personId,
-    postCacheHit: postLoad.cacheHit,
-    apifyActor:
-      platform === "linkedin"
-        ? "apimaestro~linkedin-post-detail"
-        : "apidojo~twitter-scraper-lite",
+    await linkPersonToPost(db, personId, record.postRecordId, platform);
+    return { author, postRecord: record };
   });
 
-  // 5. Link person → post (skip if already linked).
-  await linkPersonToPost(db, personId, postRecord.postRecordId, platform);
-
   return {
-    post_record_id: postRecord.postRecordId,
-    person_record_id: personId,
-    company_record_id: companyId,
+    post_record_id: imported.postRecord.postRecordId,
+    person_record_id: imported.author.person_record_id,
+    company_record_id:
+      "company_record_id" in imported.author
+        ? imported.author.company_record_id
+        : null,
     created: {
-      post: postRecord.created,
-      person: personCreated,
-      company: companyCreated,
+      post: imported.postRecord.created,
+      person: imported.author.created.person,
+      company:
+        "company" in imported.author.created
+          ? imported.author.created.company
+          : false,
     },
     platform,
     post_url: normalizedUrl,
     cache_paths: {
       post: postLoad.cachePath,
-      profile: profileCachePath,
+      profile: imported.author.cache_path,
     },
     cache_hits: {
       post: postLoad.cacheHit,
-      profile: profileCacheHit,
+      profile: imported.author.cache_hit,
     },
     mapped,
+  };
+}
+
+async function loadAuthorProfile(
+  platform: PostPlatform,
+  mapped: MappedPost,
+  args: ImportPostArgs,
+): Promise<LoadedAuthorProfile> {
+  if (platform === "linkedin") {
+    const { url, publicId } = normalizeLinkedinInput(mapped.author_profile_url);
+    const { profile, cachePath, cacheHit } = await loadLinkedinProfile({
+      cacheDir: args.profileCacheDir,
+      publicId,
+      url,
+      token: args.token,
+      refresh: args.refresh,
+      noCache: args.noCache,
+    });
+    return {
+      platform,
+      url,
+      cachePath,
+      cacheHit,
+      mapped: mapLinkedinProfile(profile),
+      provenance: {
+        actor: "harvestapi~linkedin-profile-scraper",
+        public_id: publicId,
+        fetched_at: nowIso(),
+        cache_hit: cacheHit,
+      },
+    };
+  }
+
+  const { handle } = normalizeXInput(mapped.author_profile_url);
+  const { profile, cachePath, cacheHit } = await loadXProfile({
+    cacheDir: args.profileCacheDir,
+    handle,
+    token: args.token,
+    refresh: args.refresh,
+    noCache: args.noCache,
+  });
+  const mappedProfile = mapXProfile(profile, handle);
+  return {
+    platform,
+    twitterKey: normalizedXProfileKey(mappedProfile),
+    cachePath,
+    cacheHit,
+    mapped: mappedProfile,
+    profile,
+    provenance: {
+      actor: "apidojo~twitter-user-scraper",
+      handle: mappedProfile.person.handle,
+      fetched_at: nowIso(),
+      cache_hit: cacheHit,
+    },
   };
 }
 

--- a/packages/sdk/src/operations/import-transcript.ts
+++ b/packages/sdk/src/operations/import-transcript.ts
@@ -62,7 +62,13 @@ export async function importTranscript(
   workspace: Workspace,
   payload: TranscriptPayload,
 ): Promise<TranscriptImportResult> {
-  const db = workspace.db;
+  return await workspace.db.transaction((db) => importTranscriptInDatabase(db, payload));
+}
+
+async function importTranscriptInDatabase(
+  db: Workspace["db"],
+  payload: TranscriptPayload,
+): Promise<TranscriptImportResult> {
   const resolved: ResolvedParticipant[] = [];
   const unresolved: UnresolvedParticipant[] = [];
 

--- a/packages/sdk/src/operations/import-x.ts
+++ b/packages/sdk/src/operations/import-x.ts
@@ -1,42 +1,17 @@
-import type { AcrmDatabase } from "../db/types.js";
-import { exec } from "../db/execute.js";
-import {
-  findRecordByUnique,
-  insertRecord,
-  setSingleValue,
-} from "../db/upsert.js";
-import { normalizeTwitterUrl } from "../domain/values.js";
 import {
   loadFromCacheOrFetch,
   normalizeXInput,
-  type XProfile,
 } from "../integrations/apify-x.js";
-import {
-  mapProfile,
-  type MappedXProfile,
-} from "../integrations/x-mapping.js";
-import { AcrmError, ERR } from "../lib/errors.js";
-import { generateUuid } from "../lib/ids.js";
+import { mapProfile } from "../integrations/x-mapping.js";
 import { nowIso } from "../lib/time.js";
 import type { Workspace } from "../workspace.js";
+import {
+  normalizedXProfileKey,
+  upsertMappedXProfile,
+  type XProfileUpsertResult,
+} from "./profile-upserts.js";
 
-const SOURCE = "x-import";
-const ENRICHABLE = ["job_title", "company"] as const;
-
-export type XImportResult = {
-  person_record_id: string;
-  created: { person: boolean };
-  cache_path: string | null;
-  cache_hit: boolean;
-  mapped: MappedXProfile;
-  bio: string | null;
-  needs_enrichment: {
-    person_record_id: string;
-    bio: string;
-    missing: string[];
-    instructions: string;
-  } | null;
-};
+export type XImportResult = XProfileUpsertResult;
 
 export type ImportXProfileArgs = {
   handleOrUrl: string;
@@ -54,7 +29,6 @@ export async function importXProfile(
   workspace: Workspace,
   args: ImportXProfileArgs,
 ): Promise<XImportResult> {
-  const db = workspace.db;
   const { handleOrUrl, token, cacheDir, refresh, noCache } = args;
   const { handle } = normalizeXInput(handleOrUrl);
 
@@ -75,124 +49,16 @@ export async function importXProfile(
     cache_hit: cacheHit,
   };
 
-  const twitterKey = normalizeTwitterUrl(mapped.person.twitter_url);
-  if (!twitterKey) {
-    throw new AcrmError(
-      "could not derive a normalized X URL from the profile",
-      ERR.INVALID_INPUT,
-    );
-  }
+  const twitterKey = normalizedXProfileKey(mapped);
 
-  let personId = await findRecordByUnique(
-    db,
-    "people",
-    "twitter_url",
-    twitterKey,
-  );
-  let personCreated = false;
-  if (!personId) {
-    personId = await generateUuid(db);
-    await insertRecord(db, "people", personId);
-    personCreated = true;
-  }
-
-  await setSingleValue(db, {
-    object_slug: "people",
-    record_id: personId,
-    attribute_slug: "twitter_url",
-    attribute_type: "url",
-    value: twitterKey,
-    source: SOURCE,
-    provenance,
-  });
-
-  if (mapped.person.name) {
-    await setSingleValue(db, {
-      object_slug: "people",
-      record_id: personId,
-      attribute_slug: "name",
-      attribute_type: "personal-name",
-      value: mapped.person.name,
-      source: SOURCE,
+  return await workspace.db.transaction((db) =>
+    upsertMappedXProfile(db, {
+      twitterKey,
+      cachePath,
+      cacheHit,
+      mapped,
+      profile,
       provenance,
-    });
-  }
-
-  const bio = pickBio(profile);
-  const missing: string[] = [];
-  for (const attr of ENRICHABLE) {
-    if (!(await hasActiveValue(db, "people", personId, attr))) {
-      missing.push(attr);
-    }
-  }
-
-  const needsEnrichment =
-    bio && missing.length > 0
-      ? {
-          person_record_id: personId,
-          bio,
-          missing,
-          instructions:
-            "Extract role/company from `bio`. For each slug in `missing`, write a value via `acrm execute` UPDATE/INSERT on acrm_value. Only write what's clearly stated; skip if uncertain. Source: 'x-bio-enrichment'.",
-        }
-      : null;
-
-  return {
-    person_record_id: personId,
-    created: { person: personCreated },
-    cache_path: cachePath,
-    cache_hit: cacheHit,
-    mapped,
-    bio,
-    needs_enrichment: needsEnrichment,
-  };
-}
-
-function pickBio(profile: XProfile): string | null {
-  let raw: string | null = null;
-  for (const k of ["description", "bio", "about"]) {
-    const v = (profile as Record<string, unknown>)[k];
-    if (typeof v === "string" && v.trim().length) {
-      raw = v.trim();
-      break;
-    }
-  }
-  if (!raw) return null;
-  return expandTcoUrls(raw, profile);
-}
-
-function expandTcoUrls(bio: string, profile: XProfile): string {
-  const entities = (profile as Record<string, unknown>).entities as
-    | { description?: { urls?: Array<Record<string, unknown>> } }
-    | undefined;
-  const urls = entities?.description?.urls;
-  if (!Array.isArray(urls) || urls.length === 0) return bio;
-  let out = bio;
-  for (const u of urls) {
-    const tco = typeof u.url === "string" ? u.url : null;
-    const display =
-      typeof u.display_url === "string"
-        ? u.display_url
-        : typeof u.expanded_url === "string"
-          ? u.expanded_url.replace(/^https?:\/\//i, "")
-          : null;
-    if (tco && display) out = out.split(tco).join(display);
-  }
-  return out;
-}
-
-async function hasActiveValue(
-  db: AcrmDatabase,
-  object_slug: string,
-  record_id: string,
-  attribute_slug: string,
-): Promise<boolean> {
-  const r = await exec(
-    db,
-    `SELECT 1 FROM acrm_value
-     WHERE object_slug = $1 AND record_id = $2 AND attribute_slug = $3
-       AND active_until IS NULL LIMIT 1`,
-    [object_slug, record_id, attribute_slug],
+    })
   );
-  return r.rows.length > 0;
 }

--- a/packages/sdk/src/operations/profile-upserts.ts
+++ b/packages/sdk/src/operations/profile-upserts.ts
@@ -1,0 +1,320 @@
+import type { AcrmDatabase } from "../db/types.js";
+import { exec } from "../db/execute.js";
+import {
+  findCompanyByName,
+  findRecordByUnique,
+  insertRecord,
+  setSingleValue,
+} from "../db/upsert.js";
+import {
+  normalizeLinkedinUrl,
+  normalizeTwitterUrl,
+} from "../domain/values.js";
+import type { XProfile } from "../integrations/apify-x.js";
+import type { MappedProfile } from "../integrations/linkedin-mapping.js";
+import type { MappedXProfile } from "../integrations/x-mapping.js";
+import { AcrmError, ERR } from "../lib/errors.js";
+import { generateUuid } from "../lib/ids.js";
+
+const LINKEDIN_SOURCE = "linkedin-import";
+const X_SOURCE = "x-import";
+const X_ENRICHABLE = ["job_title", "company"] as const;
+
+export type LinkedinProfileUpsertResult = {
+  person_record_id: string;
+  company_record_id: string | null;
+  created: { person: boolean; company: boolean };
+  cache_path: string | null;
+  cache_hit: boolean;
+  mapped: MappedProfile;
+};
+
+export async function upsertMappedLinkedinProfile(
+  db: AcrmDatabase,
+  args: {
+    url: string;
+    cachePath: string | null;
+    cacheHit: boolean;
+    mapped: MappedProfile;
+    provenance: Record<string, unknown>;
+  },
+): Promise<LinkedinProfileUpsertResult> {
+  const { url, cachePath, cacheHit, mapped, provenance } = args;
+
+  let companyId: string | null = null;
+  let companyCreated = false;
+  if (mapped.company.name) {
+    companyId = await findCompanyByName(db, mapped.company.name);
+    if (!companyId) {
+      companyId = await generateUuid(db);
+      await insertRecord(db, "companies", companyId);
+      await setSingleValue(db, {
+        object_slug: "companies",
+        record_id: companyId,
+        attribute_slug: "name",
+        attribute_type: "text",
+        value: mapped.company.name,
+        source: LINKEDIN_SOURCE,
+        provenance,
+      });
+      companyCreated = true;
+    }
+    if (mapped.company.linkedin_url) {
+      const cl = normalizeLinkedinUrl(mapped.company.linkedin_url);
+      if (cl) {
+        await setSingleValue(db, {
+          object_slug: "companies",
+          record_id: companyId,
+          attribute_slug: "linkedin_url",
+          attribute_type: "url",
+          value: cl,
+          source: LINKEDIN_SOURCE,
+          provenance,
+        });
+      }
+    }
+  }
+
+  const linkedinKey = mapped.person.linkedin_url
+    ? normalizeLinkedinUrl(mapped.person.linkedin_url)
+    : normalizeLinkedinUrl(url);
+  if (!linkedinKey) {
+    throw new AcrmError(
+      "could not derive a normalized LinkedIn URL from the profile",
+      ERR.INVALID_INPUT,
+    );
+  }
+
+  let personId = await findRecordByUnique(
+    db,
+    "people",
+    "linkedin_url",
+    linkedinKey,
+  );
+  let personCreated = false;
+  if (!personId) {
+    personId = await generateUuid(db);
+    await insertRecord(db, "people", personId);
+    personCreated = true;
+  }
+
+  await setSingleValue(db, {
+    object_slug: "people",
+    record_id: personId,
+    attribute_slug: "linkedin_url",
+    attribute_type: "url",
+    value: linkedinKey,
+    source: LINKEDIN_SOURCE,
+    provenance,
+  });
+
+  if (mapped.person.name) {
+    await setSingleValue(db, {
+      object_slug: "people",
+      record_id: personId,
+      attribute_slug: "name",
+      attribute_type: "personal-name",
+      value: mapped.person.name,
+      source: LINKEDIN_SOURCE,
+      provenance,
+    });
+  }
+
+  if (mapped.person.profile_picture_url) {
+    await setSingleValue(db, {
+      object_slug: "people",
+      record_id: personId,
+      attribute_slug: "profile_picture_url",
+      attribute_type: "url",
+      value: mapped.person.profile_picture_url,
+      source: LINKEDIN_SOURCE,
+      provenance,
+    });
+  }
+
+  if (mapped.person.job_title) {
+    await setSingleValue(db, {
+      object_slug: "people",
+      record_id: personId,
+      attribute_slug: "job_title",
+      attribute_type: "text",
+      value: mapped.person.job_title,
+      source: LINKEDIN_SOURCE,
+      provenance,
+    });
+  }
+
+  if (companyId) {
+    await setSingleValue(db, {
+      object_slug: "people",
+      record_id: personId,
+      attribute_slug: "company",
+      attribute_type: "record-reference",
+      value: { target_object: "companies", target_record_id: companyId },
+      source: LINKEDIN_SOURCE,
+      provenance,
+    });
+  }
+
+  return {
+    person_record_id: personId,
+    company_record_id: companyId,
+    created: { person: personCreated, company: companyCreated },
+    cache_path: cachePath,
+    cache_hit: cacheHit,
+    mapped,
+  };
+}
+
+export type XProfileUpsertResult = {
+  person_record_id: string;
+  created: { person: boolean };
+  cache_path: string | null;
+  cache_hit: boolean;
+  mapped: MappedXProfile;
+  bio: string | null;
+  needs_enrichment: {
+    person_record_id: string;
+    bio: string;
+    missing: string[];
+    instructions: string;
+  } | null;
+};
+
+export async function upsertMappedXProfile(
+  db: AcrmDatabase,
+  args: {
+    twitterKey: string;
+    cachePath: string | null;
+    cacheHit: boolean;
+    mapped: MappedXProfile;
+    profile: XProfile;
+    provenance: Record<string, unknown>;
+  },
+): Promise<XProfileUpsertResult> {
+  const { twitterKey, cachePath, cacheHit, mapped, profile, provenance } = args;
+
+  let personId = await findRecordByUnique(
+    db,
+    "people",
+    "twitter_url",
+    twitterKey,
+  );
+  let personCreated = false;
+  if (!personId) {
+    personId = await generateUuid(db);
+    await insertRecord(db, "people", personId);
+    personCreated = true;
+  }
+
+  await setSingleValue(db, {
+    object_slug: "people",
+    record_id: personId,
+    attribute_slug: "twitter_url",
+    attribute_type: "url",
+    value: twitterKey,
+    source: X_SOURCE,
+    provenance,
+  });
+
+  if (mapped.person.name) {
+    await setSingleValue(db, {
+      object_slug: "people",
+      record_id: personId,
+      attribute_slug: "name",
+      attribute_type: "personal-name",
+      value: mapped.person.name,
+      source: X_SOURCE,
+      provenance,
+    });
+  }
+
+  const bio = pickBio(profile);
+  const missing: string[] = [];
+  for (const attr of X_ENRICHABLE) {
+    if (!(await hasActiveValue(db, "people", personId, attr))) {
+      missing.push(attr);
+    }
+  }
+
+  const needsEnrichment =
+    bio && missing.length > 0
+      ? {
+          person_record_id: personId,
+          bio,
+          missing,
+          instructions:
+            "Extract role/company from `bio`. For each slug in `missing`, write a value via `acrm execute` UPDATE/INSERT on acrm_value. Only write what's clearly stated; skip if uncertain. Source: 'x-bio-enrichment'.",
+        }
+      : null;
+
+  return {
+    person_record_id: personId,
+    created: { person: personCreated },
+    cache_path: cachePath,
+    cache_hit: cacheHit,
+    mapped,
+    bio,
+    needs_enrichment: needsEnrichment,
+  };
+}
+
+export function normalizedXProfileKey(mapped: MappedXProfile): string {
+  const twitterKey = normalizeTwitterUrl(mapped.person.twitter_url);
+  if (!twitterKey) {
+    throw new AcrmError(
+      "could not derive a normalized X URL from the profile",
+      ERR.INVALID_INPUT,
+    );
+  }
+  return twitterKey;
+}
+
+function pickBio(profile: XProfile): string | null {
+  let raw: string | null = null;
+  for (const k of ["description", "bio", "about"]) {
+    const v = (profile as Record<string, unknown>)[k];
+    if (typeof v === "string" && v.trim().length) {
+      raw = v.trim();
+      break;
+    }
+  }
+  if (!raw) return null;
+  return expandTcoUrls(raw, profile);
+}
+
+function expandTcoUrls(bio: string, profile: XProfile): string {
+  const entities = (profile as Record<string, unknown>).entities as
+    | { description?: { urls?: Array<Record<string, unknown>> } }
+    | undefined;
+  const urls = entities?.description?.urls;
+  if (!Array.isArray(urls) || urls.length === 0) return bio;
+  let out = bio;
+  for (const u of urls) {
+    const tco = typeof u.url === "string" ? u.url : null;
+    const display =
+      typeof u.display_url === "string"
+        ? u.display_url
+        : typeof u.expanded_url === "string"
+          ? u.expanded_url.replace(/^https?:\/\//i, "")
+          : null;
+    if (tco && display) out = out.split(tco).join(display);
+  }
+  return out;
+}
+
+async function hasActiveValue(
+  db: AcrmDatabase,
+  object_slug: string,
+  record_id: string,
+  attribute_slug: string,
+): Promise<boolean> {
+  const r = await exec(
+    db,
+    `SELECT 1 FROM acrm_value
+     WHERE object_slug = $1 AND record_id = $2 AND attribute_slug = $3
+       AND active_until IS NULL LIMIT 1`,
+    [object_slug, record_id, attribute_slug],
+  );
+  return r.rows.length > 0;
+}

--- a/packages/sdk/src/operations/records.ts
+++ b/packages/sdk/src/operations/records.ts
@@ -311,7 +311,13 @@ export async function applyDedupe(
   workspace: Workspace,
   plan: DedupePlan,
 ): Promise<DedupeResult> {
-  const db = workspace.db;
+  return await workspace.db.transaction((db) => applyDedupeInDatabase(db, plan));
+}
+
+async function applyDedupeInDatabase(
+  db: AcrmDatabase,
+  plan: DedupePlan,
+): Promise<DedupeResult> {
   const { object_slug, keep_record_id, discard_record_id, items } = plan;
 
   let movedCount = 0;
@@ -736,23 +742,25 @@ export async function createRecord(
   workspace: Workspace,
   args: { object_slug: string; fields: string[]; source?: string },
 ): Promise<CreateRecordResult> {
-  const db = workspace.db;
   const { object_slug, fields } = args;
   const source = args.source ?? "sdk:records-create";
 
+  const db = workspace.db;
   await assertObjectRegistered(db, object_slug);
   const prepared = await prepareFields(db, object_slug, fields);
 
-  const record_id = await generateUuid(db);
-  await insertRecord(db, object_slug, record_id);
-  const inserted = await applyFields(db, object_slug, record_id, prepared, source);
+  return await workspace.db.transaction(async (tx) => {
+    const record_id = await generateUuid(tx);
+    await insertRecord(tx, object_slug, record_id);
+    const inserted = await applyFields(tx, object_slug, record_id, prepared, source);
 
-  return {
-    created: true,
-    object_slug,
-    record_id,
-    values_inserted: inserted,
-  };
+    return {
+      created: true,
+      object_slug,
+      record_id,
+      values_inserted: inserted,
+    };
+  });
 }
 
 export async function updateRecord(
@@ -764,24 +772,11 @@ export async function updateRecord(
     source?: string;
   },
 ): Promise<UpdateRecordResult> {
-  const db = workspace.db;
   const { object_slug, record_id, fields } = args;
   const source = args.source ?? "sdk:records-update";
 
+  const db = workspace.db;
   await assertObjectRegistered(db, object_slug);
-
-  const exists = await exec(
-    db,
-    "SELECT record_id FROM acrm_record WHERE object_slug = $1 AND record_id = $2",
-    [object_slug, record_id],
-  );
-  if (!exists.rows.length) {
-    throw new AcrmError(
-      `record not found: ${object_slug}/${record_id}`,
-      ERR.NOT_FOUND,
-    );
-  }
-
   const prepared = await prepareFields(db, object_slug, fields);
   if (prepared.length === 0) {
     throw new AcrmError(
@@ -790,12 +785,26 @@ export async function updateRecord(
     );
   }
 
-  const changed = await applyFields(db, object_slug, record_id, prepared, source);
+  return await workspace.db.transaction(async (tx) => {
+    const exists = await exec(
+      tx,
+      "SELECT record_id FROM acrm_record WHERE object_slug = $1 AND record_id = $2",
+      [object_slug, record_id],
+    );
+    if (!exists.rows.length) {
+      throw new AcrmError(
+        `record not found: ${object_slug}/${record_id}`,
+        ERR.NOT_FOUND,
+      );
+    }
 
-  return {
-    updated: true,
-    object_slug,
-    record_id,
-    values_changed: changed,
-  };
+    const changed = await applyFields(tx, object_slug, record_id, prepared, source);
+
+    return {
+      updated: true,
+      object_slug,
+      record_id,
+      values_changed: changed,
+    };
+  });
 }

--- a/packages/sdk/src/operations/run-with-concurrency.ts
+++ b/packages/sdk/src/operations/run-with-concurrency.ts
@@ -1,0 +1,24 @@
+export async function runWithConcurrency(
+  total: number,
+  concurrency: number,
+  worker: (index: number) => Promise<void>,
+): Promise<void> {
+  let next = 0;
+  let firstError: unknown = null;
+  const workers = Array.from(
+    { length: Math.min(Math.max(1, concurrency), Math.max(1, total)) },
+    async () => {
+      while (next < total && !firstError) {
+        const index = next++;
+        try {
+          await worker(index);
+        } catch (error) {
+          firstError ??= error;
+          return;
+        }
+      }
+    },
+  );
+  await Promise.all(workers);
+  if (firstError) throw firstError;
+}

--- a/packages/sdk/src/operations/signals.ts
+++ b/packages/sdk/src/operations/signals.ts
@@ -13,7 +13,7 @@ import {
 } from "./schema.js";
 import { setSingleValue } from "../db/upsert.js";
 import { loadAttribute } from "../workspace/catalog.js";
-import type { Workspace } from "../workspace.js";
+import { Workspace } from "../workspace.js";
 
 export type SignalObjectSlug = "people" | "companies";
 export type SignalRunMode = "missing" | "force";
@@ -203,6 +203,15 @@ export async function loadSignalDefinitions(
 }
 
 export async function ensureSignalAttributes(
+  workspace: Workspace,
+  definitions: SignalDefinition[],
+): Promise<SignalSyncResult> {
+  return await workspace.db.transaction((db) =>
+    ensureSignalAttributesInWorkspace(Workspace.fromDatabase(db), definitions)
+  );
+}
+
+async function ensureSignalAttributesInWorkspace(
   workspace: Workspace,
   definitions: SignalDefinition[],
 ): Promise<SignalSyncResult> {

--- a/packages/sdk/src/operations/signals.ts
+++ b/packages/sdk/src/operations/signals.ts
@@ -880,30 +880,32 @@ async function runOneSignal(
   const ran_at = nowIso();
   let written = 0;
 
-  for (const output of outputs) {
-    if (!requestedKeys.has(output.key)) continue;
-    const definitionOutput = outputByKey.get(output.key)!;
-    await setSingleValue(workspace.db, {
-      object_slug: definition.object_slug,
-      record_id: record.record_id,
-      attribute_slug: definitionOutput.attribute,
-      attribute_type: definitionOutput.type,
-      value: output.value,
-      source: `signal:${definition.slug}`,
-      provenance: {
-        signal_slug: definition.slug,
-        output_key: output.key,
-        ran_at,
-        definition_hash: definition.definition_hash,
-        confidence: output.confidence,
-        citations: output.citations,
-        reasoning: output.reasoning,
-        ...(output.notes ? { notes: output.notes } : {}),
-        uncited: output.citations.length === 0,
-      },
-    });
-    written++;
-  }
+  await workspace.db.transaction(async (db) => {
+    for (const output of outputs) {
+      if (!requestedKeys.has(output.key)) continue;
+      const definitionOutput = outputByKey.get(output.key)!;
+      await setSingleValue(db, {
+        object_slug: definition.object_slug,
+        record_id: record.record_id,
+        attribute_slug: definitionOutput.attribute,
+        attribute_type: definitionOutput.type,
+        value: output.value,
+        source: `signal:${definition.slug}`,
+        provenance: {
+          signal_slug: definition.slug,
+          output_key: output.key,
+          ran_at,
+          definition_hash: definition.definition_hash,
+          confidence: output.confidence,
+          citations: output.citations,
+          reasoning: output.reasoning,
+          ...(output.notes ? { notes: output.notes } : {}),
+          uncited: output.citations.length === 0,
+        },
+      });
+      written++;
+    }
+  });
   return {
     values_written: written,
     ...runnerTurnMetricFields(metrics),

--- a/packages/sdk/src/operations/transactional-writes.test.ts
+++ b/packages/sdk/src/operations/transactional-writes.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import { exec } from "../db/execute.js";
 import { PostgresDatabase } from "../db/postgres.js";
 import type { AcrmDatabase, ExecuteResult, SqlValue } from "../db/types.js";
+import { setSingleValue } from "../db/upsert.js";
 import { uuidv7 } from "../lib/uuidv7.js";
 import { Workspace } from "../workspace.js";
 import { importCsv } from "./import-csv.js";
@@ -14,7 +15,12 @@ import { importPost } from "./import-post.js";
 import { importTranscript } from "./import-transcript.js";
 import { importXProfile } from "./import-x.js";
 import { createRecord, dedupeRecords } from "./records.js";
-import { runSignals, type SignalRunner } from "./signals.js";
+import {
+  ensureSignalAttributes,
+  runSignals,
+  type SignalDefinition,
+  type SignalRunner,
+} from "./signals.js";
 
 describe("transactional SDK writes", () => {
   it("rolls back createRecord record shells if value insertion fails", async () => {
@@ -263,6 +269,56 @@ describe("transactional SDK writes", () => {
       await cleanup();
     }
   });
+
+  it("rolls back signal attribute sync if a type-change update fails", async () => {
+    let failAttributeUpdate = false;
+    await withWorkspace(
+      async (workspace) => {
+        const textDefinition = signalDefinition({
+          type: "text",
+          options: undefined,
+        });
+        const statusDefinition = signalDefinition({
+          type: "status",
+          options: [{ id: "owner_identified", title: "Owner identified" }],
+        });
+        const company = await createRecord(workspace, {
+          object_slug: "companies",
+          fields: ["name=Example Co"],
+        });
+        await ensureSignalAttributes(workspace, [textDefinition]);
+        await setSingleValue(workspace.db, {
+          object_slug: "companies",
+          record_id: company.record_id,
+          attribute_slug: "operator_signal",
+          attribute_type: "text",
+          value: "Example Holdings",
+          source: "signal:sync_rollback",
+          provenance: { signal_slug: "sync_rollback" },
+        });
+
+        failAttributeUpdate = true;
+        await expect(ensureSignalAttributes(workspace, [statusDefinition]))
+          .rejects
+          .toThrow("forced value insert failure");
+
+        await expect(
+          activeAttributeCount(workspace, company.record_id, ["operator_signal"]),
+        ).resolves.toBe(1);
+        await expect(attributeType(workspace, "companies", "operator_signal"))
+          .resolves
+          .toBe("text");
+      },
+      {
+        wrapDb: (db) =>
+          new FailingValueInsertDatabase(db, {
+            shouldFail: (sql) =>
+              failAttributeUpdate &&
+              /\bUPDATE\s+acrm_attribute\b/i.test(sql),
+          }),
+      },
+    );
+  });
 });
 
 async function withWorkspace(
@@ -327,6 +383,27 @@ Find the operator.
   return {
     dir,
     cleanup: () => rm(root, { recursive: true, force: true }),
+  };
+}
+
+function signalDefinition(output: {
+  type: "text" | "status";
+  options: SignalDefinition["outputs"][number]["options"];
+}): SignalDefinition {
+  return {
+    slug: "sync_rollback",
+    title: "Sync Rollback",
+    object_slug: "companies",
+    outputs: [{
+      key: "operator",
+      attribute: "operator_signal",
+      title: "Operator signal",
+      type: output.type,
+      ...(output.options ? { options: output.options } : {}),
+    }],
+    prompt: "Find the operator.",
+    definition_hash: "sync-rollback",
+    path: "/tmp/sync_rollback.md",
   };
 }
 
@@ -520,4 +597,21 @@ async function activeAttributeCount(
     [recordId, ...attributeSlugs],
   );
   return Number(result.rows[0]?.count ?? 0);
+}
+
+async function attributeType(
+  workspace: Workspace,
+  objectSlug: string,
+  attributeSlug: string,
+): Promise<string | null> {
+  const result = await exec(
+    workspace.db,
+    `SELECT attribute_type
+       FROM acrm_attribute
+      WHERE object_slug = $1
+        AND attribute_slug = $2
+      LIMIT 1`,
+    [objectSlug, attributeSlug],
+  );
+  return (result.rows[0]?.attribute_type as string | undefined) ?? null;
 }

--- a/packages/sdk/src/operations/transactional-writes.test.ts
+++ b/packages/sdk/src/operations/transactional-writes.test.ts
@@ -92,6 +92,29 @@ describe("transactional SDK writes", () => {
     );
   });
 
+  it("dedupes transcript imports with oversized unique source IDs", async () => {
+    await withWorkspace(async (workspace) => {
+      const sourceId = `manual:${"source-id-".repeat(700)}`;
+      await importTranscript(workspace, {
+        source: "manual",
+        source_id: sourceId,
+        title: "Intro",
+        participants: [{ email: "alice@example.com" }],
+      });
+      await importTranscript(workspace, {
+        source: "manual",
+        source_id: sourceId,
+        title: "Intro again",
+        participants: [{ email: "alice@example.com" }],
+      });
+
+      await expect(recordCount(workspace, "transcripts")).resolves.toBe(1);
+      await expect(
+        normalizedKeyFor(workspace, "transcripts", "source_id"),
+      ).resolves.toMatch(/^sha256:[0-9a-f]{64}$/);
+    });
+  });
+
   it("rolls back X profile record shells if value insertion fails", async () => {
     const cacheDir = await mkdtemp(path.join(os.tmpdir(), "acrm-x-profile-"));
     try {
@@ -578,6 +601,24 @@ async function activeValueRecordId(
     [objectSlug, attributeSlug, normalizedKey],
   );
   return (result.rows[0]?.record_id as string | undefined) ?? null;
+}
+
+async function normalizedKeyFor(
+  workspace: Workspace,
+  objectSlug: string,
+  attributeSlug: string,
+): Promise<string | null> {
+  const result = await exec(
+    workspace.db,
+    `SELECT normalized_key
+       FROM acrm_value
+      WHERE object_slug = $1
+        AND attribute_slug = $2
+        AND active_until IS NULL
+      LIMIT 1`,
+    [objectSlug, attributeSlug],
+  );
+  return (result.rows[0]?.normalized_key as string | null | undefined) ?? null;
 }
 
 async function activeAttributeCount(

--- a/packages/sdk/src/operations/transactional-writes.test.ts
+++ b/packages/sdk/src/operations/transactional-writes.test.ts
@@ -1,0 +1,523 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { newDb } from "pg-mem";
+import { describe, expect, it } from "vitest";
+import { exec } from "../db/execute.js";
+import { PostgresDatabase } from "../db/postgres.js";
+import type { AcrmDatabase, ExecuteResult, SqlValue } from "../db/types.js";
+import { uuidv7 } from "../lib/uuidv7.js";
+import { Workspace } from "../workspace.js";
+import { importCsv } from "./import-csv.js";
+import { importGoogleContacts } from "./import-google.js";
+import { importPost } from "./import-post.js";
+import { importTranscript } from "./import-transcript.js";
+import { importXProfile } from "./import-x.js";
+import { createRecord, dedupeRecords } from "./records.js";
+import { runSignals, type SignalRunner } from "./signals.js";
+
+describe("transactional SDK writes", () => {
+  it("rolls back createRecord record shells if value insertion fails", async () => {
+    await withWorkspace(
+      async (workspace) => {
+        await expect(createRecord(workspace, {
+          object_slug: "people",
+          fields: ["name=Alice"],
+        })).rejects.toThrow("forced value insert failure");
+
+        await expect(recordCount(workspace, "people")).resolves.toBe(0);
+        await expect(valueCount(workspace)).resolves.toBe(0);
+      },
+      { wrapDb: (db) => new FailingValueInsertDatabase(db) },
+    );
+  });
+
+  it("rolls back CSV import record shells if value insertion fails", async () => {
+    await withWorkspace(
+      async (workspace) => {
+        await expect(importCsv(workspace, {
+          csvText: "name,email\nAlice,alice@example.com\n",
+          source: "test-csv",
+        })).rejects.toThrow("forced value insert failure");
+
+        await expect(recordCount(workspace, "people")).resolves.toBe(0);
+        await expect(recordCount(workspace, "companies")).resolves.toBe(0);
+        await expect(valueCount(workspace)).resolves.toBe(0);
+      },
+      { wrapDb: (db) => new FailingValueInsertDatabase(db) },
+    );
+  });
+
+  it("rolls back Google contact record shells if value insertion fails", async () => {
+    await withWorkspace(
+      async (workspace) => {
+        await expect(importGoogleContacts(workspace, {
+          contacts: [{
+            resource_name: "people/c1",
+            origin: "connections",
+            display_name: "Alice",
+            emails: ["alice@example.com"],
+          }],
+        })).rejects.toThrow("forced value insert failure");
+
+        await expect(recordCount(workspace, "people")).resolves.toBe(0);
+        await expect(recordCount(workspace, "companies")).resolves.toBe(0);
+        await expect(valueCount(workspace)).resolves.toBe(0);
+      },
+      { wrapDb: (db) => new FailingValueInsertDatabase(db) },
+    );
+  });
+
+  it("rolls back transcript import record shells if value insertion fails", async () => {
+    await withWorkspace(
+      async (workspace) => {
+        await expect(importTranscript(workspace, {
+          source: "manual",
+          source_id: "transcript-1",
+          title: "Intro",
+          participants: [{ email: "alice@example.com" }],
+        })).rejects.toThrow("forced value insert failure");
+
+        await expect(recordCount(workspace, "people")).resolves.toBe(0);
+        await expect(recordCount(workspace, "transcripts")).resolves.toBe(0);
+        await expect(valueCount(workspace)).resolves.toBe(0);
+      },
+      { wrapDb: (db) => new FailingValueInsertDatabase(db) },
+    );
+  });
+
+  it("rolls back X profile record shells if value insertion fails", async () => {
+    const cacheDir = await mkdtemp(path.join(os.tmpdir(), "acrm-x-profile-"));
+    try {
+      await writeFile(
+        path.join(cacheDir, "alice.json"),
+        JSON.stringify({ username: "alice", name: "Alice" }),
+        "utf8",
+      );
+
+      await withWorkspace(
+        async (workspace) => {
+          await expect(importXProfile(workspace, {
+            handleOrUrl: "alice",
+            token: "unused",
+            cacheDir,
+          })).rejects.toThrow("forced value insert failure");
+
+          await expect(recordCount(workspace, "people")).resolves.toBe(0);
+          await expect(valueCount(workspace)).resolves.toBe(0);
+        },
+        { wrapDb: (db) => new FailingValueInsertDatabase(db) },
+      );
+    } finally {
+      await rm(cacheDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rolls back post author records if post insertion fails", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "acrm-post-import-"));
+    const postCacheDir = path.join(root, "posts");
+    const profileCacheDir = path.join(root, "profiles");
+    try {
+      await mkdir(postCacheDir);
+      await mkdir(profileCacheDir);
+      await writeFile(
+        path.join(postCacheDir, "1234567890.json"),
+        JSON.stringify({
+          url: "https://x.com/alice/status/1234567890",
+          author: { username: "alice" },
+          createdAt: "2026-01-15T12:00:00.000Z",
+          text: "hello from x",
+        }),
+        "utf8",
+      );
+      await writeFile(
+        path.join(profileCacheDir, "alice.json"),
+        JSON.stringify({ username: "alice", name: "Alice" }),
+        "utf8",
+      );
+
+      await withWorkspace(
+        async (workspace) => {
+          await expect(importPost(workspace, {
+            rawUrl: "https://x.com/alice/status/1234567890",
+            token: "unused",
+            postCacheDir,
+            profileCacheDir,
+          })).rejects.toThrow("forced value insert failure");
+
+          await expect(recordCount(workspace, "people")).resolves.toBe(0);
+          await expect(recordCount(workspace, "posts")).resolves.toBe(0);
+          await expect(valueCount(workspace)).resolves.toBe(0);
+        },
+        {
+          wrapDb: (db) =>
+            new FailingValueInsertDatabase(db, {
+              shouldFail: (sql, params) =>
+                /\bINSERT\s+INTO\s+acrm_value\b/i.test(sql) &&
+                params?.[1] === "posts",
+            }),
+        },
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rolls back dedupe rewrites if deleting the discard record fails", async () => {
+    await withWorkspace(
+      async (workspace) => {
+        const keeper = await createRecord(workspace, {
+          object_slug: "people",
+          fields: ["email_addresses=keeper@example.com"],
+        });
+        const discard = await createRecord(workspace, {
+          object_slug: "people",
+          fields: ["email_addresses=discard@example.com"],
+        });
+
+        await expect(dedupeRecords(workspace, {
+          object_slug: "people",
+          keep_record_id: keeper.record_id,
+          discard_record_id: discard.record_id,
+          prefer: "keep",
+          dryRun: false,
+        })).rejects.toThrow("forced value insert failure");
+
+        await expect(recordExists(workspace, "people", discard.record_id)).resolves.toBe(true);
+        await expect(
+          activeValueRecordId(workspace, "people", "email_addresses", "discard@example.com"),
+        ).resolves.toBe(discard.record_id);
+      },
+      {
+        wrapDb: (db) =>
+          new FailingValueInsertDatabase(db, {
+            shouldFail: (sql) => /\bDELETE\s+FROM\s+acrm_record\b/i.test(sql),
+          }),
+      },
+    );
+  });
+
+  it("rolls back partial signal output writes if one output fails", async () => {
+    const { dir, cleanup } = await withSignalDir();
+    let signalValueInserts = 0;
+    try {
+      await withWorkspace(
+        async (workspace) => {
+          const company = await createRecord(workspace, {
+            object_slug: "companies",
+            fields: ["name=Example Co"],
+          });
+          const runner: SignalRunner = async () =>
+            JSON.stringify({
+              outputs: [
+                {
+                  key: "operator_status",
+                  value: "owner_identified",
+                  confidence: "high",
+                  citations: [],
+                  reasoning: "status",
+                },
+                {
+                  key: "operator_name",
+                  value: "Example Holdings",
+                  confidence: "high",
+                  citations: [],
+                  reasoning: "name",
+                },
+              ],
+            });
+
+          const result = await runSignals(workspace, {
+            signalsDir: dir,
+            records: [{ object_slug: "companies", record_id: company.record_id }],
+            mode: "force",
+            runner,
+          });
+
+          expect(result.runs_failed).toBe(1);
+          expect(result.values_written).toBe(0);
+          await expect(
+            activeAttributeCount(workspace, company.record_id, [
+              "operator_status",
+              "operator_name",
+            ]),
+          ).resolves.toBe(0);
+        },
+        {
+          wrapDb: (db) =>
+            new FailingValueInsertDatabase(db, {
+              shouldFail: (sql, params) => {
+                if (
+                  !/\bINSERT\s+INTO\s+acrm_value\b/i.test(sql) ||
+                  params?.[9] !== "signal:rollback_signal"
+                ) {
+                  return false;
+                }
+                signalValueInserts++;
+                return signalValueInserts === 2;
+              },
+            }),
+        },
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+});
+
+async function withWorkspace(
+  run: (workspace: Workspace) => Promise<void>,
+  options: { wrapDb?: (db: AcrmDatabase) => AcrmDatabase } = {},
+): Promise<void> {
+  const mem = newDb({ noAstCoverageCheck: true });
+  mem.public.registerFunction({
+    name: "gen_random_uuid",
+    returns: "text",
+    implementation: () => uuidv7(),
+  });
+  const pg = mem.adapters.createPg();
+  const pool = new pg.Pool();
+  const baseDb = PostgresDatabase.fromQueryable(pool, () => pool.end());
+  const db = options.wrapDb?.(baseDb) ?? baseDb;
+  const workspace = await Workspace.create({ db });
+  try {
+    await run(workspace);
+  } finally {
+    await workspace.close();
+    await db.close();
+  }
+}
+
+async function withSignalDir(): Promise<{ dir: string; cleanup: () => Promise<void> }> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "acrm-signal-rollback-"));
+  const dir = path.join(root, "signals");
+  await mkdir(dir);
+  await writeFile(
+    path.join(dir, "rollback_signal.md"),
+    `---
+slug: rollback_signal
+title: Rollback Signal
+object: companies
+---
+
+\`\`\`json acrm-signal
+{
+  "outputs": [
+    {
+      "key": "operator_status",
+      "attribute": "operator_status",
+      "title": "Operator status",
+      "type": "status",
+      "options": ["owner_identified:Owner identified", "unclear:Unclear"]
+    },
+    {
+      "key": "operator_name",
+      "attribute": "operator_name",
+      "title": "Operator name",
+      "type": "text"
+    }
+  ]
+}
+\`\`\`
+
+Find the operator.
+`,
+    "utf8",
+  );
+  return {
+    dir,
+    cleanup: () => rm(root, { recursive: true, force: true }),
+  };
+}
+
+type FailingDatabaseOptions = {
+  shouldFail?: (
+    sql: string,
+    params?: ReadonlyArray<SqlValue>,
+  ) => boolean;
+};
+
+class FailingValueInsertDatabase implements AcrmDatabase {
+  private readonly shouldFail: (
+    sql: string,
+    params?: ReadonlyArray<SqlValue>,
+  ) => boolean;
+
+  constructor(
+    private readonly inner: AcrmDatabase,
+    options: FailingDatabaseOptions = {},
+    private readonly inTransaction = false,
+  ) {
+    this.shouldFail =
+      options.shouldFail ??
+      ((sql) => /\bINSERT\s+INTO\s+acrm_value\b/i.test(sql));
+  }
+
+  async execute(
+    sql: string,
+    params?: ReadonlyArray<SqlValue>,
+  ): Promise<ExecuteResult> {
+    if (this.shouldFail(sql, params)) {
+      throw new Error("forced value insert failure");
+    }
+    return await this.inner.execute(sql, params);
+  }
+
+  async transaction<T>(fn: (db: AcrmDatabase) => Promise<T>): Promise<T> {
+    const snapshot = await snapshotRecordsAndValues(this.inner);
+    if (this.inTransaction) {
+      try {
+        return await fn(new FailingValueInsertDatabase(
+          this.inner,
+          { shouldFail: this.shouldFail },
+          true,
+        ));
+      } catch (error) {
+        await restoreRecordsAndValues(this.inner, snapshot);
+        throw error;
+      }
+    }
+
+    try {
+      return await this.inner.transaction((db) =>
+        fn(new FailingValueInsertDatabase(
+          db,
+          { shouldFail: this.shouldFail },
+          true,
+        ))
+      );
+    } catch (error) {
+      await restoreRecordsAndValues(this.inner, snapshot);
+      throw error;
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.inner.close();
+  }
+}
+
+type DatabaseSnapshot = {
+  records: Array<Record<string, SqlValue>>;
+  values: Array<Record<string, SqlValue>>;
+};
+
+async function snapshotRecordsAndValues(db: AcrmDatabase): Promise<DatabaseSnapshot> {
+  const records = await db.execute(
+    "SELECT object_slug, record_id, archived FROM acrm_record",
+  );
+  const values = await db.execute(
+    `SELECT id, object_slug, record_id, attribute_slug, value_json,
+            active_from, active_until, normalized_key, ref_object, ref_record_id,
+            source, provenance_json
+       FROM acrm_value`,
+  );
+  return {
+    records: records.rows as Array<Record<string, SqlValue>>,
+    values: values.rows as Array<Record<string, SqlValue>>,
+  };
+}
+
+async function restoreRecordsAndValues(
+  db: AcrmDatabase,
+  snapshot: DatabaseSnapshot,
+): Promise<void> {
+  await db.execute("DELETE FROM acrm_value");
+  await db.execute("DELETE FROM acrm_record");
+  for (const record of snapshot.records) {
+    await db.execute(
+      `INSERT INTO acrm_record (object_slug, record_id, archived)
+       VALUES ($1, $2, $3)`,
+      [record.object_slug, record.record_id, record.archived ?? null],
+    );
+  }
+  for (const value of snapshot.values) {
+    await db.execute(
+      `INSERT INTO acrm_value
+         (id, object_slug, record_id, attribute_slug, value_json,
+          active_from, active_until, normalized_key, ref_object, ref_record_id,
+          source, provenance_json)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+      [
+        value.id,
+        value.object_slug,
+        value.record_id,
+        value.attribute_slug,
+        value.value_json,
+        value.active_from,
+        value.active_until ?? null,
+        value.normalized_key ?? null,
+        value.ref_object ?? null,
+        value.ref_record_id ?? null,
+        value.source ?? null,
+        value.provenance_json ?? null,
+      ],
+    );
+  }
+}
+
+async function recordCount(workspace: Workspace, objectSlug: string): Promise<number> {
+  const result = await exec(
+    workspace.db,
+    "SELECT COUNT(*) AS count FROM acrm_record WHERE object_slug = $1",
+    [objectSlug],
+  );
+  return Number(result.rows[0]?.count ?? 0);
+}
+
+async function recordExists(
+  workspace: Workspace,
+  objectSlug: string,
+  recordId: string,
+): Promise<boolean> {
+  const result = await exec(
+    workspace.db,
+    "SELECT 1 FROM acrm_record WHERE object_slug = $1 AND record_id = $2",
+    [objectSlug, recordId],
+  );
+  return result.rows.length > 0;
+}
+
+async function valueCount(workspace: Workspace): Promise<number> {
+  const result = await exec(workspace.db, "SELECT COUNT(*) AS count FROM acrm_value");
+  return Number(result.rows[0]?.count ?? 0);
+}
+
+async function activeValueRecordId(
+  workspace: Workspace,
+  objectSlug: string,
+  attributeSlug: string,
+  normalizedKey: string,
+): Promise<string | null> {
+  const result = await exec(
+    workspace.db,
+    `SELECT record_id
+       FROM acrm_value
+      WHERE object_slug = $1
+        AND attribute_slug = $2
+        AND normalized_key = $3
+        AND active_until IS NULL
+      LIMIT 1`,
+    [objectSlug, attributeSlug, normalizedKey],
+  );
+  return (result.rows[0]?.record_id as string | undefined) ?? null;
+}
+
+async function activeAttributeCount(
+  workspace: Workspace,
+  recordId: string,
+  attributeSlugs: string[],
+): Promise<number> {
+  const placeholders = attributeSlugs.map((_, index) => `$${index + 2}`).join(", ");
+  const result = await exec(
+    workspace.db,
+    `SELECT COUNT(*) AS count
+       FROM acrm_value
+      WHERE object_slug = 'companies'
+        AND record_id = $1
+        AND attribute_slug IN (${placeholders})
+        AND active_until IS NULL`,
+    [recordId, ...attributeSlugs],
+  );
+  return Number(result.rows[0]?.count ?? 0);
+}


### PR DESCRIPTION
## Summary
- wrap Gmail, LinkedIn, CSV, Google Contacts, transcript, X profile, post import, record create/update, dedupe, signal schema sync, and signal-output writes in SDK database transactions
- split profile fetch/map from profile row upserts so `importPost` keeps network/cache work outside the database transaction while making author + post writes atomic
- preserve outer Postgres transactions by using savepoints for nested SDK transactions
- avoid oversized normalized-key entries for long text/url values
- honor `channel_binding=require|prefer` connection-string params by enabling node-postgres channel binding
- add rollback coverage for the Postgres adapter, provider contracts, imports, record writes, post imports, dedupe, signal schema sync, signal writes, nested transaction behavior, and provider option resolution
- include a patch changeset for @agent-crm/sdk

## Testing
- npm run test --workspace @agent-crm/sdk -- src/db/providers/registry.test.ts
- npm run test --workspace @agent-crm/sdk -- src/operations/transactional-writes.test.ts
- npm run test --workspace @agent-crm/sdk -- src/operations/transactional-writes.test.ts src/operations/import-linkedin.test.ts
- npm run test --workspace @agent-crm/sdk
- npm test
- npm run build
- git diff --check


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make SDK Postgres writes transactional to prevent partial record shells on failure
> - Wraps all major SDK write paths (CSV import, Google Contacts, LinkedIn, X, transcript, post, signal, record create/update, dedupe) in database transactions so failures roll back cleanly without leaving orphaned record rows.
> - Adds savepoint support to `PostgresDatabase.transaction` for nested transactions, and adds passthrough mode for externally-managed clients via `fromClient`.
> - Normalizes oversized text and URL values to `sha256:<hex>` keys (capped at 1024 bytes) in `normalizeUniqueKey` and new `normalizeLookupKey`, fixing lookups for unbounded strings.
> - Honors `channel_binding=require|prefer` in Postgres connection strings by mapping to `enableChannelBinding` in pool options.
> - Risk: normalized keys for text/URL values longer than 1024 bytes will change from the raw value to a `sha256:` hash, affecting any existing rows stored with the old key format.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d9bf9f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->