### PR TITLE
Prompt for deals after pipeline setup

### DIFF
--- a/.changeset/soft-deals-follow-up.md
+++ b/.changeset/soft-deals-follow-up.md
@@ -1,0 +1,6 @@
+---
+"@agent-crm/cli": patch
+"@agent-crm/sdk": patch
+---
+
+Guide agents to ask which real deals to create after configuring a Deals pipeline.

--- a/packages/cli/skills/setup-deal-pipeline.md
+++ b/packages/cli/skills/setup-deal-pipeline.md
@@ -72,6 +72,10 @@ into `deals`. Suggest a custom object instead.
      --map lost:closed_lost
    ```
 
+6. After the pipeline is set, keep the user in flow by asking which real deals
+   they want to create next. Ask for the company/person, stage, and next step
+   for each deal; do not invent deals without user-provided opportunities.
+
 ## Create or update deals
 
 Only create a first deal if the user asks for it or gives a real opportunity.

--- a/packages/sdk/src/agent-instructions.ts
+++ b/packages/sdk/src/agent-instructions.ts
@@ -77,6 +77,7 @@ export const AGENT_INSTRUCTIONS_BLOCK = [
   "- `acrm records update <object> <record_id> --field slug=value` updates an existing record; repeat `--field` for multiple or multivalued fields.",
   "- `acrm records dedupe <object> --keep <record_id> --discard <record_id>` merges duplicate records.",
   "- In desktop cloud sessions, `acrm deals pipeline set --stage lead:Lead --stage closed_won:\"Closed Won\" --stage closed_lost:\"Closed Lost\"` configures the Deals pipeline.",
+  "- After configuring a Deals pipeline, ask which real deals the user wants to create next; do not invent deals without user-provided opportunities.",
   "- In desktop cloud sessions, `acrm deals create`, `acrm deals update`, `acrm deals list`, and `acrm deals delete` manage sales opportunities through the hosted backend API.",
   "",
   "Data model:",


### PR DESCRIPTION
## Summary
- update the bundled setup-deal-pipeline skill to ask which real deals to create after pipeline setup
- mirror that guidance in generated workspace agent instructions
- add a changeset for the CLI and SDK packages

## Validation
- npm run check:agent-instructions --workspace @agent-crm/cli

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prompt agents to ask for real deals after Deals pipeline setup
> Adds a post-setup instruction to [setup-deal-pipeline.md](https://github.com/cluster-software/agent-crm/pull/208/files#diff-93233cd255bb2f90f67b5e7bd06772e5534a54a8d8de9c5a65999d65527e29c2) and `AGENT_INSTRUCTIONS_BLOCK` in [agent-instructions.ts](https://github.com/cluster-software/agent-crm/pull/208/files#diff-08c10eeda4a8c219afebb9e6374c59115c64e7b2bd0024782078714a602f496a) telling agents to ask the user which real deals to create after configuring a pipeline. Agents are explicitly instructed not to invent deals without user-provided opportunities.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cfc62cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deals pipeline setup guidance to instruct agents to ask which real deals to create after configuration, preventing automatic deal creation without user-provided opportunities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->