### PR TITLE
chore: add org_id changeset

### DIFF
--- a/.changeset/use-org-id-cloud-metadata.md
+++ b/.changeset/use-org-id-cloud-metadata.md
@@ -1,0 +1,5 @@
+---
+"@agent-crm/cli": patch
+---
+
+Use `org_id` for cloud workspace metadata and desktop cloud-session outputs, removing the legacy `cluster_org_id` fallbacks.


### PR DESCRIPTION
## Summary
- Adds the missing patch changeset for the already-merged org_id cloud metadata fix
- Scopes the release note to @agent-crm/cli

## Validation
- npm exec changeset -- status

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add changeset for `@agent-crm/cli` patch switching to `org_id` for cloud metadata
> Adds a changeset file declaring a patch release for `@agent-crm/cli` that documents the switch from `cluster_org_id` to `org_id` in cloud workspace metadata and desktop cloud-session outputs, removing legacy fallback handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7db2b19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->