### PR TITLE
Tighten deal pipeline agent guidance

### DIFF
--- a/.changeset/deals-skill-guidance.md
+++ b/.changeset/deals-skill-guidance.md
@@ -1,0 +1,6 @@
+---
+"@agent-crm/cli": patch
+"@agent-crm/sdk": patch
+---
+
+Tighten Agent CRM command guidance and point onboarding follow-up toward deal pipeline setup.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,11 @@ implementation rather than after mistakes.
 Generated workspace guidance for Claude/Codex lives in
 `packages/sdk/src/agent-instructions.ts`.
 
+Agents should only run ACRM commands that are documented in this file, in a
+bundled skill, in generated workspace instructions, or discovered through
+`acrm --help` / subcommand `--help`. Do not guess command names such as
+list/search variants without checking help first.
+
 When changing CLI commands, SDK workspace schema/objects, import behavior,
 skills, or SQL guidance, update that file in the same PR and run
 `npm run check:agent-instructions --workspace @agent-crm/cli`. CI catches new

--- a/packages/cli/skills/acrm-onboarding.md
+++ b/packages/cli/skills/acrm-onboarding.md
@@ -151,7 +151,7 @@ commands.
 Then suggest up to 2 valuable things they can do next, based on what got imported:
 
 1. Recommend finding folks to follow up with (if communications were imported e.g. emails, chats, transcripts)
-2. Recommend connecting Granola so meetings flow in: `try /connect-granola-to-acrm`.
+2. Recommend setting up the Deals pipeline: `try /setup-deal-pipeline` (bundled from `packages/cli/skills/setup-deal-pipeline.md`).
 
 Keep the close short - pick the most relevant one or two suggestions, not a feature dump.
 

--- a/packages/cli/skills/setup-deal-pipeline.md
+++ b/packages/cli/skills/setup-deal-pipeline.md
@@ -53,6 +53,10 @@ into `deals`. Suggest a custom object instead.
      --stage closed_lost:"Closed Lost"
    ```
 
+   `acrm deals pipeline set` expects `--stage id:Title` pairs. The backend
+   stores each stage as EAV status JSON (`{id,title}`), and the app renders the
+   `title`. Do not pass JSON to `--stage`.
+
 5. If the command says existing deals use stages not in the new pipeline, map
    each old id to the closest new generic stage:
 
@@ -86,6 +90,10 @@ acrm deals create \
 Use `acrm deals update <deal_id> --stage <stage_id>` to move a deal between
 stages, and `acrm deals delete <deal_id>` only when the user explicitly wants
 the deal archived.
+
+Do not use `acrm records create deals` or raw EAV writes for cloud deal setup.
+Use `acrm deals create` / `acrm deals update` so stage IDs, text values, and
+record references are serialized consistently with the backend.
 
 ## Hard rules
 

--- a/packages/sdk/src/agent-instructions.ts
+++ b/packages/sdk/src/agent-instructions.ts
@@ -59,6 +59,7 @@ export const AGENT_INSTRUCTIONS_BLOCK = [
   "- In the desktop app, use the existing `ACRM_SYNC_ENGINE_URL`, `ACRM_CLOUD_WORKSPACE_ID`, `ACRM_CLOUD_ORG_ID`, and `ACRM_DESKTOP_SESSION_TOKEN` environment. Do not print `ACRM_DESKTOP_SESSION_TOKEN`.",
   "- Outside the desktop app, target a workspace with `acrm -w <postgres-url> ...`, or set `ACRM_DATABASE_URL`, `NEON_DATABASE_URL`, `SUPABASE_DATABASE_URL`, or `DATABASE_URL`. Use `ACRM_DATABASE_PROVIDER=neon|supabase|postgres` only when the provider cannot be inferred from the URL.",
   "- Use first-class CLI commands for reads and writes. Direct SQL/raw workspace queries are not supported in cloud-first Agent CRM workspaces.",
+  "- Only run ACRM commands documented here, in a bundled skill, or discovered through `acrm --help` / subcommand `--help`. Do not guess command names.",
   "",
   "Common commands:",
   "- `acrm connect linkedin` connects LinkedIn through Agent CRM's hosted sync engine, or reports when the workspace is already connected. `acrm connect linkedin --status` checks status without starting a connect flow.",


### PR DESCRIPTION
## Summary
- tell agents to only run documented or help-discovered ACRM commands
- update onboarding follow-up to recommend deal pipeline setup
- clarify setup-deal-pipeline should use first-class deals commands, not raw EAV/records writes

## Validation
- npm run check:agent-instructions --workspace @agent-crm/cli

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced command guidance clarifying which ACRM commands are available and documented
  * Reorganized onboarding flow to prioritize deal pipeline setup
  * Clarified deal pipeline configuration requirements with improved format guidance
  * Added warnings against improper deal creation and configuration procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tighten deal pipeline agent guidance to prevent command guessing and misuse
> - Updates `AGENT_INSTRUCTIONS_BLOCK` in [agent-instructions.ts](https://github.com/cluster-software/agent-crm/pull/206/files#diff-08c10eeda4a8c219afebb9e6374c59115c64e7b2bd0024782078714a602f496a) to explicitly prohibit guessing ACRM command names, requiring agents to only run documented or help-discoverable commands.
> - Updates [setup-deal-pipeline.md](https://github.com/cluster-software/agent-crm/pull/206/files#diff-93233cd255bb2f90f67b5e7bd06772e5534a54a8d8de9c5a65999d65527e29c2) to clarify that `acrm deals pipeline set` expects `--stage id:Title` pairs (not JSON), and that `acrm deals create`/`acrm deals update` should be used instead of `acrm records create deals` or raw EAV writes.
> - Updates [acrm-onboarding.md](https://github.com/cluster-software/agent-crm/pull/206/files#diff-62c6a245c0067c368907b06da492d53a7808aedf9a47d02a16704ed93f5688c8) to recommend deal pipeline setup as the follow-up action after onboarding.
> - Adds the same command-guessing constraint to [CLAUDE.md](https://github.com/cluster-software/agent-crm/pull/206/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7) for local development guidance.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b136024.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->