### PR TITLE
fix: use org_id in cloud workspace metadata

### DIFF
--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -167,7 +167,6 @@ type LinkedinConnectResult = {
   auth_url: string;
   workspace_id: string;
   org_id: string | null;
-  cluster_org_id: string | null;
   sync_engine_url: string;
   linkedin: CliProviderStatus;
 } | {
@@ -175,7 +174,6 @@ type LinkedinConnectResult = {
   message: string;
   workspace_id: string;
   org_id: string | null;
-  cluster_org_id: string | null;
   sync_engine_url: string;
   linkedin: CliProviderStatus;
 };
@@ -199,7 +197,6 @@ async function runConnectLinkedin(opts: CommandWorkspaceOpts & { orgId?: string 
         message: linkedinAlreadyConnectedMessage(linkedin),
         workspace_id: cloudSession.workspaceId,
         org_id: orgId,
-        cluster_org_id: orgId,
         sync_engine_url: cloudSession.syncEngineUrl,
         linkedin,
       };
@@ -218,7 +215,6 @@ async function runConnectLinkedin(opts: CommandWorkspaceOpts & { orgId?: string 
       }), handoff.code),
       workspace_id: cloudSession.workspaceId,
       org_id: orgId,
-      cluster_org_id: orgId,
       sync_engine_url: cloudSession.syncEngineUrl,
       linkedin,
     };
@@ -229,7 +225,7 @@ async function runConnectLinkedin(opts: CommandWorkspaceOpts & { orgId?: string 
   const metadata = await ensureCloudWorkspaceMetadataForWorkspace(workspaceFile, {
     workspaceId: process.env.ACRM_CLOUD_WORKSPACE_ID,
     clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,
-    clusterOrgId: opts.orgId ?? process.env.ACRM_CLOUD_ORG_ID ?? process.env.ACRM_CLOUD_CLUSTER_ORG_ID,
+    orgId: opts.orgId ?? process.env.ACRM_CLOUD_ORG_ID,
   }, { db: opts.db });
   const syncEngineUrl = process.env.ACRM_SYNC_ENGINE_URL ?? DEFAULT_SYNC_ENGINE_URL;
   await registerCloudWorkspace({
@@ -251,8 +247,7 @@ async function runConnectLinkedin(opts: CommandWorkspaceOpts & { orgId?: string 
       connected: true,
       message: linkedinAlreadyConnectedMessage(linkedin),
       workspace_id: metadata.workspaceId,
-      org_id: metadata.clusterOrgId ?? null,
-      cluster_org_id: metadata.clusterOrgId ?? null,
+      org_id: metadata.orgId ?? null,
       sync_engine_url: syncEngineUrl,
       linkedin,
     };
@@ -262,12 +257,11 @@ async function runConnectLinkedin(opts: CommandWorkspaceOpts & { orgId?: string 
     auth_url: linkedinConnectUrl({
       syncEngineUrl,
       workspaceId: metadata.workspaceId,
-      orgId: metadata.clusterOrgId,
+      orgId: metadata.orgId,
       workspaceName,
     }),
     workspace_id: metadata.workspaceId,
-    org_id: metadata.clusterOrgId ?? null,
-    cluster_org_id: metadata.clusterOrgId ?? null,
+    org_id: metadata.orgId ?? null,
     sync_engine_url: syncEngineUrl,
     linkedin,
   };
@@ -311,7 +305,7 @@ async function runConnectLinkedinStatus(opts: CommandWorkspaceOpts): Promise<{
   const metadata = await ensureCloudWorkspaceMetadataForWorkspace(workspaceFile, {
     workspaceId: process.env.ACRM_CLOUD_WORKSPACE_ID,
     clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,
-    clusterOrgId: process.env.ACRM_CLOUD_ORG_ID ?? process.env.ACRM_CLOUD_CLUSTER_ORG_ID,
+    orgId: process.env.ACRM_CLOUD_ORG_ID,
   }, { db: opts.db });
   const syncEngineUrl = process.env.ACRM_SYNC_ENGINE_URL ?? DEFAULT_SYNC_ENGINE_URL;
   const status = await fetchCloudIntegrationStatus({
@@ -321,7 +315,7 @@ async function runConnectLinkedinStatus(opts: CommandWorkspaceOpts): Promise<{
   });
   return {
     workspace_id: metadata.workspaceId,
-    org_id: metadata.clusterOrgId ?? null,
+    org_id: metadata.orgId ?? null,
     sync_engine_url: syncEngineUrl,
     linkedin: toCliProviderStatus(status.linkedin, {
       requireActiveAccount: true,
@@ -352,7 +346,7 @@ async function runConnectGranola(opts: {
 }): Promise<{
   auth_url: string;
   workspace_id: string;
-  cluster_org_id: string | null;
+  org_id: string | null;
   sync_engine_url: string;
   connected: boolean;
   account?: unknown;
@@ -382,7 +376,7 @@ async function runConnectGranola(opts: {
     return {
       auth_url,
       workspace_id: metadata.workspaceId,
-      cluster_org_id: metadata.clusterOrgId ?? null,
+      org_id: metadata.orgId ?? null,
       sync_engine_url: syncEngineUrl,
       connected: false,
     };
@@ -397,7 +391,7 @@ async function runConnectGranola(opts: {
   return {
     auth_url,
     workspace_id: metadata.workspaceId,
-    cluster_org_id: metadata.clusterOrgId ?? null,
+    org_id: metadata.orgId ?? null,
     sync_engine_url: syncEngineUrl,
     connected: true,
     account: connected.account,
@@ -414,7 +408,7 @@ async function runConnectGranolaStatus(opts: CommandWorkspaceOpts): Promise<{
   const metadata = await ensureCloudWorkspaceMetadataForWorkspace(workspaceFile, {
     workspaceId: process.env.ACRM_CLOUD_WORKSPACE_ID,
     clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,
-    clusterOrgId: process.env.ACRM_CLOUD_ORG_ID ?? process.env.ACRM_CLOUD_CLUSTER_ORG_ID,
+    orgId: process.env.ACRM_CLOUD_ORG_ID,
   }, { db: opts.db });
   const syncEngineUrl = process.env.ACRM_SYNC_ENGINE_URL ?? DEFAULT_SYNC_ENGINE_URL;
   const status = await fetchCloudIntegrationStatus({

--- a/packages/cli/src/commands/import-gmail.test.ts
+++ b/packages/cli/src/commands/import-gmail.test.ts
@@ -189,7 +189,6 @@ describe("importGoogleContacts", () => {
 
       expect(result.workspace_id).toBe("workspace-1");
       expect(result.org_id).toBe("org-1");
-      expect(result.cluster_org_id).toBe("org-1");
       expect(result.sync_engine_url).toBe("https://sync.example.com");
       expect(authUrl.origin + authUrl.pathname).toBe("https://sync.example.com/integrations/gmail/connect");
       expect(authUrl.searchParams.get("workspace_id")).toBe("workspace-1");

--- a/packages/cli/src/commands/import-gmail.ts
+++ b/packages/cli/src/commands/import-gmail.ts
@@ -88,7 +88,6 @@ async function runImportGmail(opts: {
   auth_url: string;
   workspace_id: string;
   org_id: string | null;
-  cluster_org_id: string | null;
   sync_engine_url: string;
   gmail_sync_preferences?: GmailSyncPreferences;
 }> {
@@ -113,7 +112,6 @@ async function runImportGmail(opts: {
       auth_url: authUrl,
       workspace_id: cloudSession.workspaceId,
       org_id: orgId,
-      cluster_org_id: orgId,
       sync_engine_url: cloudSession.syncEngineUrl,
       ...(hasGmailSyncPreferences(opts)
         ? {
@@ -132,7 +130,7 @@ async function runImportGmail(opts: {
   const metadata = await ensureCloudWorkspaceMetadataForWorkspace(workspaceFile, {
     workspaceId: process.env.ACRM_CLOUD_WORKSPACE_ID,
     clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,
-    clusterOrgId: opts.orgId ?? process.env.ACRM_CLOUD_ORG_ID ?? process.env.ACRM_CLOUD_CLUSTER_ORG_ID,
+    orgId: opts.orgId ?? process.env.ACRM_CLOUD_ORG_ID,
   }, { db: opts.db });
   const syncEngineUrl = process.env.ACRM_SYNC_ENGINE_URL ?? DEFAULT_SYNC_ENGINE_URL;
   await registerCloudWorkspace({
@@ -145,15 +143,14 @@ async function runImportGmail(opts: {
     auth_url: gmailConnectUrl({
       syncEngineUrl,
       workspaceId: metadata.workspaceId,
-      orgId: metadata.clusterOrgId,
+      orgId: metadata.orgId,
       workspaceName,
       backfillDays: opts.backfillDays,
       backfillSince: opts.backfillSince,
       excludeNewsletters: opts.excludeNewsletters,
     }),
     workspace_id: metadata.workspaceId,
-    org_id: metadata.clusterOrgId ?? null,
-    cluster_org_id: metadata.clusterOrgId ?? null,
+    org_id: metadata.orgId ?? null,
     sync_engine_url: syncEngineUrl,
     ...(hasGmailSyncPreferences(opts)
       ? {

--- a/packages/cli/src/commands/import-granola.ts
+++ b/packages/cli/src/commands/import-granola.ts
@@ -73,7 +73,7 @@ async function runImportGranola(opts: {
   const metadata = await ensureCloudWorkspaceMetadataForWorkspace(workspaceFile, {
     workspaceId: process.env.ACRM_CLOUD_WORKSPACE_ID,
     clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,
-    clusterOrgId: process.env.ACRM_CLOUD_ORG_ID ?? process.env.ACRM_CLOUD_CLUSTER_ORG_ID,
+    orgId: process.env.ACRM_CLOUD_ORG_ID,
   }, { db: opts.db });
   const syncEngineUrl = process.env.ACRM_SYNC_ENGINE_URL ?? DEFAULT_SYNC_ENGINE_URL;
   let backfill: { started: number; integration_account_ids: string[] } | undefined;

--- a/packages/cli/src/commands/import-linkedin.ts
+++ b/packages/cli/src/commands/import-linkedin.ts
@@ -161,7 +161,7 @@ async function runImportLinkedinNetwork(opts: { workspace?: string; db?: AcrmDat
   const metadata = await ensureCloudWorkspaceMetadataForWorkspace(workspaceFile, {
     workspaceId: process.env.ACRM_CLOUD_WORKSPACE_ID,
     clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,
-    clusterOrgId: process.env.ACRM_CLOUD_ORG_ID ?? process.env.ACRM_CLOUD_CLUSTER_ORG_ID,
+    orgId: process.env.ACRM_CLOUD_ORG_ID,
   }, { db: opts.db });
   const syncEngineUrl = process.env.ACRM_SYNC_ENGINE_URL ?? DEFAULT_SYNC_ENGINE_URL;
   const { relations } = await fetchCloudLinkedinRelationsExport({
@@ -291,7 +291,7 @@ async function runSyncLinkedin(opts: { workspace?: string; db?: AcrmDatabase }):
   const metadata = await ensureCloudWorkspaceMetadataForWorkspace(workspaceFile, {
     workspaceId: process.env.ACRM_CLOUD_WORKSPACE_ID,
     clientToken: process.env.ACRM_CLOUD_WORKSPACE_CLIENT_TOKEN,
-    clusterOrgId: process.env.ACRM_CLOUD_ORG_ID ?? process.env.ACRM_CLOUD_CLUSTER_ORG_ID,
+    orgId: process.env.ACRM_CLOUD_ORG_ID,
   }, { db: opts.db });
   const syncEngineUrl = process.env.ACRM_SYNC_ENGINE_URL ?? DEFAULT_SYNC_ENGINE_URL;
   const batch = await fetchCloudCommunicationExport({

--- a/packages/cli/src/lib/cloud-workspace.test.ts
+++ b/packages/cli/src/lib/cloud-workspace.test.ts
@@ -34,13 +34,13 @@ describe("cloud workspace metadata", () => {
       const first = await ensureCloudWorkspaceMetadata(db, {
         workspaceId: "workspace-1",
         clientToken: "client-token-1",
-        clusterOrgId: "org-1",
+        orgId: "org-1",
       });
       const second = await ensureCloudWorkspaceMetadata(db);
-      const raw = await exec(db, "SELECT value FROM acrm_metadata WHERE key = $1", ["cloud.cluster_org_id"]);
+      const raw = await exec(db, "SELECT value FROM acrm_metadata WHERE key = $1", ["cloud.org_id"]);
 
-      expect(first.clusterOrgId).toBe("org-1");
-      expect(second.clusterOrgId).toBe("org-1");
+      expect(first.orgId).toBe("org-1");
+      expect(second.orgId).toBe("org-1");
       expect(raw.rows[0]?.value).toBe("org-1");
     } finally {
       await db.close();
@@ -74,7 +74,7 @@ describe("cloud workspace metadata", () => {
       await ensureCloudWorkspaceMetadata(db, {
         workspaceId: "workspace-1",
         clientToken: "client-token-1",
-        clusterOrgId: "org-1",
+        orgId: "org-1",
         localWorkspaceId: "local-1",
       });
       const raw = await exec(db, "SELECT value FROM acrm_metadata WHERE key = $1", ["cloud.workspace"]);
@@ -82,7 +82,7 @@ describe("cloud workspace metadata", () => {
       expect(JSON.parse(String(raw.rows[0]?.value))).toMatchObject({
         workspaceId: "workspace-1",
         clientToken: "client-token-1",
-        clusterOrgId: "org-1",
+        orgId: "org-1",
         localWorkspaceId: "local-1",
       });
     } finally {
@@ -137,7 +137,7 @@ describe("cloud workspace metadata", () => {
         `${JSON.stringify({
           workspaceId: "workspace-legacy",
           clientToken: "client-token-legacy",
-          clusterOrgId: "org-legacy",
+          orgId: "org-legacy",
         })}\n`,
         "utf8",
       );
@@ -151,11 +151,11 @@ describe("cloud workspace metadata", () => {
 
       expect(metadata.workspaceId).toBe("workspace-legacy");
       expect(metadata.clientToken).toBe("client-token-legacy");
-      expect(metadata.clusterOrgId).toBe("org-legacy");
+      expect(metadata.orgId).toBe("org-legacy");
       expect(JSON.parse(String(raw.rows[0]?.value))).toMatchObject({
         workspaceId: "workspace-legacy",
         clientToken: "client-token-legacy",
-        clusterOrgId: "org-legacy",
+        orgId: "org-legacy",
       });
     } finally {
       rmSync(legacyDir, { recursive: true, force: true });
@@ -200,14 +200,14 @@ describe("cloud workspace metadata", () => {
       await ensureCloudWorkspaceMetadata(db, {
         workspaceId: "workspace-db",
         clientToken: "client-token-db",
-        clusterOrgId: "org-db",
+        orgId: "org-db",
       });
       writeFileSync(
         join(legacyDir, ".agent-crm-cloud.json"),
         `${JSON.stringify({
           workspaceId: "workspace-legacy",
           clientToken: "client-token-legacy",
-          clusterOrgId: "org-legacy",
+          orgId: "org-legacy",
         })}\n`,
         "utf8",
       );
@@ -220,7 +220,7 @@ describe("cloud workspace metadata", () => {
 
       expect(metadata.workspaceId).toBe("workspace-db");
       expect(metadata.clientToken).toBe("client-token-db");
-      expect(metadata.clusterOrgId).toBe("org-db");
+      expect(metadata.orgId).toBe("org-db");
     } finally {
       rmSync(legacyDir, { recursive: true, force: true });
       await db.close();
@@ -238,12 +238,12 @@ describe("cloud workspace metadata", () => {
       const metadata = await ensureCloudWorkspaceMetadata(db, {
         workspaceId: "new-workspace",
         clientToken: "new-token",
-        clusterOrgId: "org-2",
+        orgId: "org-2",
       });
 
       expect(metadata.workspaceId).toBe("workspace-1");
       expect(metadata.clientToken).toBe("client-token-1");
-      expect(metadata.clusterOrgId).toBe("org-2");
+      expect(metadata.orgId).toBe("org-2");
       expect(metadata.localWorkspaceId).toBe("local-1");
     } finally {
       await db.close();

--- a/packages/cli/src/lib/cloud-workspace.ts
+++ b/packages/cli/src/lib/cloud-workspace.ts
@@ -37,7 +37,6 @@ const CLOUD_METADATA_KEYS = {
   workspaceId: "cloud.workspace_id",
   clientToken: "cloud.client_token",
   orgId: "cloud.org_id",
-  clusterOrgId: "cloud.cluster_org_id",
   localWorkspaceId: "cloud.local_workspace_id",
   createdAt: "cloud.created_at",
 } as const;
@@ -46,7 +45,6 @@ export type CloudMetadata = {
   workspaceId?: string;
   clientToken?: string;
   orgId?: string;
-  clusterOrgId?: string;
   localWorkspaceId?: string;
   createdAt?: string;
 };
@@ -88,7 +86,7 @@ export type CloudIntegrationStatus = {
 export function readCloudSessionContext(env: NodeJS.ProcessEnv = process.env): CloudSessionContext | null {
   const syncEngineUrl = env.ACRM_SYNC_ENGINE_URL?.trim() || DEFAULT_SYNC_ENGINE_URL;
   const workspaceId = env.ACRM_CLOUD_WORKSPACE_ID?.trim();
-  const orgId = env.ACRM_CLOUD_ORG_ID?.trim() || env.ACRM_CLOUD_CLUSTER_ORG_ID?.trim();
+  const orgId = env.ACRM_CLOUD_ORG_ID?.trim();
   const desktopSessionToken = env.ACRM_DESKTOP_SESSION_TOKEN?.trim();
   if (!workspaceId || !orgId || !desktopSessionToken) return null;
   return {
@@ -104,10 +102,10 @@ export function ensureCloudWorkspaceMetadata(
   preferred: {
     workspaceId?: string;
     clientToken?: string;
-    clusterOrgId?: string;
+    orgId?: string;
     localWorkspaceId?: string;
   } = {},
-): Promise<{ workspaceId: string; clientToken: string; clusterOrgId?: string; localWorkspaceId?: string }> {
+): Promise<{ workspaceId: string; clientToken: string; orgId?: string; localWorkspaceId?: string }> {
   return ensureCloudWorkspaceMetadataInDatabase(db, preferred);
 }
 
@@ -116,25 +114,22 @@ export async function ensureCloudWorkspaceMetadataInDatabase(
   preferred: {
     workspaceId?: string;
     clientToken?: string;
-    clusterOrgId?: string;
+    orgId?: string;
     localWorkspaceId?: string;
   } = {},
   fallback: {
     workspaceId?: string;
     clientToken?: string;
-    clusterOrgId?: string;
+    orgId?: string;
   } = {},
-): Promise<{ workspaceId: string; clientToken: string; clusterOrgId?: string; localWorkspaceId?: string }> {
+): Promise<{ workspaceId: string; clientToken: string; orgId?: string; localWorkspaceId?: string }> {
   return await db.transaction(async (tx) => {
     const existing = await readCloudMetadata(tx);
     const initial = {
       workspaceId: existing.workspaceId || preferred.workspaceId || fallback.workspaceId || randomUUID(),
       clientToken: existing.clientToken || preferred.clientToken || fallback.clientToken || randomUUID(),
-      ...(preferred.clusterOrgId || existing.clusterOrgId || fallback.clusterOrgId
-        ? { clusterOrgId: preferred.clusterOrgId || existing.clusterOrgId || fallback.clusterOrgId }
-        : {}),
-      ...(preferred.clusterOrgId || existing.orgId || fallback.clusterOrgId
-        ? { orgId: preferred.clusterOrgId || existing.orgId || fallback.clusterOrgId }
+      ...(preferred.orgId || existing.orgId || fallback.orgId
+        ? { orgId: preferred.orgId || existing.orgId || fallback.orgId }
         : {}),
       ...(preferred.localWorkspaceId || existing.localWorkspaceId
         ? { localWorkspaceId: preferred.localWorkspaceId || existing.localWorkspaceId }
@@ -147,15 +142,14 @@ export async function ensureCloudWorkspaceMetadataInDatabase(
     const canonical = await readCloudMetadata(tx);
     const workspaceId = canonical.workspaceId ?? initial.workspaceId;
     const clientToken = canonical.clientToken ?? initial.clientToken;
-    const clusterOrgId = preferred.clusterOrgId || canonical.orgId || canonical.clusterOrgId || fallback.clusterOrgId;
+    const orgId = preferred.orgId || canonical.orgId || fallback.orgId;
     const nextLocalWorkspaceId = preferred.localWorkspaceId || canonical.localWorkspaceId;
     const createdAt = canonical.createdAt ?? initial.createdAt;
 
     await writeCloudMetadata(tx, {
       workspaceId,
       clientToken,
-      ...(clusterOrgId ? { orgId: clusterOrgId } : {}),
-      ...(clusterOrgId ? { clusterOrgId } : {}),
+      ...(orgId ? { orgId } : {}),
       ...(nextLocalWorkspaceId ? { localWorkspaceId: nextLocalWorkspaceId } : {}),
       createdAt,
     });
@@ -163,7 +157,7 @@ export async function ensureCloudWorkspaceMetadataInDatabase(
     return {
       workspaceId,
       clientToken,
-      ...(clusterOrgId ? { clusterOrgId } : {}),
+      ...(orgId ? { orgId } : {}),
       ...(nextLocalWorkspaceId ? { localWorkspaceId: nextLocalWorkspaceId } : {}),
     };
   });
@@ -171,9 +165,9 @@ export async function ensureCloudWorkspaceMetadataInDatabase(
 
 export async function ensureCloudWorkspaceMetadataForWorkspace(
   workspacePath: string,
-  preferred: { workspaceId?: string; clientToken?: string; clusterOrgId?: string } = {},
+  preferred: { workspaceId?: string; clientToken?: string; orgId?: string } = {},
   options: { db?: AcrmDatabase; legacyMetadataDir?: string } = {},
-): Promise<{ workspaceId: string; clientToken: string; clusterOrgId?: string; localWorkspaceId?: string }> {
+): Promise<{ workspaceId: string; clientToken: string; orgId?: string; localWorkspaceId?: string }> {
   const workspace = options.db
     ? await Workspace.open({ db: options.db })
     : await Workspace.open(workspacePath);
@@ -185,7 +179,7 @@ export async function ensureCloudWorkspaceMetadataForWorkspace(
     return await ensureCloudWorkspaceMetadataInDatabase(workspace.db, {
       workspaceId: preferred.workspaceId,
       clientToken: preferred.clientToken,
-      clusterOrgId: preferred.clusterOrgId,
+      orgId: preferred.orgId,
       localWorkspaceId,
     }, legacy);
   } finally {
@@ -217,7 +211,6 @@ function metadataFromValues(values: Map<string, string>): CloudMetadata {
     ...(values.get(CLOUD_METADATA_KEYS.workspaceId) ? { workspaceId: values.get(CLOUD_METADATA_KEYS.workspaceId) } : {}),
     ...(values.get(CLOUD_METADATA_KEYS.clientToken) ? { clientToken: values.get(CLOUD_METADATA_KEYS.clientToken) } : {}),
     ...(values.get(CLOUD_METADATA_KEYS.orgId) ? { orgId: values.get(CLOUD_METADATA_KEYS.orgId) } : {}),
-    ...(values.get(CLOUD_METADATA_KEYS.clusterOrgId) ? { clusterOrgId: values.get(CLOUD_METADATA_KEYS.clusterOrgId) } : {}),
     ...(values.get(CLOUD_METADATA_KEYS.localWorkspaceId) ? { localWorkspaceId: values.get(CLOUD_METADATA_KEYS.localWorkspaceId) } : {}),
     ...(values.get(CLOUD_METADATA_KEYS.createdAt) ? { createdAt: values.get(CLOUD_METADATA_KEYS.createdAt) } : {}),
   };
@@ -248,8 +241,7 @@ async function writeCloudMetadata(db: AcrmDatabase, metadata: Required<Pick<Clou
   const entries: Array<[string, string | undefined]> = [
     [CLOUD_METADATA_KEYS.workspaceId, metadata.workspaceId],
     [CLOUD_METADATA_KEYS.clientToken, metadata.clientToken],
-    [CLOUD_METADATA_KEYS.orgId, metadata.orgId ?? metadata.clusterOrgId],
-    [CLOUD_METADATA_KEYS.clusterOrgId, metadata.clusterOrgId],
+    [CLOUD_METADATA_KEYS.orgId, metadata.orgId],
     [CLOUD_METADATA_KEYS.localWorkspaceId, metadata.localWorkspaceId],
     [CLOUD_METADATA_KEYS.createdAt, metadata.createdAt],
   ];
@@ -293,7 +285,6 @@ function cleanCloudMetadata(parsed: Record<string, unknown>): CloudMetadata {
     ...(typeof parsed.workspaceId === "string" && parsed.workspaceId ? { workspaceId: parsed.workspaceId } : {}),
     ...(typeof parsed.clientToken === "string" && parsed.clientToken ? { clientToken: parsed.clientToken } : {}),
     ...(typeof parsed.orgId === "string" && parsed.orgId ? { orgId: parsed.orgId } : {}),
-    ...(typeof parsed.clusterOrgId === "string" && parsed.clusterOrgId ? { clusterOrgId: parsed.clusterOrgId } : {}),
     ...(typeof parsed.localWorkspaceId === "string" && parsed.localWorkspaceId ? { localWorkspaceId: parsed.localWorkspaceId } : {}),
     ...(typeof parsed.createdAt === "string" && parsed.createdAt ? { createdAt: parsed.createdAt } : {}),
   };


### PR DESCRIPTION
## Summary
- Replace cloud workspace metadata and CLI payload references with org_id/orgId only
- Remove legacy cluster_org_id env and metadata fallback paths
- Keep Gmail/LinkedIn/Granola cloud-session URLs and outputs on org_id

## Tests
- npm run build
- npm test

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `clusterOrgId` with `orgId` in cloud workspace metadata
> - Removes all reads and writes of the `cloud.cluster_org_id` metadata key (`ACRM_CLOUD_CLUSTER_ORG_ID`) across [cloud-workspace.ts](https://github.com/cluster-software/agent-crm/pull/190/files#diff-dc6510de9617586a0aa8a79f5c9728fc7df1f39cd1bf1e4d708624e7fb8ccd20) and all connect/import commands, replacing them with `orgId` (`ACRM_CLOUD_ORG_ID`) exclusively.
> - `readCloudSessionContext` now returns `null` if `ACRM_CLOUD_ORG_ID` is absent, even when `ACRM_CLOUD_CLUSTER_ORG_ID` is set.
> - Connect and import command outputs no longer include a `cluster_org_id` field; `org_id` is populated from `metadata.orgId`.
> - Risk: any environment or integration that sets only `ACRM_CLOUD_CLUSTER_ORG_ID` will lose cloud session detection and org resolution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 589b5d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->