### PR TITLE
fix: silence postgres sslmode warning

### DIFF
--- a/.changeset/smooth-postgres-sslmode.md
+++ b/.changeset/smooth-postgres-sslmode.md
@@ -1,0 +1,6 @@
+---
+"@agent-crm/sdk": patch
+"@agent-crm/cli": patch
+---
+
+Canonicalize Postgres `sslmode=require`/`prefer`/`verify-ca` to `verify-full` before opening node-postgres pools so Neon/Supabase URLs do not emit a misleading SSL warning while preserving current TLS verification behavior.

--- a/packages/sdk/src/db/postgres.test.ts
+++ b/packages/sdk/src/db/postgres.test.ts
@@ -42,6 +42,35 @@ describe("PostgresDatabase", () => {
     }
   });
 
+  it("canonicalizes sslmode aliases that node-postgres warns about", async () => {
+    const required = PostgresDatabase.connect(
+      "postgresql://user:pass@example.com/db?sslmode=require&channel_binding=require",
+    );
+    const preferred = PostgresDatabase.connect({
+      connectionString: "postgresql://user:pass@example.com/db?sslmode=prefer",
+    });
+    const verifyCa = PostgresDatabase.connect(
+      "postgresql://user:pass@example.com/db?sslmode=verify-ca",
+    );
+    const disabled = PostgresDatabase.connect(
+      "postgresql://user:pass@example.com/db?sslmode=disable",
+    );
+    try {
+      expect(poolOptions(required).connectionString).toContain("sslmode=verify-full");
+      expect(poolOptions(required).enableChannelBinding).toBe(true);
+      expect(poolOptions(preferred).connectionString).toContain("sslmode=verify-full");
+      expect(poolOptions(verifyCa).connectionString).toContain("sslmode=verify-full");
+      expect(poolOptions(disabled).connectionString).toContain("sslmode=disable");
+    } finally {
+      await Promise.all([
+        required.close(),
+        preferred.close(),
+        verifyCa.close(),
+        disabled.close(),
+      ]);
+    }
+  });
+
   it("rolls back failed pool-backed transactions", async () => {
     const pool = new TransactionalPool();
     const db = PostgresDatabase.fromQueryable(pool);
@@ -145,9 +174,12 @@ async function expectRollback(db: AcrmDatabase): Promise<void> {
   expect(result.rows).toEqual([]);
 }
 
-function poolOptions(db: PostgresDatabase): { enableChannelBinding?: boolean } {
+function poolOptions(db: PostgresDatabase): {
+  connectionString?: string;
+  enableChannelBinding?: boolean;
+} {
   return (db as unknown as {
-    queryable: { options: { enableChannelBinding?: boolean } };
+    queryable: { options: { connectionString?: string; enableChannelBinding?: boolean } };
   }).queryable.options;
 }
 

--- a/packages/sdk/src/db/postgres.ts
+++ b/packages/sdk/src/db/postgres.ts
@@ -133,12 +133,18 @@ function connectionOptionsFromString(
 function normalizeConnectionOptions(
   options: PostgresConnectionOptions,
 ): PostgresConnectionOptions {
-  if (options.enableChannelBinding !== undefined) return options;
+  const normalized: PostgresConnectionOptions = {
+    ...options,
+    connectionString: normalizeConnectionString(options.connectionString),
+  };
   const channelBinding = channelBindingMode(options.connectionString);
-  if (channelBinding === "require" || channelBinding === "prefer") {
-    return { ...options, enableChannelBinding: true };
+  if (
+    options.enableChannelBinding === undefined &&
+    (channelBinding === "require" || channelBinding === "prefer")
+  ) {
+    return { ...normalized, enableChannelBinding: true };
   }
-  return options;
+  return normalized;
 }
 
 function channelBindingMode(connectionString: string): string | null {
@@ -150,4 +156,20 @@ function channelBindingMode(connectionString: string): string | null {
   } catch {
     return null;
   }
+}
+
+function normalizeConnectionString(connectionString: string): string {
+  try {
+    const parsed = new URL(connectionString);
+    const sslmode = parsed.searchParams.get("sslmode")?.toLowerCase();
+    if (sslmode === "prefer" || sslmode === "require" || sslmode === "verify-ca") {
+      // node-postgres 8 treats these aliases as verify-full and warns. Pass the
+      // explicit mode to preserve today's behavior without emitting the warning.
+      parsed.searchParams.set("sslmode", "verify-full");
+      return parsed.toString();
+    }
+  } catch {
+    return connectionString;
+  }
+  return connectionString;
 }


### PR DESCRIPTION
## Summary
- canonicalize node-postgres sslmode aliases (`require`, `prefer`, `verify-ca`) to `verify-full` before opening pools
- preserve existing channel binding mapping for Neon-style URLs
- add a changeset so both SDK and CLI are republished

## Verification
- `npm run test --workspace @agent-crm/sdk -- src/db/postgres.test.ts src/db/providers/registry.test.ts`
- `npm run build`
- live `connect linkedin --status` smoke against Postgres: no SSL warning; workspace reports LinkedIn not connected
- live `import linkedin` smoke against Postgres: no SSL warning; returns the real not-connected error
- `npm test`
- `npm run check:agent-instructions --workspace @agent-crm/cli`
- `git diff --check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Silence Postgres sslmode warning by canonicalizing aliases to `verify-full`
> - Adds `normalizeConnectionString` in [`postgres.ts`](https://github.com/cluster-software/agent-crm/pull/186/files#diff-05ba48e5893c4b96ef71ea08d57c1d5b43b2a7d789bc6300fb7d3fa724e1f905) that rewrites `sslmode=require`, `prefer`, and `verify-ca` to `sslmode=verify-full` before opening a connection pool, suppressing the node-postgres warning these values trigger.
> - Auto-enabling of channel binding is now gated to only apply when `enableChannelBinding` is not already set and `channel_binding` in the URL is `require` or `prefer`.
> - Behavioral Change: connections previously opened with `sslmode=require`, `prefer`, or `verify-ca` will now use `verify-full`, which enforces certificate validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a113267.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->